### PR TITLE
fix: Check for rewrite composition in badger

### DIFF
--- a/tket2/src/optimiser/badger/hugr_pqueue.rs
+++ b/tket2/src/optimiser/badger/hugr_pqueue.rs
@@ -53,7 +53,7 @@ impl<P: Ord, C> HugrPQ<P, C> {
     where
         C: Fn(&Hugr) -> P,
     {
-        let hash = hugr.circuit_hash();
+        let hash = hugr.circuit_hash().unwrap();
         let cost = (self.cost_fn)(&hugr);
         self.push_unchecked(hugr, hash, cost);
     }

--- a/tket2/src/optimiser/badger/worker.rs
+++ b/tket2/src/optimiser/badger/worker.rs
@@ -73,7 +73,13 @@ where
                         return None;
                     }
 
-                    let hash = c.circuit_hash();
+                    let Ok(hash) = c.circuit_hash() else {
+                        // The composed rewrites were not valid.
+                        //
+                        // See [https://github.com/CQCL/tket2/discussions/242]
+                        return None;
+                    };
+
                     Some(Work {
                         cost: new_cost,
                         hash,


### PR DESCRIPTION
This is a short-term quick-but-incomplete fix for #239.

We now check right after the composition whether we have invalidated the circuit by making a loop.
We leverage that circuit hashing already does a toposort traversal, adding an error when a loop is found and catching it.

Still, it is theoretically possible for an invalid chain of rewrites to end up producing a valid (but not equivalent) circuit. There is a discussion open for discussing more general solutions to this problem #242.