### PR TITLE
feat: Use tket1 and tket2 circuits interchangeably everywhere

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = []                                             # TODO
 maintainers = []                                         # TODO
 include = ["pyproject.toml"]
 license = "Apache-2.0"
+license_file = "LICENCE"
 readme = "README.md"
 
 packages = [{ include = "tket2-py" }]

--- a/tket2-py/src/circuit.rs
+++ b/tket2-py/src/circuit.rs
@@ -13,20 +13,18 @@ use tket2::json::TKETDecode;
 use tket2::rewrite::CircuitRewrite;
 use tket_json_rs::circuit_json::SerialCircuit;
 
-pub use self::convert::{try_update_hugr, try_with_hugr, update_hugr, with_hugr, T2Circuit};
+pub use self::convert::{try_update_hugr, try_with_hugr, update_hugr, with_hugr, Tk2Circuit};
 
 /// The module definition
 pub fn module(py: Python) -> PyResult<&PyModule> {
     let m = PyModule::new(py, "_circuit")?;
-    m.add_class::<T2Circuit>()?;
+    m.add_class::<Tk2Circuit>()?;
     m.add_class::<PyNode>()?;
     m.add_class::<tket2::T2Op>()?;
     m.add_class::<tket2::Pauli>()?;
 
     m.add_function(wrap_pyfunction!(validate_hugr, m)?)?;
     m.add_function(wrap_pyfunction!(to_hugr_dot, m)?)?;
-    m.add_function(wrap_pyfunction!(tket1_to_tket2, m)?)?;
-    m.add_function(wrap_pyfunction!(tket2_to_tket1, m)?)?;
 
     m.add("HugrError", py.get_type::<hugr::hugr::PyHugrError>())?;
     m.add("BuildError", py.get_type::<hugr::builder::PyBuildError>())?;
@@ -56,18 +54,6 @@ pub fn validate_hugr(c: &PyAny) -> PyResult<()> {
 #[pyfunction]
 pub fn to_hugr_dot(c: &PyAny) -> PyResult<String> {
     with_hugr(c, |hugr, _| hugr.dot_string())
-}
-
-/// Cast a python tket1 circuit to a [`T2Circuit`].
-#[pyfunction]
-pub fn tket1_to_tket2(c: &PyAny) -> PyResult<T2Circuit> {
-    T2Circuit::from_circuit(c)
-}
-
-/// Cast a [`T2Circuit`] to a python tket1 circuit.
-#[pyfunction]
-pub fn tket2_to_tket1(py: Python, c: T2Circuit) -> PyResult<&PyAny> {
-    c.finish(py)
 }
 
 /// A [`hugr::Node`] wrapper for Python.

--- a/tket2-py/src/circuit.rs
+++ b/tket2-py/src/circuit.rs
@@ -25,7 +25,8 @@ pub fn module(py: Python) -> PyResult<&PyModule> {
 
     m.add_function(wrap_pyfunction!(validate_hugr, m)?)?;
     m.add_function(wrap_pyfunction!(to_hugr_dot, m)?)?;
-    m.add_function(wrap_pyfunction!(to_hugr, m)?)?;
+    m.add_function(wrap_pyfunction!(tket1_to_hugr, m)?)?;
+    m.add_function(wrap_pyfunction!(hugr_to_tket1, m)?)?;
 
     m.add("HugrError", py.get_type::<hugr::hugr::PyHugrError>())?;
     m.add("BuildError", py.get_type::<hugr::builder::PyBuildError>())?;
@@ -57,10 +58,16 @@ pub fn to_hugr_dot(c: Py<PyAny>) -> PyResult<String> {
     with_hugr(c, |hugr| hugr.dot_string())
 }
 
-/// Downcast a python object to a [`Hugr`].
+/// Cast a python tket1 circuit to a [`T2Circuit`].
 #[pyfunction]
-pub fn to_hugr(c: Py<PyAny>) -> PyResult<T2Circuit> {
-    with_hugr(c, |hugr| hugr.into())
+pub fn tket1_to_hugr(c: Py<PyAny>) -> PyResult<T2Circuit> {
+    T2Circuit::from_circuit(c)
+}
+
+/// Cast a [`T2Circuit`] to a python tket1 circuit.
+#[pyfunction]
+pub fn hugr_to_tket1(c: T2Circuit) -> PyResult<Py<PyAny>> {
+    c.finish()
 }
 
 /// A [`hugr::Node`] wrapper for Python.

--- a/tket2-py/src/circuit.rs
+++ b/tket2-py/src/circuit.rs
@@ -25,8 +25,8 @@ pub fn module(py: Python) -> PyResult<&PyModule> {
 
     m.add_function(wrap_pyfunction!(validate_hugr, m)?)?;
     m.add_function(wrap_pyfunction!(to_hugr_dot, m)?)?;
-    m.add_function(wrap_pyfunction!(tket1_to_hugr, m)?)?;
-    m.add_function(wrap_pyfunction!(hugr_to_tket1, m)?)?;
+    m.add_function(wrap_pyfunction!(tket1_to_tket2, m)?)?;
+    m.add_function(wrap_pyfunction!(tket2_to_tket1, m)?)?;
 
     m.add("HugrError", py.get_type::<hugr::hugr::PyHugrError>())?;
     m.add("BuildError", py.get_type::<hugr::builder::PyBuildError>())?;
@@ -48,26 +48,26 @@ pub fn module(py: Python) -> PyResult<&PyModule> {
 
 /// Run the validation checks on a circuit.
 #[pyfunction]
-pub fn validate_hugr(c: Py<PyAny>) -> PyResult<()> {
-    try_with_hugr(c, |hugr| hugr.validate(&REGISTRY))
+pub fn validate_hugr(c: &PyAny) -> PyResult<()> {
+    try_with_hugr(c, |hugr, _| hugr.validate(&REGISTRY))
 }
 
 /// Return a Graphviz DOT string representation of the circuit.
 #[pyfunction]
-pub fn to_hugr_dot(c: Py<PyAny>) -> PyResult<String> {
-    with_hugr(c, |hugr| hugr.dot_string())
+pub fn to_hugr_dot(c: &PyAny) -> PyResult<String> {
+    with_hugr(c, |hugr, _| hugr.dot_string())
 }
 
 /// Cast a python tket1 circuit to a [`T2Circuit`].
 #[pyfunction]
-pub fn tket1_to_hugr(c: Py<PyAny>) -> PyResult<T2Circuit> {
+pub fn tket1_to_tket2(c: &PyAny) -> PyResult<T2Circuit> {
     T2Circuit::from_circuit(c)
 }
 
 /// Cast a [`T2Circuit`] to a python tket1 circuit.
 #[pyfunction]
-pub fn hugr_to_tket1(c: T2Circuit) -> PyResult<Py<PyAny>> {
-    c.finish()
+pub fn tket2_to_tket1(py: Python, c: T2Circuit) -> PyResult<&PyAny> {
+    c.finish(py)
 }
 
 /// A [`hugr::Node`] wrapper for Python.

--- a/tket2-py/src/circuit/convert.rs
+++ b/tket2-py/src/circuit/convert.rs
@@ -42,6 +42,8 @@ impl Tk2Circuit {
     }
 
     /// Encode the circuit as a HUGR json string.
+    //
+    // TODO: Bind a messagepack encoder/decoder too.
     pub fn to_hugr_json(&self) -> PyResult<String> {
         Ok(serde_json::to_string(&self.hugr).unwrap())
     }
@@ -100,7 +102,9 @@ impl CircuitType {
     }
 }
 
-/// Apply a fallible function expecting a hugr on a pytket circuit.
+/// Apply a fallible function expecting a hugr on a python circuit.
+///
+/// This method supports both `pytket.Circuit` and `Tk2Circuit` python objects.
 pub fn try_with_hugr<T, E, F>(circ: &PyAny, f: F) -> PyResult<T>
 where
     E: Into<PyErr>,
@@ -118,7 +122,9 @@ where
     (f)(hugr, typ).map_err(|e| e.into())
 }
 
-/// Apply a function expecting a hugr on a pytket circuit.
+/// Apply a function expecting a hugr on a python circuit.
+///
+/// This method supports both `pytket.Circuit` and `Tk2Circuit` python objects.
 pub fn with_hugr<T, F>(circ: &PyAny, f: F) -> PyResult<T>
 where
     F: FnOnce(Hugr, CircuitType) -> T,
@@ -126,7 +132,10 @@ where
     try_with_hugr(circ, |hugr, typ| Ok::<T, PyErr>((f)(hugr, typ)))
 }
 
-/// Apply a hugr-to-hugr function on a pytket circuit, and return the modified circuit.
+/// Apply a fallible hugr-to-hugr function on a python circuit, and return the modified circuit.
+///
+/// This method supports both `pytket.Circuit` and `Tk2Circuit` python objects.
+/// The returned Hugr is converted to the matching python object.
 pub fn try_update_hugr<E, F>(circ: &PyAny, f: F) -> PyResult<&PyAny>
 where
     E: Into<PyErr>,
@@ -139,7 +148,10 @@ where
     })
 }
 
-/// Apply a hugr-to-hugr function on a pytket circuit, and return the modified circuit.
+/// Apply a hugr-to-hugr function on a python circuit, and return the modified circuit.
+///
+/// This method supports both `pytket.Circuit` and `Tk2Circuit` python objects.
+/// The returned Hugr is converted to the matching python object.
 pub fn update_hugr<F>(circ: &PyAny, f: F) -> PyResult<&PyAny>
 where
     F: FnOnce(Hugr, CircuitType) -> Hugr,

--- a/tket2-py/src/circuit/convert.rs
+++ b/tket2-py/src/circuit/convert.rs
@@ -23,7 +23,7 @@ pub struct Tk2Circuit {
 
 #[pymethods]
 impl Tk2Circuit {
-    /// Cast a tket1 circuit to a [`Tk2Circuit`].
+    /// Convert a tket1 circuit to a [`Tk2Circuit`].
     #[new]
     pub fn from_tket1(circ: &PyAny) -> PyResult<Self> {
         Ok(Self {
@@ -31,7 +31,7 @@ impl Tk2Circuit {
         })
     }
 
-    /// Cast the [`Tk2Circuit`] to a tket1 circuit.
+    /// Convert the [`Tk2Circuit`] to a tket1 circuit.
     pub fn to_tket1<'py>(&self, py: Python<'py>) -> PyResult<&'py PyAny> {
         SerialCircuit::encode(&self.hugr)?.to_tket1(py)
     }

--- a/tket2-py/src/optimiser.rs
+++ b/tket2-py/src/optimiser.rs
@@ -57,16 +57,16 @@ impl PyBadgerOptimiser {
     /// * `log_progress`: The path to a CSV file to log progress to.
     ///
     #[pyo3(name = "optimise")]
-    pub fn py_optimise(
+    pub fn py_optimise<'py>(
         &self,
-        circ: PyObject,
+        circ: &'py PyAny,
         timeout: Option<u64>,
         n_threads: Option<NonZeroUsize>,
         split_circ: Option<bool>,
         log_progress: Option<PathBuf>,
         queue_size: Option<usize>,
-    ) -> PyResult<PyObject> {
-        update_hugr(circ, |circ| {
+    ) -> PyResult<&'py PyAny> {
+        update_hugr(circ, |circ, _| {
             self.optimise(
                 circ,
                 timeout,

--- a/tket2-py/src/passes/chunks.rs
+++ b/tket2-py/src/passes/chunks.rs
@@ -13,7 +13,7 @@ use crate::circuit::{try_with_hugr, with_hugr};
 #[pyfunction]
 pub fn chunks(c: &PyAny, max_chunk_size: usize) -> PyResult<PyCircuitChunks> {
     with_hugr(c, |hugr, typ| {
-        // TODO: Detect if the circuit is in tket1 format or T2Circuit.
+        // TODO: Detect if the circuit is in tket1 format or Tk2Circuit.
         let chunks = CircuitChunks::split(&hugr, max_chunk_size);
         (chunks, typ).into()
     })

--- a/tket2-py/src/passes/chunks.rs
+++ b/tket2-py/src/passes/chunks.rs
@@ -3,21 +3,19 @@
 use derive_more::From;
 use pyo3::exceptions::PyAttributeError;
 use pyo3::prelude::*;
-use tket2::json::TKETDecode;
 use tket2::passes::CircuitChunks;
 use tket2::Circuit;
-use tket_json_rs::circuit_json::SerialCircuit;
 
-use crate::circuit::{with_hugr, T2Circuit};
+use crate::circuit::convert::CircuitType;
+use crate::circuit::{try_with_hugr, with_hugr};
 
 /// Split a circuit into chunks of a given size.
 #[pyfunction]
-pub fn chunks(c: Py<PyAny>, max_chunk_size: usize) -> PyResult<PyCircuitChunks> {
-    with_hugr(c, |hugr| {
+pub fn chunks(c: &PyAny, max_chunk_size: usize) -> PyResult<PyCircuitChunks> {
+    with_hugr(c, |hugr, typ| {
         // TODO: Detect if the circuit is in tket1 format or T2Circuit.
-        let is_tket1 = true;
         let chunks = CircuitChunks::split(&hugr, max_chunk_size);
-        (chunks, is_tket1).into()
+        (chunks, typ).into()
     })
 }
 
@@ -32,38 +30,36 @@ pub fn chunks(c: Py<PyAny>, max_chunk_size: usize) -> PyResult<PyCircuitChunks> 
 pub struct PyCircuitChunks {
     /// Rust representation of the circuit chunks.
     pub chunks: CircuitChunks,
-    /// Whether to reassemble the circuit in the tket1 format.
-    pub in_tket1: bool,
+    /// Whether to reassemble the circuit in the tket1 or tket2 format.
+    pub original_type: CircuitType,
 }
 
 #[pymethods]
 impl PyCircuitChunks {
     /// Reassemble the chunks into a circuit.
-    fn reassemble(&self) -> PyResult<Py<PyAny>> {
+    fn reassemble<'py>(&self, py: Python<'py>) -> PyResult<&'py PyAny> {
         let hugr = self.clone().chunks.reassemble()?;
-        Python::with_gil(|py| match self.in_tket1 {
-            true => Ok(SerialCircuit::encode(&hugr)?.to_tket1(py)?.into_py(py)),
-            false => Ok(T2Circuit { hugr }.into_py(py)),
-        })
+        self.original_type.convert(py, hugr)
     }
 
     /// Returns clones of the split circuits.
-    fn circuits(&self) -> PyResult<Vec<Py<PyAny>>> {
+    fn circuits<'py>(&self, py: Python<'py>) -> PyResult<Vec<&'py PyAny>> {
         self.chunks
             .iter()
-            .map(|hugr| SerialCircuit::encode(hugr)?.to_tket1_with_gil())
+            .map(|hugr| self.original_type.convert(py, hugr.clone()))
             .collect()
     }
 
     /// Replaces a chunk's circuit with an updated version.
-    fn update_circuit(&mut self, index: usize, new_circ: Py<PyAny>) -> PyResult<()> {
-        let hugr = SerialCircuit::from_tket1_with_gil(new_circ)?.decode()?;
-        if hugr.circuit_signature() != self.chunks[index].circuit_signature() {
-            return Err(PyAttributeError::new_err(
-                "The new circuit has a different signature.",
-            ));
-        }
-        self.chunks[index] = hugr;
-        Ok(())
+    fn update_circuit(&mut self, index: usize, new_circ: &PyAny) -> PyResult<()> {
+        try_with_hugr(new_circ, |hugr, _| {
+            if hugr.circuit_signature() != self.chunks[index].circuit_signature() {
+                return Err(PyAttributeError::new_err(
+                    "The new circuit has a different signature.",
+                ));
+            }
+            self.chunks[index] = hugr;
+            Ok(())
+        })
     }
 }

--- a/tket2-py/src/pattern.rs
+++ b/tket2-py/src/pattern.rs
@@ -3,7 +3,7 @@
 pub mod portmatching;
 pub mod rewrite;
 
-use crate::circuit::{to_hugr, T2Circuit};
+use crate::circuit::{tket1_to_hugr, T2Circuit};
 
 use hugr::Hugr;
 use pyo3::prelude::*;
@@ -46,8 +46,8 @@ pub struct Rule(pub [Hugr; 2]);
 impl Rule {
     #[new]
     fn new_rule(l: PyObject, r: PyObject) -> PyResult<Rule> {
-        let l = to_hugr(l)?;
-        let r = to_hugr(r)?;
+        let l = tket1_to_hugr(l)?;
+        let r = tket1_to_hugr(r)?;
 
         Ok(Rule([l.hugr, r.hugr]))
     }

--- a/tket2-py/src/pattern.rs
+++ b/tket2-py/src/pattern.rs
@@ -3,7 +3,7 @@
 pub mod portmatching;
 pub mod rewrite;
 
-use crate::circuit::{tket1_to_tket2, T2Circuit};
+use crate::circuit::Tk2Circuit;
 
 use hugr::Hugr;
 use pyo3::prelude::*;
@@ -46,8 +46,8 @@ pub struct Rule(pub [Hugr; 2]);
 impl Rule {
     #[new]
     fn new_rule(l: &PyAny, r: &PyAny) -> PyResult<Rule> {
-        let l = tket1_to_tket2(l)?;
-        let r = tket1_to_tket2(r)?;
+        let l = Tk2Circuit::from_tket1(l)?;
+        let r = Tk2Circuit::from_tket1(r)?;
 
         Ok(Rule([l.hugr, r.hugr]))
     }
@@ -71,7 +71,7 @@ impl RuleMatcher {
         Ok(Self { matcher, rights })
     }
 
-    pub fn find_match(&self, target: &T2Circuit) -> PyResult<Option<PyCircuitRewrite>> {
+    pub fn find_match(&self, target: &Tk2Circuit) -> PyResult<Option<PyCircuitRewrite>> {
         let h = &target.hugr;
         if let Some(p_match) = self.matcher.find_matches_iter(h).next() {
             let r = self.rights.get(p_match.pattern_id().0).unwrap().clone();

--- a/tket2-py/src/pattern.rs
+++ b/tket2-py/src/pattern.rs
@@ -3,7 +3,7 @@
 pub mod portmatching;
 pub mod rewrite;
 
-use crate::circuit::{tket1_to_hugr, T2Circuit};
+use crate::circuit::{tket1_to_tket2, T2Circuit};
 
 use hugr::Hugr;
 use pyo3::prelude::*;
@@ -45,9 +45,9 @@ pub struct Rule(pub [Hugr; 2]);
 #[pymethods]
 impl Rule {
     #[new]
-    fn new_rule(l: PyObject, r: PyObject) -> PyResult<Rule> {
-        let l = tket1_to_hugr(l)?;
-        let r = tket1_to_hugr(r)?;
+    fn new_rule(l: &PyAny, r: &PyAny) -> PyResult<Rule> {
+        let l = tket1_to_tket2(l)?;
+        let r = tket1_to_tket2(r)?;
 
         Ok(Rule([l.hugr, r.hugr]))
     }

--- a/tket2-py/src/pattern/portmatching.rs
+++ b/tket2-py/src/pattern/portmatching.rs
@@ -29,8 +29,8 @@ pub struct PyCircuitPattern {
 impl PyCircuitPattern {
     /// Construct a pattern from a TKET1 circuit
     #[new]
-    pub fn from_circuit(circ: Py<PyAny>) -> PyResult<Self> {
-        let pattern = try_with_hugr(circ, |circ| CircuitPattern::try_from_circuit(&circ))?;
+    pub fn from_circuit(circ: &PyAny) -> PyResult<Self> {
+        let pattern = try_with_hugr(circ, |circ, _| CircuitPattern::try_from_circuit(&circ))?;
         Ok(pattern.into())
     }
 
@@ -79,8 +79,8 @@ impl PyPatternMatcher {
     }
 
     /// Find all convex matches in a circuit.
-    pub fn find_matches(&self, circ: PyObject) -> PyResult<Vec<PyPatternMatch>> {
-        with_hugr(circ, |circ| {
+    pub fn find_matches(&self, circ: &PyAny) -> PyResult<Vec<PyPatternMatch>> {
+        with_hugr(circ, |circ, _| {
             self.matcher
                 .find_matches(&circ)
                 .into_iter()

--- a/tket2-py/test/test_bindings.py
+++ b/tket2-py/test/test_bindings.py
@@ -3,7 +3,7 @@ from pytket.circuit import Circuit
 
 from tket2 import passes
 from tket2.passes import greedy_depth_reduce
-from tket2.circuit import T2Circuit, to_hugr_dot, tket1_to_tket2, tket2_to_tket1
+from tket2.circuit import Tk2Circuit, to_hugr_dot
 from tket2.pattern import Rule, RuleMatcher
 
 
@@ -11,13 +11,13 @@ def test_conversion():
     tk1 = Circuit(4).CX(0, 2).CX(1, 2).CX(1, 3)
     tk1_dot = to_hugr_dot(tk1)
 
-    tk2 = tket1_to_tket2(tk1)
+    tk2 = Tk2Circuit(tk1)
     tk2_dot = to_hugr_dot(tk2)
 
-    assert type(tk2) == T2Circuit
+    assert type(tk2) == Tk2Circuit
     assert tk1_dot == tk2_dot
 
-    tk1_back = tket2_to_tket1(tk2)
+    tk1_back = tk2.to_tket1()
 
     assert tk1_back == tk1
     assert type(tk1_back) == Circuit
@@ -54,14 +54,14 @@ def test_chunks():
     assert type(c2) == Circuit
 
     # Split and reassemble, with a tket2 circuit
-    tk2_chunks = passes.chunks(T2Circuit(c2), 2)
+    tk2_chunks = passes.chunks(Tk2Circuit(c2), 2)
     tk2 = tk2_chunks.reassemble()
 
-    assert type(tk2) == T2Circuit
+    assert type(tk2) == Tk2Circuit
 
 
 def test_cx_rule():
-    c = T2Circuit(Circuit(4).CX(0, 2).CX(1, 2).CX(1, 2))
+    c = Tk2Circuit(Circuit(4).CX(0, 2).CX(1, 2).CX(1, 2))
 
     rule = Rule(Circuit(2).CX(0, 1).CX(0, 1), Circuit(2))
     matcher = RuleMatcher([rule])
@@ -70,13 +70,13 @@ def test_cx_rule():
 
     c.apply_match(mtch)
 
-    out = c.finish()
+    out = c.to_tket1()
 
     assert out == Circuit(4).CX(0, 2)
 
 
 def test_multiple_rules():
-    circ = T2Circuit(Circuit(3).CX(0, 1).H(0).H(1).H(2).Z(0).H(0).H(1).H(2))
+    circ = Tk2Circuit(Circuit(3).CX(0, 1).H(0).H(1).H(2).Z(0).H(0).H(1).H(2))
 
     rule1 = Rule(Circuit(1).H(0).Z(0).H(0), Circuit(1).X(0))
     rule2 = Rule(Circuit(1).H(0).H(0), Circuit(1))
@@ -89,5 +89,5 @@ def test_multiple_rules():
 
     assert match_count == 3
 
-    out = circ.finish()
+    out = circ.to_tket1()
     assert out == Circuit(3).CX(0, 1).X(0)

--- a/tket2-py/test/test_bindings.py
+++ b/tket2-py/test/test_bindings.py
@@ -3,8 +3,24 @@ from pytket.circuit import Circuit
 
 from tket2 import passes
 from tket2.passes import greedy_depth_reduce
-from tket2.circuit import T2Circuit
+from tket2.circuit import T2Circuit, to_hugr_dot, tket1_to_tket2, tket2_to_tket1
 from tket2.pattern import Rule, RuleMatcher
+
+
+def test_conversion():
+    tk1 = Circuit(4).CX(0, 2).CX(1, 2).CX(1, 3)
+    tk1_dot = to_hugr_dot(tk1)
+
+    tk2 = tket1_to_tket2(tk1)
+    tk2_dot = to_hugr_dot(tk2)
+
+    assert type(tk2) == T2Circuit
+    assert tk1_dot == tk2_dot
+
+    tk1_back = tket2_to_tket1(tk2)
+
+    assert tk1_back == tk1
+    assert type(tk1_back) == Circuit
 
 
 @dataclass
@@ -35,6 +51,13 @@ def test_chunks():
     c2 = chunks.reassemble()
 
     assert c2.depth() == 3
+    assert type(c2) == Circuit
+
+    # Split and reassemble, with a tket2 circuit
+    tk2_chunks = passes.chunks(T2Circuit(c2), 2)
+    tk2 = tk2_chunks.reassemble()
+
+    assert type(tk2) == T2Circuit
 
 
 def test_cx_rule():


### PR DESCRIPTION
Adds a `tket1`/`tket2` to the `with_hugr` helpers, so we always know what format to output afterwards.

The more noisy part of this commit changing all the GIL-independent types to capturing references, so we don't have to manually lock multiple times per call.

Closes #178.