### PR TITLE
feat: Use cost deltas instead of recalculating the full cost

### DIFF
--- a/src/optimiser/taso/worker.rs
+++ b/src/optimiser/taso/worker.rs
@@ -2,8 +2,6 @@
 
 use std::thread::{self, JoinHandle};
 
-use hugr::Hugr;
-
 use crate::circuit::cost::CircuitCost;
 use crate::circuit::CircuitHash;
 use crate::rewrite::strategy::RewriteStrategy;
@@ -12,7 +10,7 @@ use crate::rewrite::Rewriter;
 use super::hugr_pchannel::{PriorityChannelCommunication, Work};
 
 /// A worker that processes circuits for the TASO optimiser.
-pub struct TasoWorker<R, S, C, P: Ord> {
+pub struct TasoWorker<R, S, P: Ord> {
     /// The worker ID.
     #[allow(unused)]
     id: usize,
@@ -22,15 +20,12 @@ pub struct TasoWorker<R, S, C, P: Ord> {
     rewriter: R,
     /// The rewrite strategy to use.
     strategy: S,
-    /// The cost function
-    cost_fn: C,
 }
 
-impl<R, S, C, P> TasoWorker<R, S, C, P>
+impl<R, S, P> TasoWorker<R, S, P>
 where
     R: Rewriter + Send + 'static,
-    S: RewriteStrategy + Send + 'static,
-    C: Fn(&Hugr) -> P + Send + Sync + 'static,
+    S: RewriteStrategy<Cost = P> + Send + 'static,
     P: CircuitCost + Send + Sync + 'static,
 {
     /// Spawn a new worker thread.
@@ -40,7 +35,6 @@ where
         priority_channel: PriorityChannelCommunication<P>,
         rewriter: R,
         strategy: S,
-        cost_fn: C,
     ) -> JoinHandle<()> {
         let name = format!("TasoWorker-{id}");
         thread::Builder::new()
@@ -51,7 +45,6 @@ where
                     priority_channel,
                     rewriter,
                     strategy,
-                    cost_fn,
                 };
                 worker.run_loop()
             })
