### PR TITLE
chore: Update hugr dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ members = ["pyrs", "compile-rewriter", "taso-optimiser"]
 
 [workspace.dependencies]
 
-quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr", rev = "527cce5" }
+quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr", rev = "0beb165" }
 portgraph = { version = "0.10" }
 pyo3 = { version = "0.20" }
 itertools = { version = "0.11.0" }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -8,20 +8,21 @@ pub mod units;
 pub use command::{Command, CommandIterator};
 pub use hash::CircuitHash;
 
-use hugr::HugrView;
-
 use derive_more::From;
 use hugr::hugr::hugrmut::HugrMut;
-use hugr::hugr::{NodeType, PortIndex};
+use hugr::hugr::NodeType;
 use hugr::ops::dataflow::IOTrait;
-pub use hugr::ops::OpType;
 use hugr::ops::{Input, Output, DFG};
 use hugr::types::FunctionType;
-pub use hugr::types::{EdgeKind, Signature, Type, TypeRow};
-pub use hugr::{Node, Port, Wire};
+use hugr::HugrView;
+use hugr::PortIndex;
 use itertools::Itertools;
 use portgraph::Direction;
 use thiserror::Error;
+
+pub use hugr::ops::OpType;
+pub use hugr::types::{EdgeKind, Signature, Type, TypeRow};
+pub use hugr::{Node, Port, Wire};
 
 use self::cost::CircuitCost;
 use self::units::{filter, FilteredUnits, Units};

--- a/src/circuit/command.rs
+++ b/src/circuit/command.rs
@@ -6,7 +6,7 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::iter::FusedIterator;
 
-use hugr::hugr::{NodeType, PortIndex};
+use hugr::hugr::NodeType;
 use hugr::ops::{OpTag, OpTrait};
 use petgraph::visit as pv;
 
@@ -14,10 +14,9 @@ use super::units::filter::FilteredUnits;
 use super::units::{filter, DefaultUnitLabeller, LinearUnit, UnitLabeller, Units};
 use super::Circuit;
 
-pub use hugr::hugr::CircuitUnit;
 pub use hugr::ops::OpType;
 pub use hugr::types::{EdgeKind, Signature, Type, TypeRow};
-pub use hugr::{Direction, Node, Port, Wire};
+pub use hugr::{CircuitUnit, Direction, Node, Port, PortIndex, Wire};
 
 /// An operation applied to specific wires.
 pub struct Command<'circ, Circ> {

--- a/src/circuit/units.rs
+++ b/src/circuit/units.rs
@@ -17,9 +17,9 @@ pub use filter::FilteredUnits;
 
 use std::iter::FusedIterator;
 
-use hugr::hugr::CircuitUnit;
 use hugr::ops::OpTrait;
 use hugr::types::{EdgeKind, Type, TypeRow};
+use hugr::CircuitUnit;
 use hugr::{Direction, Node, Port, Wire};
 
 use crate::utils::type_is_linear;

--- a/src/circuit/units/filter.rs
+++ b/src/circuit/units/filter.rs
@@ -2,8 +2,8 @@
 //! possible.
 
 use hugr::extension::prelude;
-use hugr::hugr::CircuitUnit;
 use hugr::types::Type;
+use hugr::CircuitUnit;
 use hugr::{Port, Wire};
 
 use super::{DefaultUnitLabeller, LinearUnit, Units};

--- a/src/json.rs
+++ b/src/json.rs
@@ -7,7 +7,7 @@ pub mod op;
 #[cfg(test)]
 mod tests;
 
-use hugr::hugr::CircuitUnit;
+use hugr::CircuitUnit;
 #[cfg(feature = "pyo3")]
 use pyo3::{create_exception, exceptions::PyException, PyErr};
 

