### PR TITLE
feat: hash op arguments

### DIFF
--- a/src/circuit/hash.rs
+++ b/src/circuit/hash.rs
@@ -108,9 +108,14 @@ impl HashState {
 fn hashable_op(op: &OpType) -> impl Hash {
     match op {
         OpType::LeafOp(LeafOp::CustomOp(op)) if !op.args().is_empty() => {
-            panic!("Parametric operation {} cannot be hashed.", op.name())
+            // TODO: Require hashing for TypeParams?
+            format!(
+                "{}[{}]",
+                op.name(),
+                serde_json::to_string(op.args()).unwrap()
+            )
         }
-        _ => op.name(),
+        _ => op.name().to_string(),
     }
 }
 


### PR DESCRIPTION
A bit of a hack, we use the json-encoded params to produce a hash.

We could require some hash method in the Hugr definition, but this is a quick fix so we can do benchmarking.