### PR TITLE
fix: Register the type parameters as custom types

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -27,9 +27,13 @@ pub const LINEAR_BIT_NAME: SmolStr = SmolStr::new_inline("LBit");
 /// The name for opaque TKET1 operations.
 pub const JSON_OP_NAME: SmolStr = SmolStr::new_inline("TKET1 Json Op");
 
+/// The ID of an opaque TKET1 operation metadata.
+pub const JSON_PAYLOAD_NAME: SmolStr = SmolStr::new_inline("TKET1 Json Payload");
+
 lazy_static! {
 /// A custom type for the encoded TKET1 operation
-static ref TKET1_OP_PAYLOAD : CustomType = CustomType::new("TKET1 Json Op", vec![], TKET1_EXTENSION_ID, TypeBound::Eq);
+static ref TKET1_OP_PAYLOAD : CustomType =
+    TKET1_EXTENSION.get_type(&JSON_PAYLOAD_NAME).unwrap().instantiate_concrete([]).unwrap();
 
 /// The TKET1 extension, containing the opaque TKET1 operations.
 pub static ref TKET1_EXTENSION: Extension = {
@@ -37,7 +41,8 @@ pub static ref TKET1_EXTENSION: Extension = {
 
     res.add_type(LINEAR_BIT_NAME, vec![], "A linear bit.".into(), TypeBound::Any.into()).unwrap();
 
-    let json_op_payload = TypeParam::Opaque(TKET1_OP_PAYLOAD.clone());
+    let json_op_payload_def = res.add_type(JSON_PAYLOAD_NAME, vec![], "Opaque TKET1 operation metadata.".into(), TypeBound::Eq.into()).unwrap();
+    let json_op_payload = TypeParam::Opaque(json_op_payload_def.instantiate_concrete([]).unwrap());
     res.add_op_custom_sig(
         JSON_OP_NAME,
         "An opaque TKET1 operation.".into(),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -179,12 +179,6 @@ impl T2Op {
     }
 }
 
-/// The type of the symbolic expression opaque type arg.
-pub const SYM_EXPR_T: CustomType =
-    CustomType::new_simple(SmolStr::new_inline("SymExpr"), EXTENSION_ID, TypeBound::Eq);
-
-const SYM_OP_ID: SmolStr = SmolStr::new_inline("symbolic_float");
-
 /// Initialize a new custom symbolic expression constant op from a string.
 pub fn symbolic_constant_op(s: &str) -> OpType {
     let value: serde_yaml::Value = s.into();
@@ -192,7 +186,7 @@ pub fn symbolic_constant_op(s: &str) -> OpType {
         .instantiate_extension_op(
             &SYM_OP_ID,
             vec![TypeArg::Opaque {
-                arg: CustomTypeArg::new(SYM_EXPR_T, value).unwrap(),
+                arg: CustomTypeArg::new(SYM_EXPR_T.clone(), value).unwrap(),
             }],
         )
         .unwrap()
@@ -227,21 +221,40 @@ pub(crate) fn match_symb_const_op(op: &OpType) -> Option<&str> {
     }
 }
 
-fn extension() -> Extension {
+/// The name of the symbolic expression opaque type arg.
+pub const SYM_EXPR_NAME: SmolStr = SmolStr::new_inline("SymExpr");
+
+/// The name of the symbolic expression opaque type arg.
+const SYM_OP_ID: SmolStr = SmolStr::new_inline("symbolic_float");
+
+lazy_static! {
+/// The type of the symbolic expression opaque type arg.
+pub static ref SYM_EXPR_T: CustomType =
+    EXTENSION.get_type(&SYM_EXPR_NAME).unwrap().instantiate_concrete([]).unwrap();
+
+pub static ref EXTENSION: Extension = {
     let mut e = Extension::new(EXTENSION_ID);
     load_all_ops::<T2Op>(&mut e).expect("add fail");
+
+    let sym_expr_opdef = e.add_type(
+        SYM_EXPR_NAME,
+        vec![],
+        "Symbolic expression.".into(),
+        TypeBound::Eq.into(),
+    )
+    .unwrap();
+    let sym_expr_param = TypeParam::Opaque(sym_expr_opdef.instantiate_concrete([]).unwrap());
+
     e.add_op_custom_sig_simple(
         SYM_OP_ID,
         "Store a sympy expression that can be evaluated to a float.".to_string(),
-        vec![TypeParam::Opaque(SYM_EXPR_T)],
+        vec![sym_expr_param],
         |_: &[TypeArg]| Ok(FunctionType::new(type_row![], type_row![FLOAT64_TYPE])),
     )
     .unwrap();
-    e
-}
 
-lazy_static! {
-    pub static ref EXTENSION: Extension = extension();
+    e
+};
 }
 
 // From implementations could be made generic over SimpleOpEnum


### PR DESCRIPTION
Fixes the errors found in #98 by registering the opaque `TypeParam`s as custom types in the extensions.

@acl-cqc Is this the intended way to register parameters? There are no uses of `TypeParam::Opaque` in Hugr to base this on.