### PR TITLE
chore: update hugr dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license-file = "LICENCE"
 [workspace.dependencies]
 
 tket2 = { path = "./tket2" }
-quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr", rev = "356bbc5" }
+quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr", rev = "1fce927" }
 portgraph = { version = "0.10" }
 pyo3 = { version = "0.20" }
 itertools = { version = "0.11.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license-file = "LICENCE"
 [workspace.dependencies]
 
 tket2 = { path = "./tket2" }
-quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr", rev = "0beb165" }
+quantinuum-hugr = { git = "https://github.com/CQCL-DEV/hugr", rev = "356bbc5" }
 portgraph = { version = "0.10" }
 pyo3 = { version = "0.20" }
 itertools = { version = "0.11.0" }

--- a/tket2/Cargo.toml
+++ b/tket2/Cargo.toml
@@ -56,7 +56,6 @@ bytemuck = "1.14.0"
 stringreader = "0.1.1"
 crossbeam-channel = "0.5.8"
 tracing = { workspace = true }
-either = "1.9.0"
 
 [dev-dependencies]
 rstest = "0.18.1"

--- a/tket2/Cargo.toml
+++ b/tket2/Cargo.toml
@@ -56,6 +56,7 @@ bytemuck = "1.14.0"
 stringreader = "0.1.1"
 crossbeam-channel = "0.5.8"
 tracing = { workspace = true }
+either = "1.9.0"
 
 [dev-dependencies]
 rstest = "0.18.1"

--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -6,8 +6,8 @@ mod hash;
 pub mod units;
 
 pub use command::{Command, CommandIterator};
-use either::Either::{Left, Right};
 pub use hash::CircuitHash;
+use itertools::Either::{Left, Right};
 
 use derive_more::From;
 use hugr::hugr::hugrmut::HugrMut;

--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -6,6 +6,7 @@ mod hash;
 pub mod units;
 
 pub use command::{Command, CommandIterator};
+use either::Either::{Left, Right};
 pub use hash::CircuitHash;
 
 use derive_more::From;
@@ -174,7 +175,7 @@ pub(crate) fn remove_empty_wire(
     if input_port >= circ.num_outputs(inp) {
         return Err(CircuitMutError::InvalidPortOffset(input_port));
     }
-    let input_port = Port::new_outgoing(input_port);
+    let input_port = Port::new(Direction::Outgoing, input_port);
     let link = circ
         .linked_ports(inp, input_port)
         .at_most_one()
@@ -234,9 +235,15 @@ fn shift_ports<C: HugrMut + ?Sized>(
         }
         for (other_n, other_p) in links {
             // TODO: simplify when CQCL-DEV/hugr#565 is resolved
-            match dir {
-                Direction::Incoming => circ.connect(other_n, other_p, node, free_port),
-                Direction::Outgoing => circ.connect(node, free_port, other_n, other_p),
+            match other_p.as_directed() {
+                Right(other_p) => {
+                    let dst_port = free_port.as_incoming().unwrap();
+                    circ.connect(other_n, other_p, node, dst_port)
+                }
+                Left(other_p) => {
+                    let src_port = free_port.as_outgoing().unwrap();
+                    circ.connect(node, src_port, other_n, other_p)
+                }
             }?;
         }
         free_port = port;

--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -234,7 +234,6 @@ fn shift_ports<C: HugrMut + ?Sized>(
             circ.disconnect(node, port)?;
         }
         for (other_n, other_p) in links {
-            // TODO: simplify when CQCL-DEV/hugr#565 is resolved
             match other_p.as_directed() {
                 Right(other_p) => {
                     let dst_port = free_port.as_incoming().unwrap();

--- a/tket2/src/circuit/command.rs
+++ b/tket2/src/circuit/command.rs
@@ -6,9 +6,9 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::iter::FusedIterator;
 
-use either::Either::{Left, Right};
 use hugr::hugr::NodeType;
 use hugr::ops::{OpTag, OpTrait};
+use itertools::Either::{Left, Right};
 use petgraph::visit as pv;
 
 use super::units::filter::FilteredUnits;

--- a/tket2/src/circuit/units.rs
+++ b/tket2/src/circuit/units.rs
@@ -239,9 +239,7 @@ impl UnitLabeller for DefaultUnitLabeller {
 
     #[inline]
     fn assign_wire(&self, node: Node, port: Port) -> Option<Wire> {
-        match port.direction() {
-            Direction::Incoming => None,
-            Direction::Outgoing => Some(Wire::new(node, port)),
-        }
+        let port = port.as_outgoing().ok()?;
+        Some(Wire::new(node, port))
     }
 }

--- a/tket2/src/passes/chunks.rs
+++ b/tket2/src/passes/chunks.rs
@@ -223,13 +223,11 @@ struct ChunkInsertResult {
 }
 
 /// The target of a chunk connection in a reassembled circuit.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum ConnectionTarget {
     /// The target is a chunk node's input.
-    #[from]
     InsertedInput(Node, IncomingPort),
     /// The target is a chunk node's output.
-    #[from]
     InsertedOutput(Node, OutgoingPort),
     /// The link goes directly to the opposite boundary, without an intermediary
     /// node.

--- a/tket2/src/passes/chunks.rs
+++ b/tket2/src/passes/chunks.rs
@@ -16,7 +16,7 @@ use hugr::hugr::{HugrError, NodeMetadata};
 use hugr::ops::handle::DataflowParentID;
 use hugr::ops::OpType;
 use hugr::types::{FunctionType, Signature};
-use hugr::{Hugr, HugrView, Node, Port, PortIndex, Wire};
+use hugr::{Hugr, HugrView, IncomingPort, Node, OutgoingPort, PortIndex, Wire};
 use itertools::Itertools;
 
 use crate::Circuit;
@@ -79,7 +79,7 @@ impl Chunk {
             .map(|wires| {
                 let (inp_node, inp_port) = wires[0];
                 let (out_node, out_port) = circ
-                    .linked_ports(inp_node, inp_port)
+                    .linked_outputs(inp_node, inp_port)
                     .exactly_one()
                     .ok()
                     .unwrap();
@@ -127,7 +127,7 @@ impl Chunk {
         {
             let connection_targets: Vec<ConnectionTarget> = self
                 .circ
-                .linked_ports(chunk_inp, chunk_inp_port)
+                .linked_inputs(chunk_inp, chunk_inp_port)
                 .map(|(node, port)| {
                     if node == chunk_out {
                         // This was a direct wire from the chunk input to the output. Use the output's [`ChunkConnection`].
@@ -135,7 +135,7 @@ impl Chunk {
                         ConnectionTarget::TransitiveConnection(output_connection)
                     } else {
                         // Translate the original chunk node into the inserted node.
-                        (*node_map.get(&node).unwrap(), port).into()
+                        ConnectionTarget::InsertedInput(*node_map.get(&node).unwrap(), port)
                     }
                 })
                 .collect();
@@ -145,7 +145,7 @@ impl Chunk {
         for (&wire, chunk_out_port) in self.outputs.iter().zip(self.circ.node_inputs(chunk_out)) {
             let (node, port) = self
                 .circ
-                .linked_ports(chunk_out, chunk_out_port)
+                .linked_outputs(chunk_out, chunk_out_port)
                 .exactly_one()
                 .ok()
                 .unwrap();
@@ -155,7 +155,7 @@ impl Chunk {
                 ConnectionTarget::TransitiveConnection(input_connection)
             } else {
                 // Translate the original chunk node into the inserted node.
-                (*node_map.get(&node).unwrap(), port).into()
+                ConnectionTarget::InsertedOutput(*node_map.get(&node).unwrap(), port)
             };
             output_map.insert(wire, target);
         }
@@ -225,9 +225,12 @@ struct ChunkInsertResult {
 /// The target of a chunk connection in a reassembled circuit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, From)]
 enum ConnectionTarget {
-    /// The target is a single node and port.
+    /// The target is a chunk node's input.
     #[from]
-    InsertedNode(Node, Port),
+    InsertedInput(Node, IncomingPort),
+    /// The target is a chunk node's output.
+    #[from]
+    InsertedOutput(Node, OutgoingPort),
     /// The link goes directly to the opposite boundary, without an intermediary
     /// node.
     TransitiveConnection(ChunkConnection),
@@ -284,7 +287,7 @@ impl CircuitChunks {
             .collect();
         let output_connections = circ
             .node_inputs(circ_output)
-            .flat_map(|p| circ.linked_ports(circ_output, p))
+            .flat_map(|p| circ.linked_outputs(circ_output, p))
             .map(|(n, p)| Wire::new(n, p).into())
             .collect();
 
@@ -336,8 +339,8 @@ impl CircuitChunks {
         // The chunks input and outputs are each identified with a
         // [`ChunkConnection`]. We collect both sides first, and rewire them
         // after the chunks have been inserted.
-        let mut sources: HashMap<ChunkConnection, (Node, Port)> = HashMap::new();
-        let mut targets: HashMap<ChunkConnection, Vec<(Node, Port)>> = HashMap::new();
+        let mut sources: HashMap<ChunkConnection, (Node, OutgoingPort)> = HashMap::new();
+        let mut targets: HashMap<ChunkConnection, Vec<(Node, IncomingPort)>> = HashMap::new();
 
         // A map for `ChunkConnection`s that have been merged into another (due
         // to identity wires in the updated chunks).
@@ -380,7 +383,7 @@ impl CircuitChunks {
             // (due to an identity wire).
             for (connection, conn_target) in outgoing_connections {
                 match conn_target {
-                    ConnectionTarget::InsertedNode(node, port) => {
+                    ConnectionTarget::InsertedOutput(node, port) => {
                         // The output of a chunk always has fresh `ChunkConnection`s.
                         sources.insert(connection, (node, port));
                     }
@@ -390,6 +393,7 @@ impl CircuitChunks {
                             get_merged_connection(&transitive_connections, merged_connection);
                         transitive_connections.insert(connection, merged_connection);
                     }
+                    _ => panic!("Unexpected connection target"),
                 }
             }
             for (connection, conn_targets) in incoming_connections {
@@ -397,7 +401,7 @@ impl CircuitChunks {
                 let connection = get_merged_connection(&transitive_connections, connection);
                 for tgt in conn_targets {
                     match tgt {
-                        ConnectionTarget::InsertedNode(node, port) => {
+                        ConnectionTarget::InsertedInput(node, port) => {
                             targets.entry(connection).or_default().push((node, port));
                         }
                         ConnectionTarget::TransitiveConnection(_merged_connection) => {
@@ -405,6 +409,7 @@ impl CircuitChunks {
                             // outgoing_connections, so we don't need to do
                             // anything here.
                         }
+                        _ => panic!("Unexpected connection target"),
                     }
                 }
             }

--- a/tket2/src/portmatching.rs
+++ b/tket2/src/portmatching.rs
@@ -5,6 +5,7 @@ pub mod pattern;
 #[cfg(feature = "pyo3")]
 pub mod pyo3;
 
+use hugr::OutgoingPort;
 use itertools::Itertools;
 pub use matcher::{PatternMatch, PatternMatcher};
 pub use pattern::CircuitPattern;
@@ -132,6 +133,14 @@ impl portmatching::EdgeProperty for PEdge {
 pub(super) enum NodeID {
     HugrNode(Node),
     CopyNode(Node, Port),
+}
+
+impl NodeID {
+    /// Create a new copy NodeID.
+    pub fn new_copy(node: Node, port: impl Into<OutgoingPort>) -> Self {
+        let port: OutgoingPort = port.into();
+        Self::CopyNode(node, port.into())
+    }
 }
 
 impl From<Node> for NodeID {

--- a/tket2/src/portmatching/pattern.rs
+++ b/tket2/src/portmatching/pattern.rs
@@ -53,7 +53,7 @@ impl CircuitPattern {
                     .expect("invalid HUGR");
                 let prev_node = match edge_prop {
                     PEdge::InternalEdge { .. } => NodeID::HugrNode(prev_node),
-                    PEdge::InputEdge { .. } => NodeID::CopyNode(prev_node, prev_port.into()),
+                    PEdge::InputEdge { .. } => NodeID::new_copy(prev_node, prev_port),
                 };
                 pattern.add_edge(cmd.node().into(), prev_node, edge_prop);
             }
@@ -162,7 +162,7 @@ mod tests {
     use hugr::ops::LeafOp;
     use hugr::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
     use hugr::types::FunctionType;
-    use hugr::{Direction, Hugr};
+    use hugr::Hugr;
 
     use crate::extension::REGISTRY;
     use crate::utils::build_simple_circuit;
@@ -236,14 +236,8 @@ mod tests {
             edges,
             [
                 (cx_gate, h_gate),
-                (
-                    cx_gate,
-                    NodeID::CopyNode(inp, Port::new(Direction::Outgoing, 0))
-                ),
-                (
-                    cx_gate,
-                    NodeID::CopyNode(inp, Port::new(Direction::Outgoing, 1))
-                ),
+                (cx_gate, NodeID::new_copy(inp, 0)),
+                (cx_gate, NodeID::new_copy(inp, 1)),
             ]
             .into_iter()
             .collect()
@@ -299,7 +293,7 @@ mod tests {
             assert!(edges.iter().any(|e| {
                 e.reverse().is_none()
                     && e.source.unwrap() == rx_n.into()
-                    && e.target.unwrap() == NodeID::CopyNode(inp, Port::new(Direction::Outgoing, 1))
+                    && e.target.unwrap() == NodeID::new_copy(inp, 1)
             }));
         }
     }

--- a/tket2/src/portmatching/pattern.rs
+++ b/tket2/src/portmatching/pattern.rs
@@ -1,5 +1,6 @@
 //! Circuit Patterns for pattern matching
 
+use hugr::IncomingPort;
 use hugr::{ops::OpTrait, Node, Port};
 use itertools::Itertools;
 use portmatching::{patterns::NoRootFound, HashMap, Pattern, SinglePatternMatcher};
@@ -42,17 +43,17 @@ impl CircuitPattern {
             let op = cmd.optype().clone();
             pattern.require(cmd.node().into(), op.try_into().unwrap());
             for in_offset in 0..cmd.input_count() {
-                let in_offset = Port::new_incoming(in_offset);
-                let edge_prop =
-                    PEdge::try_from_port(cmd.node(), in_offset, circuit).expect("Invalid HUGR");
+                let in_offset: IncomingPort = in_offset.into();
+                let edge_prop = PEdge::try_from_port(cmd.node(), in_offset.into(), circuit)
+                    .expect("Invalid HUGR");
                 let (prev_node, prev_port) = circuit
-                    .linked_ports(cmd.node(), in_offset)
+                    .linked_outputs(cmd.node(), in_offset)
                     .exactly_one()
                     .ok()
                     .expect("invalid HUGR");
                 let prev_node = match edge_prop {
                     PEdge::InternalEdge { .. } => NodeID::HugrNode(prev_node),
-                    PEdge::InputEdge { .. } => NodeID::CopyNode(prev_node, prev_port),
+                    PEdge::InputEdge { .. } => NodeID::CopyNode(prev_node, prev_port.into()),
                 };
                 pattern.add_edge(cmd.node().into(), prev_node, edge_prop);
             }
@@ -161,7 +162,7 @@ mod tests {
     use hugr::ops::LeafOp;
     use hugr::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
     use hugr::types::FunctionType;
-    use hugr::Hugr;
+    use hugr::{Direction, Hugr};
 
     use crate::extension::REGISTRY;
     use crate::utils::build_simple_circuit;
@@ -235,8 +236,14 @@ mod tests {
             edges,
             [
                 (cx_gate, h_gate),
-                (cx_gate, NodeID::CopyNode(inp, Port::new_outgoing(0))),
-                (cx_gate, NodeID::CopyNode(inp, Port::new_outgoing(1))),
+                (
+                    cx_gate,
+                    NodeID::CopyNode(inp, Port::new(Direction::Outgoing, 0))
+                ),
+                (
+                    cx_gate,
+                    NodeID::CopyNode(inp, Port::new(Direction::Outgoing, 1))
+                ),
             ]
             .into_iter()
             .collect()
@@ -292,7 +299,7 @@ mod tests {
             assert!(edges.iter().any(|e| {
                 e.reverse().is_none()
                     && e.source.unwrap() == rx_n.into()
-                    && e.target.unwrap() == NodeID::CopyNode(inp, Port::new_outgoing(1))
+                    && e.target.unwrap() == NodeID::CopyNode(inp, Port::new(Direction::Outgoing, 1))
             }));
         }
     }

--- a/tket2/src/portmatching/pyo3.rs
+++ b/tket2/src/portmatching/pyo3.rs
@@ -4,7 +4,7 @@ use std::fmt;
 
 use derive_more::{From, Into};
 use hugr::hugr::views::sibling_subgraph::PyInvalidReplacementError;
-use hugr::{Hugr, Port};
+use hugr::{Hugr, IncomingPort, OutgoingPort};
 use itertools::Itertools;
 use portmatching::{HashMap, PatternID};
 use pyo3::{prelude::*, types::PyIterator};
@@ -94,11 +94,11 @@ pub struct PyPatternMatch {
     /// This is the incoming boundary of a [`hugr::hugr::views::SiblingSubgraph`].
     /// The input ports are grouped together if they are connected to the same
     /// source.
-    pub inputs: Vec<Vec<(Node, Port)>>,
+    pub inputs: Vec<Vec<(Node, IncomingPort)>>,
     /// The output ports of the subcircuit.
     ///
     /// This is the outgoing boundary of a [`hugr::hugr::views::SiblingSubgraph`].
-    pub outputs: Vec<(Node, Port)>,
+    pub outputs: Vec<(Node, OutgoingPort)>,
     /// The node map from pattern to circuit.
     pub node_map: HashMap<Node, Node>,
 }
@@ -134,16 +134,16 @@ impl PyPatternMatch {
         let inputs = pattern
             .inputs
             .iter()
-            .map(|p| {
-                p.iter()
-                    .map(|&(n, p)| (node_map[&Node(n)], p))
+            .map(|ps| {
+                ps.iter()
+                    .map(|&(n, p)| (node_map[&Node(n)], p.as_incoming().unwrap()))
                     .collect_vec()
             })
             .collect_vec();
         let outputs = pattern
             .outputs
             .iter()
-            .map(|&(n, p)| (node_map[&Node(n)], p))
+            .map(|&(n, p)| (node_map[&Node(n)], p.as_outgoing().unwrap()))
             .collect_vec();
         Ok(Self {
             pattern_id: pattern_id.0,


### PR DESCRIPTION
This required a partial move from using `Port` everywhere to the more specific `OutgoingPort` and `IncomingPort`.

I'll open a separate issue for the more pervasive changes like updating the `Units` iterator and the `portmatching` module.
For now, we just cast and `unwrap` in those cases.

Requires https://github.com/CQCL/hugr/pull/647