### PR TITLE
ci: fix failing py coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,6 @@ jobs:
       - name: Upload python coverage to codecov.io
         uses: codecov/codecov-action@v3
         with:
-          files: pyrs/coverage.xml
+          files: coverage.xml
           name: python
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
#211 didn't update the coverage path in `ci.yml` x_x