### PR TITLE
feat: Trim TASO priority queue progresively

### DIFF
--- a/pyrs/src/optimiser.rs
+++ b/pyrs/src/optimiser.rs
@@ -79,7 +79,7 @@ impl PyDefaultTasoOptimiser {
                 timeout,
                 n_threads.unwrap_or(NonZeroUsize::new(1).unwrap()),
                 split_circ.unwrap_or(false),
-                queue_size.unwrap_or(10_000),
+                queue_size.unwrap_or(100),
             )
         })
     }

--- a/src/optimiser/taso.rs
+++ b/src/optimiser/taso.rs
@@ -149,7 +149,7 @@ where
             let strategy = self.strategy.clone();
             move |circ: &'_ Hugr| strategy.circuit_cost(circ)
         };
-        let mut pq = HugrPQ::with_capacity(cost_fn, queue_size);
+        let mut pq = HugrPQ::new(cost_fn, queue_size);
         pq.push(circ.clone());
 
         let mut circ_cnt = 1;
@@ -448,7 +448,7 @@ mod tests {
 
     #[rstest]
     fn rz_rz_cancellation(rz_rz: Hugr, taso_opt: DefaultTasoOptimiser) {
-        let opt_rz = taso_opt.optimise(&rz_rz, None, 1.try_into().unwrap(), false, 10_000);
+        let opt_rz = taso_opt.optimise(&rz_rz, None, 1.try_into().unwrap(), false, 100);
         let cmds = opt_rz
             .commands()
             .map(|cmd| {

--- a/src/optimiser/taso/hugr_pchannel.rs
+++ b/src/optimiser/taso/hugr_pchannel.rs
@@ -21,8 +21,6 @@ pub(super) struct HugrPriorityChannel<C, P: Ord> {
     log: Sender<PriorityChannelLog<P>>,
     // Inbound channel to be terminated.
     timeout: Receiver<()>,
-    // The queue capacity. Queue size is halved when it exceeds this.
-    queue_capacity: usize,
     // The priority queue data structure.
     pq: HugrPQ<P, C>,
     // The set of hashes we've seen.
@@ -102,7 +100,7 @@ where
         queue_capacity: usize,
     ) -> Self {
         // The priority queue, local to this thread.
-        let pq = HugrPQ::with_capacity(cost_fn, queue_capacity);
+        let pq = HugrPQ::new(cost_fn, queue_capacity);
         // The set of hashes we've seen.
         let seen_hashes = FxHashSet::default();
         // The minimum cost we've seen.
@@ -115,7 +113,6 @@ where
             pop,
             log,
             timeout,
-            queue_capacity,
             pq,
             seen_hashes,
             min_cost,
@@ -204,10 +201,6 @@ where
                     ))
                     .unwrap();
             }
-        }
-        // If the queue got too big, truncate it.
-        if self.pq.len() >= self.queue_capacity {
-            self.pq.truncate(self.queue_capacity / 2);
         }
     }
 }

--- a/src/optimiser/taso/hugr_pqueue.rs
+++ b/src/optimiser/taso/hugr_pqueue.rs
@@ -49,7 +49,7 @@ impl<P: Ord, C> HugrPQ<P, C> {
 
     /// Push a Hugr into the queue.
     ///
-    /// If the queue is full, the most last will be dropped.
+    /// If the queue is full, the element with the highest cost will be dropped.
     pub(super) fn push(&mut self, hugr: Hugr)
     where
         C: Fn(&Hugr) -> P,
@@ -75,8 +75,7 @@ impl<P: Ord, C> HugrPQ<P, C> {
             return;
         }
         if self.len() >= self.max_size {
-            let max_cost = self.max_cost().unwrap();
-            if self.len() >= self.max_size && cost >= *max_cost {
+            if cost >= *self.max_cost().unwrap() {
                 return;
             }
             self.pop_max();

--- a/taso-optimiser/src/main.rs
+++ b/taso-optimiser/src/main.rs
@@ -88,9 +88,9 @@ struct CmdLineArgs {
     #[arg(
         short = 'q',
         long = "queue-size",
-        default_value = "10000",
+        default_value = "100",
         value_name = "QUEUE_SIZE",
-        help = "The priority queue size. Defaults to 10_000."
+        help = "The priority queue size. Defaults to 100."
     )]
     queue_size: usize,
 }


### PR DESCRIPTION
Instead of cutting the truncating in half, we just pop the last element before inserting if we're at capacity.

Sets the new default size to 100, as that is more sensible for our workloads.