### PR TITLE
chore: update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ homepage = "https://github.com/CQCL/tket2"
 license-file = "LICENCE"
 # authors
 
+[workspace.lints.rust]
+missing_docs = "warn"
+
 [workspace.dependencies]
 
 tket2 = { path = "./tket2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tket2 = { path = "./tket2" }
 quantinuum-hugr = { git = "https://github.com/CQCL/hugr", rev = "e7473f2" }
 portgraph = { version = "0.10" }
 pyo3 = { version = "0.20" }
-itertools = { version = "0.11.0" }
+itertools = { version = "0.12.0" }
 tket-json-rs = { version = "0.3.0" }
 tracing = "0.1.37"
-portmatching = { git = "https://github.com/lmondada/portmatching", rev = "738c91c" }
+portmatching = { version = "0.3.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license-file = "LICENCE"
 [workspace.dependencies]
 
 tket2 = { path = "./tket2" }
-quantinuum-hugr = { git = "https://github.com/CQCL/hugr", rev = "c261bea" }
+quantinuum-hugr = { git = "https://github.com/CQCL/hugr", rev = "e7473f2" }
 portgraph = { version = "0.10" }
 pyo3 = { version = "0.20" }
 itertools = { version = "0.11.0" }

--- a/tket2-py/Cargo.toml
+++ b/tket2-py/Cargo.toml
@@ -6,7 +6,9 @@ rust-version = { workspace = true }
 homepage = { workspace = true }
 license-file = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
+
 [lib]
 name = "tket2"
 crate-type = ["cdylib"]

--- a/tket2-py/src/lib.rs
+++ b/tket2-py/src/lib.rs
@@ -1,6 +1,4 @@
 //! Python bindings for TKET2.
-#![warn(missing_docs)]
-
 pub mod circuit;
 pub mod optimiser;
 pub mod passes;

--- a/tket2/Cargo.toml
+++ b/tket2/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = { workspace = true }
 homepage = { workspace = true }
 license-file = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 bench = false
 name = "tket2"

--- a/tket2/benches/bench_main.rs
+++ b/tket2/benches/bench_main.rs
@@ -1,3 +1,5 @@
+//! Benchmarks for the tket2 crate.
+
 #[allow(dead_code)]
 mod benchmarks;
 

--- a/tket2/src/circuit/command.rs
+++ b/tket2/src/circuit/command.rs
@@ -130,14 +130,13 @@ impl<'circ, Circ: Circuit> Command<'circ, Circ> {
     /// Returns the number of inputs of this command.
     #[inline]
     pub fn input_count(&self) -> usize {
-        let optype = self.optype();
-        optype.signature().input_count() + optype.static_input().is_some() as usize
+        self.optype().value_input_count() + self.optype().static_input_port().is_some() as usize
     }
 
     /// Returns the number of outputs of this command.
     #[inline]
     pub fn output_count(&self) -> usize {
-        self.optype().signature().output_count()
+        self.optype().value_output_count() + self.optype().static_output_port().is_some() as usize
     }
 
     /// Returns the port in the command given a linear unit.

--- a/tket2/src/extension.rs
+++ b/tket2/src/extension.rs
@@ -11,7 +11,6 @@ use hugr::extension::prelude::PRELUDE;
 use hugr::extension::{ExtensionId, ExtensionRegistry, SignatureError};
 use hugr::hugr::IdentList;
 use hugr::ops::custom::{ExternalOp, OpaqueOp};
-use hugr::ops::OpName;
 use hugr::std_extensions::arithmetic::float_types::{extension as float_extension, FLOAT64_TYPE};
 use hugr::types::type_param::{CustomTypeArg, TypeArg, TypeParam};
 use hugr::types::{CustomType, FunctionType, Type, TypeBound};

--- a/tket2/src/extension/angle.rs
+++ b/tket2/src/extension/angle.rs
@@ -166,7 +166,7 @@ fn abinop_sig(arg_values: &[TypeArg]) -> Result<FunctionType, SignatureError> {
 
 fn aunop_sig(extension: &Extension) -> Result<FunctionType, SignatureError> {
     let angle = type_var(0, extension)?;
-    Ok(FunctionType::new_linear(vec![angle]))
+    Ok(FunctionType::new_endo(vec![angle]))
 }
 
 fn angle_def(extension: &Extension) -> &TypeDef {

--- a/tket2/src/json/decoder.rs
+++ b/tket2/src/json/decoder.rs
@@ -64,7 +64,7 @@ impl JsonDecoder {
             }
             wire_map.insert((register, 0).into(), i);
         }
-        let sig = FunctionType::new_linear(
+        let sig = FunctionType::new_endo(
             [vec![QB_T; num_qubits], vec![LINEAR_BIT.clone(); num_bits]].concat(),
         );
         // .with_extension_delta(&ExtensionSet::singleton(&TKET1_EXTENSION_ID));

--- a/tket2/src/json/op.rs
+++ b/tket2/src/json/op.rs
@@ -245,13 +245,15 @@ impl TryFrom<&OpType> for JsonOp {
         let mut num_qubits = 0;
         let mut num_bits = 0;
         let mut num_params = 0;
-        for ty in op.signature().input.iter() {
-            if ty == &QB_T {
-                num_qubits += 1
-            } else if *ty == *LINEAR_BIT {
-                num_bits += 1
-            } else if ty == &FLOAT64_TYPE {
-                num_params += 1
+        if let Some(sig) = op.dataflow_signature() {
+            for ty in sig.input.iter() {
+                if ty == &QB_T {
+                    num_qubits += 1
+                } else if *ty == *LINEAR_BIT {
+                    num_bits += 1
+                } else if ty == &FLOAT64_TYPE {
+                    num_params += 1
+                }
             }
         }
 

--- a/tket2/src/lib.rs
+++ b/tket2/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 //! TKET2: The Hardware Agnostic Quantum Compiler
 //!
 //! TKET2 is an open source quantum compiler developed by Quantinuum. Central to

--- a/tket2/src/portmatching.rs
+++ b/tket2/src/portmatching.rs
@@ -78,9 +78,9 @@ impl PEdge {
             return Ok(Self::InputEdge { src });
         }
         let port_type = circ
-            .get_optype(node)
-            .signature()
-            .get(src)
+            .signature(node)
+            .unwrap()
+            .port_type(src)
             .cloned()
             .ok_or(InvalidEdgeProperty::UntypedPort(src))?;
         let is_reversible = type_is_linear(&port_type);

--- a/tket2/src/portmatching/pattern.rs
+++ b/tket2/src/portmatching/pattern.rs
@@ -1,7 +1,7 @@
 //! Circuit Patterns for pattern matching
 
 use hugr::IncomingPort;
-use hugr::{ops::OpTrait, Node, Port};
+use hugr::{Node, Port};
 use itertools::Itertools;
 use portmatching::{patterns::NoRootFound, HashMap, Pattern, SinglePatternMatcher};
 use std::fmt::Debug;
@@ -62,8 +62,8 @@ impl CircuitPattern {
             return Err(InvalidPattern::NotConnected);
         }
         let (inp, out) = (circuit.input(), circuit.output());
-        let inp_ports = circuit.get_optype(inp).signature().output_ports();
-        let out_ports = circuit.get_optype(out).signature().input_ports();
+        let inp_ports = circuit.signature(inp).unwrap().output_ports();
+        let out_ports = circuit.signature(out).unwrap().input_ports();
         let inputs = inp_ports
             .map(|p| circuit.linked_ports(inp, p).collect())
             .collect_vec();

--- a/tket2/src/rewrite/ecc_rewriter.rs
+++ b/tket2/src/rewrite/ecc_rewriter.rs
@@ -13,7 +13,6 @@
 //! of the Quartz repository.
 
 use derive_more::{From, Into};
-use hugr::ops::OpTrait;
 use hugr::PortIndex;
 use itertools::Itertools;
 use portmatching::PatternID;
@@ -247,12 +246,13 @@ fn get_patterns(rep_sets: &[EqCircClass]) -> Vec<Option<(CircuitPattern, Vec<usi
 
 /// The port offsets of wires that are empty.
 fn empty_wires(circ: &impl Circuit) -> Vec<usize> {
-    let inp = circ.input();
-    circ.node_outputs(inp)
+    let input = circ.input();
+    let input_sig = circ.signature(input).unwrap();
+    circ.node_outputs(input)
         // Only consider dataflow edges
-        .filter(|&p| circ.get_optype(inp).signature().get(p).is_some())
+        .filter(|&p| input_sig.out_port_type(p).is_some())
         // Only consider ports linked to at most one other port
-        .filter_map(|p| Some((p, circ.linked_ports(inp, p).at_most_one().ok()?)))
+        .filter_map(|p| Some((p, circ.linked_ports(input, p).at_most_one().ok()?)))
         // Ports are either connected to output or nothing
         .filter_map(|(from, to)| {
             if let Some((n, _)) = to {


### PR DESCRIPTION
- Updates the API changes introduced in https://github.com/CQCL/hugr/pull/680
- Uses the latest published portmatching instead of a git dependency
- Moves the lint configuration to the workspace Cargo.toml (new to rust [1.74](https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html))
  This throws warnings in older rust versions due to the unrecognised fields, but works alright.