@@ -65,19 +58,18 @@ where
     #[tracing::instrument(target = "taso::metrics", skip(self))]
     fn run_loop(&mut self) {
         loop {
-            let Ok(Work { circ, .. }) = self.priority_channel.recv() else {
+            let Ok(Work { circ, cost, .. }) = self.priority_channel.recv() else {
                 break;
             };
 
             let rewrites = self.rewriter.get_rewrites(&circ);
-            let circs = self.strategy.apply_rewrites(rewrites, &circ);
-            let new_circs = circs
+            let rewrite_result = self.strategy.apply_rewrites(rewrites, &circ);
+            let new_circs = rewrite_result
                 .into_iter()
-                .map(|c| {
+                .map(|(c, cost_delta)| {
                     let hash = c.circuit_hash();
-                    let cost = (self.cost_fn)(&c);
                     Work {
-                        cost,
+                        cost: cost.add_delta(&cost_delta),
                         hash,
                         circ: c,
                     }

--- a/src/passes/chunks.rs
+++ b/src/passes/chunks.rs
@@ -21,7 +21,7 @@ use itertools::Itertools;
 
 use crate::Circuit;
 
-use crate::circuit::cost::CircuitCost;
+use crate::circuit::cost::{CircuitCost, CostDelta};
 #[cfg(feature = "pyo3")]
 use crate::json::TKETDecode;
 #[cfg(feature = "pyo3")]
@@ -295,7 +295,7 @@ impl CircuitChunks {
         let mut current_group = 0;
         for (_, commands) in &circ.commands().map(|cmd| cmd.node()).group_by(|&node| {
             let new_cost = running_cost.clone() + op_cost(circ.get_optype(node));
-            if new_cost.sub_cost(&max_cost) > 0 {
+            if new_cost.sub_cost(&max_cost).as_isize() > 0 {
                 running_cost = C::default();
                 current_group += 1;
             } else {

--- a/src/rewrite/strategy.rs
+++ b/src/rewrite/strategy.rs
@@ -127,7 +127,7 @@ pub trait ExhaustiveThresholdStrategy {
     /// Returns true if the rewrite is allowed, based on the cost of the pattern and target.
     #[inline]
     fn under_threshold(&self, pattern_cost: &Self::OpCost, target_cost: &Self::OpCost) -> bool {
-        target_cost.sub_cost(pattern_cost) <= 0
+        target_cost.sub_cost(pattern_cost).as_isize() <= 0
     }
 
     /// The cost of a single operation.

--- a/src/rewrite/strategy.rs
+++ b/src/rewrite/strategy.rs
@@ -18,7 +18,7 @@ use hugr::ops::OpType;
 use hugr::{Hugr, HugrView};
 use itertools::Itertools;
 
-use crate::circuit::cost::{is_cx, is_quantum, CircuitCost, MajorMinorCost};
+use crate::circuit::cost::{is_cx, is_quantum, CircuitCost, CostDelta, MajorMinorCost};
 use crate::Circuit;
 
 use super::CircuitRewrite;
@@ -41,7 +41,7 @@ pub trait RewriteStrategy {
         &self,
         rewrites: impl IntoIterator<Item = CircuitRewrite>,
         circ: &Hugr,
-    ) -> Vec<Hugr>;
+    ) -> RewriteResult<Self::Cost>;
 
     /// The cost of a single operation for this strategy's cost function.
     fn op_cost(&self, op: &OpType) -> Self::Cost;
@@ -50,6 +50,50 @@ pub trait RewriteStrategy {
     #[inline]
     fn circuit_cost(&self, circ: &Hugr) -> Self::Cost {
         circ.circuit_cost(|op| self.op_cost(op))
+    }
+}
+
+/// The result of a rewrite strategy.
+///
+/// Returned by [`RewriteStrategy::apply_rewrites`].
+pub struct RewriteResult<Cost: CircuitCost> {
+    /// The rewritten circuits.
+    pub circs: Vec<Hugr>,
+    /// The cost delta of each rewritten circuit.
+    pub cost_deltas: Vec<Cost::CostDelta>,
+}
+
+impl<Cost: CircuitCost> RewriteResult<Cost> {
+    /// Init a new rewrite result.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            circs: Vec::with_capacity(capacity),
+            cost_deltas: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Returns the number of rewritten circuits.
+    pub fn len(&self) -> usize {
+        self.circs.len()
+    }
+
+    /// Returns true if there are no rewritten circuits.
+    pub fn is_empty(&self) -> bool {
+        self.circs.is_empty()
+    }
+
+    /// Returns an iterator over the rewritten circuits and their cost deltas.
+    pub fn iter(&self) -> impl Iterator<Item = (&Hugr, &Cost::CostDelta)> {
+        self.circs.iter().zip(self.cost_deltas.iter())
+    }
+}
+
+impl<Cost: CircuitCost> IntoIterator for RewriteResult<Cost> {
+    type Item = (Hugr, Cost::CostDelta);
+    type IntoIter = std::iter::Zip<std::vec::IntoIter<Hugr>, std::vec::IntoIter<Cost::CostDelta>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.circs.into_iter().zip(self.cost_deltas)
     }
 }
 
@@ -73,12 +117,13 @@ impl RewriteStrategy for GreedyRewriteStrategy {
         &self,
         rewrites: impl IntoIterator<Item = CircuitRewrite>,
         circ: &Hugr,
-    ) -> Vec<Hugr> {
+    ) -> RewriteResult<usize> {
         let rewrites = rewrites
             .into_iter()
             .sorted_by_key(|rw| rw.node_count_delta())
             .take_while(|rw| rw.node_count_delta() < 0);
         let mut changed_nodes = HashSet::new();
+        let mut cost_delta = 0;
         let mut circ = circ.clone();
         for rewrite in rewrites {
             if rewrite
@@ -90,11 +135,15 @@ impl RewriteStrategy for GreedyRewriteStrategy {
                 continue;
             }
             changed_nodes.extend(rewrite.subcircuit().nodes().iter().copied());
+            cost_delta += rewrite.node_count_delta();
             rewrite
                 .apply(&mut circ)
                 .expect("Could not perform rewrite in greedy strategy");
         }
-        vec![circ]
+        RewriteResult {
+            circs: vec![circ],
+            cost_deltas: vec![cost_delta],
+        }
     }
 
     fn circuit_cost(&self, circ: &Hugr) -> Self::Cost {
@@ -142,20 +191,22 @@ impl<T: ExhaustiveThresholdStrategy> RewriteStrategy for T {
         &self,
         rewrites: impl IntoIterator<Item = CircuitRewrite>,
         circ: &Hugr,
-    ) -> Vec<Hugr> {
-        rewrites
+    ) -> RewriteResult<T::OpCost> {
+        let (circs, cost_deltas) = rewrites
             .into_iter()
-            .filter(|rw| {
-                let pattern_cost = pre_rewrite_cost(rw, circ, |op| self.op_cost(op));
-                let target_cost = post_rewrite_cost(rw, circ, |op| self.op_cost(op));
-                self.under_threshold(&pattern_cost, &target_cost)
-            })
-            .map(|rw| {
+            .filter_map(|rw| {
+                let pattern_cost = pre_rewrite_cost(&rw, circ, |op| self.op_cost(op));
+                let target_cost = post_rewrite_cost(&rw, circ, |op| self.op_cost(op));
+                if !self.under_threshold(&pattern_cost, &target_cost) {
+                    return None;
+                }
+
                 let mut circ = circ.clone();
                 rw.apply(&mut circ).expect("invalid pattern match");
-                circ
+                Some((circ, target_cost.sub_cost(&pattern_cost)))
             })
-            .collect()
+            .unzip();
+        RewriteResult { circs, cost_deltas }
     }
 
     #[inline]
@@ -360,7 +411,7 @@ mod tests {
         let strategy = GreedyRewriteStrategy;
         let rewritten = strategy.apply_rewrites(rws, &circ);
         assert_eq!(rewritten.len(), 1);
-        assert_eq!(rewritten[0].num_gates(), 5);
+        assert_eq!(rewritten.circs[0].num_gates(), 5);
     }
 
     #[test]
@@ -381,7 +432,7 @@ mod tests {
         let strategy = ExhaustiveGammaStrategy::exhaustive_cx();
         let rewritten = strategy.apply_rewrites(rws, &circ);
         let exp_circ_lens = HashSet::from_iter([8, 6, 9]);
-        let circ_lens: HashSet<_> = rewritten.iter().map(|c| c.num_gates()).collect();
+        let circ_lens: HashSet<_> = rewritten.circs.iter().map(|c| c.num_gates()).collect();
         assert_eq!(circ_lens, exp_circ_lens);
     }
 
@@ -403,7 +454,7 @@ mod tests {
         let strategy = ExhaustiveGammaStrategy::exhaustive_cx_with_gamma(10.);
         let rewritten = strategy.apply_rewrites(rws, &circ);
         let exp_circ_lens = HashSet::from_iter([8, 17, 6, 9]);
-        let circ_lens: HashSet<_> = rewritten.iter().map(|c| c.num_gates()).collect();
+        let circ_lens: HashSet<_> = rewritten.circs.iter().map(|c| c.num_gates()).collect();
         assert_eq!(circ_lens, exp_circ_lens);
     }
 

--- a/src/rewrite/strategy.rs
+++ b/src/rewrite/strategy.rs
@@ -15,7 +15,7 @@
 use std::{collections::HashSet, fmt::Debug};
 
 use hugr::ops::OpType;
-use hugr::{Hugr, HugrView};
+use hugr::Hugr;
 use itertools::Itertools;
 
 use crate::circuit::cost::{is_cx, is_quantum, CircuitCost, CostDelta, MajorMinorCost};
@@ -196,7 +196,7 @@ impl<T: ExhaustiveThresholdStrategy> RewriteStrategy for T {
             .into_iter()
             .filter_map(|rw| {
                 let pattern_cost = pre_rewrite_cost(&rw, circ, |op| self.op_cost(op));
-                let target_cost = post_rewrite_cost(&rw, circ, |op| self.op_cost(op));
+                let target_cost = post_rewrite_cost(&rw, |op| self.op_cost(op));
                 if !self.under_threshold(&pattern_cost, &target_cost) {
                     return None;
                 }
@@ -346,12 +346,12 @@ where
     circ.nodes_cost(rw.subcircuit().nodes().iter().copied(), pred)
 }
 
-fn post_rewrite_cost<F, C>(rw: &CircuitRewrite, circ: &Hugr, pred: F) -> C
+fn post_rewrite_cost<F, C>(rw: &CircuitRewrite, pred: F) -> C
 where
     C: CircuitCost,
     F: Fn(&OpType) -> C,
 {
-    circ.nodes_cost(rw.replacement().nodes(), pred)
+    rw.replacement().circuit_cost(pred)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Avoids doing full circuit traversals for each candidate.