### PR TITLE
chore(deps)!: Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ portmatching = { optional = true, git = "https://github.com/lmondada/portmatchin
 ] }
 derive_more = "0.99.17"
 quantinuum-hugr = { workspace = true }
-portgraph = { workspace = true }
+portgraph = { workspace = true, features = ["serde"] }
 pyo3 = { workspace = true, optional = true, features = ["multiple-pymethods"] }
 strum_macros = "0.25.2"
 strum = "0.25.0"
@@ -70,9 +70,9 @@ members = ["pyrs", "compile-rewriter", "taso-optimiser"]
 
 [workspace.dependencies]
 
-quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr", rev = "9195d15" }
-portgraph = { version = "0.9", features = ["serde"] }
-pyo3 = { version = "0.19" }
+quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr", rev = "527cce5" }
+portgraph = { version = "0.10" }
+pyo3 = { version = "0.20" }
 itertools = { version = "0.11.0" }
-tket-json-rs = "0.1.1"
+tket-json-rs = "0.2.0"
 tracing = "0.1.37"

--- a/pyrs/Cargo.toml
+++ b/pyrs/Cargo.toml
@@ -14,6 +14,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tket-json-rs = { workspace = true, features = ["pyo3"] }
 quantinuum-hugr = { workspace = true }
-portgraph = { workspace = true, features = ["pyo3"] }
+portgraph = { workspace = true, features = ["pyo3", "serde"] }
 pyo3 = { workspace = true, features = ["extension-module"] }
 num_cpus = "1.16.0"


### PR DESCRIPTION
Final update in the dependency tree: now all crates use `pyo3 0.20`.

BREAKING CHANGE: Updated `pyo3` to `0.20` all dependencies must have matching versions due to it linking to the python lib.