### PR TITLE
chore: Support any pytket >= 1.0

### DIFF
--- a/pyrs/pyproject.toml
+++ b/pyrs/pyproject.toml
@@ -10,4 +10,4 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = ["pytket~=1.0", "pytest~=7.1"]
+dependencies = ["pytket>=1.0", "pytest~=7.1"]

--- a/pyrs/pyrs/passes.py
+++ b/pyrs/pyrs/passes.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from pytket import Circuit
+from pytket.passes import CustomPass
+from pyrs.pyrs import passes, optimiser
+
+
+def taso_pass(
+    rewriter_dir=None,
+    rewriter_file=None,
+    max_threads=None,
+    timeout=None,
+    log_dir=None,
+    rebase=None,
+) -> CustomPass:
+    """Construct a TASO pass.
+
+    A Taso optimiser may be specified using either `rewriter_dir` or `rewriter_file`.
+    If `rewriter_dir` is specified, the optimiser will be loaded from the file
+    `rewriter_dir/nam_6_3.rwr`. By default, will search for a rewritier in
+    the current directory. The rewriter must be precompiled.
+
+    The arguments `max_threads`, `timeout`, `log_dir` and `rebase` are optional
+    and will be passed on to the TASO optimiser if provided."""
+    if rewriter_dir is None:
+        rewriter_dir = "."
+    if rewriter_file is None:
+        rewriter_file = Path(rewriter_dir) / "nam_6_3.rwr"
+    opt = optimiser.TasoOptimiser.load_precompiled(rewriter_file)
+
+    def apply(circuit: Circuit):
+        """Apply TASO optimisation to the circuit."""
+        return passes.taso_optimise(
+            circuit,
+            opt,
+            max_threads,
+            timeout,
+            log_dir,
+            rebase,
+        )
+
+    return CustomPass(apply)

--- a/pyrs/src/optimiser.rs
+++ b/pyrs/src/optimiser.rs
@@ -12,7 +12,7 @@ use crate::circuit::update_hugr;
 /// The circuit optimisation module.
 pub fn add_optimiser_module(py: Python, parent: &PyModule) -> PyResult<()> {
     let m = PyModule::new(py, "optimiser")?;
-    m.add_class::<PyDefaultTasoOptimiser>()?;
+    m.add_class::<PyTasoOptimiser>()?;
 
     parent.add_submodule(m)
 }
@@ -22,10 +22,10 @@ pub fn add_optimiser_module(py: Python, parent: &PyModule) -> PyResult<()> {
 /// Currently only exposes loading from an ECC file using the constructor
 /// and optimising using default logging settings.
 #[pyclass(name = "TasoOptimiser")]
-pub struct PyDefaultTasoOptimiser(DefaultTasoOptimiser);
+pub struct PyTasoOptimiser(DefaultTasoOptimiser);
 
 #[pymethods]
-impl PyDefaultTasoOptimiser {
+impl PyTasoOptimiser {
     /// Create a new [`PyDefaultTasoOptimiser`] from a precompiled rewriter.
     #[staticmethod]
     pub fn load_precompiled(path: PathBuf) -> Self {
@@ -80,7 +80,7 @@ impl PyDefaultTasoOptimiser {
     }
 }
 
-impl PyDefaultTasoOptimiser {
+impl PyTasoOptimiser {
     /// The Python optimise method, but on Hugrs.
     pub(super) fn optimise(
         &self,

--- a/pyrs/test/test_pass.py
+++ b/pyrs/test/test_pass.py
@@ -1,9 +1,9 @@
 from pytket import Circuit, OpType
-from pyrs.pyrs import passes
+from pyrs.passes import taso_pass
 
 
 def test_simple_taso_pass_no_opt():
     c = Circuit(3).CCX(0, 1, 2)
-    c = passes.taso_optimise(c, max_threads = 1, timeout = 0)
-    print(c)
+    taso = taso_pass(max_threads = 1, timeout = 0)
+    c = taso.apply(c)
     assert c.n_gates_of_type(OpType.CX) == 6

--- a/src/optimiser/taso/hugr_pqueue.rs
+++ b/src/optimiser/taso/hugr_pqueue.rs
@@ -108,6 +108,7 @@ impl<P: Ord, C> HugrPQ<P, C> {
     }
 
     /// The cost function used by the queue.
+    #[allow(unused)]
     pub fn cost_fn(&self) -> &C {
         &self.cost_fn
     }


### PR DESCRIPTION
I don't think there is a reason to only support pytket 1.0. I was getting some
conflicts with pytket extensions based on this.
