### PR TITLE
feat: Track max memory usage for TASO

### DIFF
--- a/taso-optimiser/Cargo.toml
+++ b/taso-optimiser/Cargo.toml
@@ -12,3 +12,8 @@ tket2 = { path = "../", features = ["portmatching"] }
 quantinuum-hugr = { workspace = true }
 itertools = { workspace = true }
 tket-json-rs = { workspace = true }
+peak_alloc = { version = "0.2.0", optional = true }
+
+[features]
+default = ["peak_alloc"]
+peak_alloc = ["dep:peak_alloc"]

--- a/taso-optimiser/src/main.rs
+++ b/taso-optimiser/src/main.rs
@@ -8,6 +8,13 @@ use tket2::{
 };
 use tket_json_rs::circuit_json::SerialCircuit;
 
+#[cfg(feature = "peak_alloc")]
+use peak_alloc::PeakAlloc;
+
+#[cfg(feature = "peak_alloc")]
+#[global_allocator]
+static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
 /// Optimise circuits using Quartz-generated ECCs.
 ///
 /// Quartz: <https://github.com/quantum-compiler/quartz>
@@ -90,6 +97,9 @@ fn main() {
 
     println!("Saving result");
     save_tk1_json_file(output_path, &opt_circ).unwrap();
+
+    #[cfg(feature = "peak_alloc")]
+    println!("Peak memory usage: {} GB", PEAK_ALLOC.peak_usage_as_gb());
 
     println!("Done.")
 }


### PR DESCRIPTION
Adds a `peak_alloc` feature to the binary (enabled by default) to print the max memory usage at the end of the execution.