### PR TITLE
fix: Don't run miri on tests that open files

### DIFF
--- a/src/json/tests.rs
+++ b/src/json/tests.rs
@@ -65,6 +65,7 @@ fn json_roundtrip(#[case] circ_s: &str, #[case] num_commands: usize, #[case] num
 }
 
 #[rstest]
+#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 #[case::barenco_tof_10("test_files/barenco_tof_10.json")]
 fn json_file_roundtrip(#[case] circ: impl AsRef<std::path::Path>) {
     let reader = BufReader::new(std::fs::File::open(circ).unwrap());


### PR DESCRIPTION
Fixes the failing CI test in `HEAD`.
https://github.com/CQCL-DEV/tket2/actions/runs/6393267172/job/17352161422