### PR TITLE
ci: Various improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,30 @@ jobs:
         run: cargo test --verbose --all-features --no-run
       - name: Tests with all features
         run: cargo test --verbose --all-features
-      - name: Test pyo3 bindings
+
+  py-tests:
+    # Not required, we can ignore it for the merge queue check.
+    if: github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    name: "python bindings"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Build pyo3 bindings
         run: |
           pip install -r requirements.txt
           cd pyrs
           maturin build
           pip install ../target/wheels/*.whl
+      - name: Test pyo3 bindings
+        run: |
+          cd pyrs
           pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ['1.70', stable, beta, nightly]
+        rust: ['1.70', stable, beta]
         # workaround to ignore non-stable tests when running the merge queue checks
         # see: https://github.community/t/how-to-conditionally-include-exclude-items-in-matrix-eg-based-on-branch/16853/6
         isMerge:
@@ -65,8 +65,6 @@ jobs:
           - rust: '1.70'
             isMerge: true
           - rust: beta
-            isMerge: true
-          - rust: nightly
             isMerge: true
     name: tests (Rust ${{ matrix.rust }})
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "--cfg=ci_run"
   MIRIFLAGS: '-Zmiri-permissive-provenance' # Required due to warnings in bitvec 1.0.1
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
   check:
@@ -26,9 +28,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v0
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Check formatting
         run: cargo fmt -- --check
       - name: Run clippy
@@ -46,9 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v0
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Build benchmarks with no features
         run: cargo bench --verbose --no-run --no-default-features
       - name: Build benchmarks with all features
@@ -79,9 +77,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v0-rust-${{ matrix.rust }}
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Build with no features
         run: cargo test --verbose --no-default-features --no-run
       - name: Tests with no features

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -11,6 +11,8 @@ env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "--cfg=ci_run"
   MIRIFLAGS: '-Zmiri-permissive-provenance' # Required due to warnings in bitvec 1.0.1
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
 
 jobs:
 
@@ -24,8 +26,6 @@ jobs:
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
-      - uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v0-miri
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Test with Miri
         run: cargo miri test


### PR DESCRIPTION
- Move from [rust-cache](https://github.com/Swatinem/rust-cache) to [sccache](https://github.com/Mozilla-Actions/sccache-action). This has helped in other crates, but I can't say I see an improvement yet. I'll monitor it once it's being used.

- Move the python bindings to their own job. This is where most of the CI time is being spent, so it makes sense to run it directly from the beginning. I added a python cache and excluded this from the merge queue checks.

- Stop testing on the rust `nightly` channel. This test is mostly to report back any breaks but the cache gets invalidated daily, adding to the CI times. Testing on `beta` should suffice.