### PR TITLE
Use different caches for different jobs

### DIFF
--- a/.github/workflows/with-bindings.yml
+++ b/.github/workflows/with-bindings.yml
@@ -26,7 +26,7 @@ jobs:
           gcc-version: 11
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: v0
+          prefix-key: v0-conan
       - name: Build benchmarks with all features
         run: cargo bench --verbose --no-run --all-features
 
@@ -59,7 +59,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: ${{ matrix.cache }}
         with:
-          prefix-key: v0-rust-${{ matrix.rust }}
+          prefix-key: v0-rust-${{ matrix.rust }}-conan
       - name: Build with all features
         run: cargo build --verbose --all-features
       - name: Tests with all features


### PR DESCRIPTION
Apparently the cache keys don't use the workflow name.

> Failed to save: Unable to reserve cache with key v0-rust-stable-tests-d6e3b735-21dbb18c, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/main, Key: v0-rust-stable-tests-d6e3b735-21dbb18c, Version: 92136cdf631095457a6144dd65a6b436a3ae5a9ea3e2dacbe46a08bfc3457313

in https://github.com/CQCL-DEV/tket2proto/actions/runs/5424937183/jobs/9865012491#step:37:30