### PR TITLE
perf: Use jemallocator by default for taso

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ bench = false
 name = "tket2"
 path = "src/lib.rs"
 
+[profile.release]
+lto = "thin"
+
 [dependencies]
 lazy_static = "1.4.0"
 cgmath = "0.18.0"

--- a/taso-optimiser/Cargo.toml
+++ b/taso-optimiser/Cargo.toml
@@ -17,7 +17,7 @@ tracing-subscriber = "0.3.17"
 tracing-appender = "0.2.2"
 peak_alloc = { version = "0.2.0", optional = true }
 
-[target.'cfg(all(not(target_env = "msvc"), not(feature = "peak_alloc"))'.dependencies]
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"
 
 [features]

--- a/taso-optimiser/Cargo.toml
+++ b/taso-optimiser/Cargo.toml
@@ -17,6 +17,9 @@ tracing-subscriber = "0.3.17"
 tracing-appender = "0.2.2"
 peak_alloc = { version = "0.2.0", optional = true }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"
+
 [features]
-default = ["peak_alloc"]
+default = []
 peak_alloc = ["dep:peak_alloc"]

--- a/taso-optimiser/Cargo.toml
+++ b/taso-optimiser/Cargo.toml
@@ -17,7 +17,7 @@ tracing-subscriber = "0.3.17"
 tracing-appender = "0.2.2"
 peak_alloc = { version = "0.2.0", optional = true }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(all(not(target_env = "msvc"), not(feature = "peak_alloc"))'.dependencies]
 tikv-jemallocator = "0.5"
 
 [features]

--- a/taso-optimiser/src/main.rs
+++ b/taso-optimiser/src/main.rs
@@ -15,11 +15,12 @@ use tket2::optimiser::taso::log::TasoLogger;
 use tket2::optimiser::TasoOptimiser;
 
 #[cfg(feature = "peak_alloc")]
-use peak_alloc::PeakAlloc;
-
-#[cfg(feature = "peak_alloc")]
 #[global_allocator]
-static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+static PEAK_ALLOC: peak_alloc::PeakAlloc = peak_alloc::PeakAlloc;
+
+#[cfg(all(not(target_env = "msvc"), not(feature = "peak_alloc")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 /// Optimise circuits using Quartz-generated ECCs.
 ///


### PR DESCRIPTION
Also enables thin LTO on release builds.

Tested on `barenco_tof_10`, 10s timeout, single threaded, on my laptop.

Before / after:

<img src="https://github.com/CQCL/tket2/assets/121866228/a3bec2d1-c985-4462-8404-d3c6d3baf4ea" width="49%"/>
<img src="https://github.com/CQCL/tket2/assets/121866228/c39e2bfc-b1b3-47a3-ae4f-837870a8b2fb" width="49%"/>
