### PR TITLE
fix: avoid special casing pi symbols

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -142,12 +142,7 @@ impl From<OpConvertError> for TK1LoadError {
 
 #[inline]
 fn parse_val(n: &str) -> Option<f64> {
-    if n == "pi" {
-        // angles are in multiples of pi
-        Some(1.0)
-    } else {
-        n.parse::<f64>().ok()
-    }
+    n.parse::<f64>().ok()
 }
 /// Try to interpret a TKET1 parameter as a constant value.
 #[inline]

--- a/src/json/tests.rs
+++ b/src/json/tests.rs
@@ -43,7 +43,7 @@ const PARAMETRIZED: &str = r#"{
             {"args":[["q",[0]]],"op":{"type":"H"}},
             {"args":[["q",[1]],["q",[0]]],"op":{"type":"CX"}},
             {"args":[["q",[0]]],"op":{"params":["0.1"],"type":"Rz"}},
-            {"args": [["q", [0]]], "op": {"params": ["0.1", "alpha", "0.3"], "type": "TK1"}}
+            {"args": [["q", [0]]], "op": {"params": ["3.141596/pi", "alpha", "0.3"], "type": "TK1"}}
         ],
         "created_qubits": [],
         "discarded_qubits": [],


### PR DESCRIPTION
TKET sometimes uses division by pi.
Avoid trying to parse this and just keep the string.

I'm a bit skeptical of parsing the division too, but will leave until it causes problems.