--- a/src/json/decoder.rs
+++ b/src/json/decoder.rs
@@ -9,10 +9,10 @@ use hugr::builder::{CircuitBuilder, Container, DFGBuilder, Dataflow, DataflowHug
 use hugr::extension::prelude::{PRELUDE_ID, QB_T};
 use hugr::extension::ExtensionSet;
 
-use hugr::hugr::CircuitUnit;
 use hugr::ops::Const;
 use hugr::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
 use hugr::types::FunctionType;
+use hugr::CircuitUnit;
 use hugr::{Hugr, Wire};
 
 use serde_json::json;

--- a/src/optimiser/taso/qtz_circuit.rs
+++ b/src/optimiser/taso/qtz_circuit.rs
@@ -4,10 +4,10 @@ use std::path::Path;
 
 use hugr::builder::{DFGBuilder, Dataflow, DataflowHugr};
 use hugr::extension::prelude::QB_T;
-use hugr::hugr::CircuitUnit;
 use hugr::ops::OpType as Op;
 use hugr::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
 use hugr::types::{FunctionType, Type};
+use hugr::CircuitUnit;
 use hugr::Hugr as Circuit;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};

--- a/src/passes/chunks.rs
+++ b/src/passes/chunks.rs
@@ -12,11 +12,11 @@ use hugr::extension::ExtensionSet;
 use hugr::hugr::hugrmut::HugrMut;
 use hugr::hugr::views::sibling_subgraph::ConvexChecker;
 use hugr::hugr::views::{HierarchyView, SiblingGraph, SiblingSubgraph};
-use hugr::hugr::{HugrError, NodeMetadata, PortIndex};
+use hugr::hugr::{HugrError, NodeMetadata};
 use hugr::ops::handle::DataflowParentID;
 use hugr::ops::OpType;
 use hugr::types::{FunctionType, Signature};
-use hugr::{Hugr, HugrView, Node, Port, Wire};
+use hugr::{Hugr, HugrView, Node, Port, PortIndex, Wire};
 use itertools::Itertools;
 
 use crate::Circuit;

--- a/src/passes/commutation.rs
+++ b/src/passes/commutation.rs
@@ -1,9 +1,7 @@
 use std::{collections::HashMap, rc::Rc};
 
-use hugr::{
-    hugr::{hugrmut::HugrMut, CircuitUnit, HugrError, PortIndex, Rewrite},
-    Direction, Hugr, HugrView, Node, Port,
-};
+use hugr::hugr::{hugrmut::HugrMut, HugrError, Rewrite};
+use hugr::{CircuitUnit, Direction, Hugr, HugrView, Node, Port, PortIndex};
 use itertools::Itertools;
 use portgraph::PortOffset;
 

--- a/src/portmatching/matcher.rs
+++ b/src/portmatching/matcher.rs
@@ -11,8 +11,9 @@ use super::{CircuitPattern, NodeID, PEdge, PNode};
 use hugr::hugr::views::sibling_subgraph::{
     ConvexChecker, InvalidReplacement, InvalidSubgraph, InvalidSubgraphBoundary,
 };
-use hugr::hugr::PortIndex;
-use hugr::{hugr::views::SiblingSubgraph, ops::OpType, Hugr, Node, Port};
+use hugr::hugr::views::SiblingSubgraph;
+use hugr::ops::OpType;
+use hugr::{Hugr, Node, Port, PortIndex};
 use itertools::Itertools;
 use portmatching::{
     automaton::{LineBuilder, ScopeAutomaton},

--- a/src/rewrite/ecc_rewriter.rs
+++ b/src/rewrite/ecc_rewriter.rs
@@ -13,8 +13,8 @@
 //! of the Quartz repository.
 
 use derive_more::{From, Into};
-use hugr::hugr::PortIndex;
 use hugr::ops::OpTrait;
+use hugr::PortIndex;
 use itertools::Itertools;
 use portmatching::PatternID;
 use std::{


### PR DESCRIPTION
- Some base types were moved from `hugr::hugr::*` to the crate's root.