### PR TITLE
feat: Implement `PyErr` conversion locally in `tket2-py`

### DIFF
--- a/tket2-py/Cargo.toml
+++ b/tket2-py/Cargo.toml
@@ -18,8 +18,8 @@ tket2 = { workspace = true, features = ["pyo3", "portmatching"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tket-json-rs = { workspace = true, features = ["pyo3"] }
-quantinuum-hugr = { workspace = true, features = ["pyo3"] }
-portgraph = { workspace = true, features = ["pyo3", "serde"] }
+quantinuum-hugr = { workspace = true }
+portgraph = { workspace = true, features = ["serde"] }
 pyo3 = { workspace = true, features = ["extension-module"] }
 num_cpus = "1.16.0"
 derive_more = "0.99.17"

--- a/tket2-py/src/circuit.rs
+++ b/tket2-py/src/circuit.rs
@@ -14,6 +14,8 @@ use tket2::json::TKETDecode;
 use tket2::rewrite::CircuitRewrite;
 use tket_json_rs::circuit_json::SerialCircuit;
 
+use crate::utils::create_py_exception;
+
 pub use self::convert::{try_update_hugr, try_with_hugr, update_hugr, with_hugr, Tk2Circuit};
 pub use self::cost::PyCircuitCost;
 pub use tket2::{Pauli, Tk2Op};
@@ -30,23 +32,47 @@ pub fn module(py: Python) -> PyResult<&PyModule> {
     m.add_function(wrap_pyfunction!(validate_hugr, m)?)?;
     m.add_function(wrap_pyfunction!(to_hugr_dot, m)?)?;
 
-    m.add("HugrError", py.get_type::<hugr::hugr::PyHugrError>())?;
-    m.add("BuildError", py.get_type::<hugr::builder::PyBuildError>())?;
-    m.add(
-        "ValidationError",
-        py.get_type::<hugr::hugr::validate::PyValidationError>(),
-    )?;
+    m.add("HugrError", py.get_type::<PyHugrError>())?;
+    m.add("BuildError", py.get_type::<PyBuildError>())?;
+    m.add("ValidationError", py.get_type::<PyValidationError>())?;
     m.add(
         "HUGRSerializationError",
-        py.get_type::<hugr::hugr::serialize::PyHUGRSerializationError>(),
+        py.get_type::<PyHUGRSerializationError>(),
     )?;
-    m.add(
-        "OpConvertError",
-        py.get_type::<tket2::json::PyOpConvertError>(),
-    )?;
+    m.add("OpConvertError", py.get_type::<PyOpConvertError>())?;
 
     Ok(m)
 }
+
+create_py_exception!(
+    hugr::hugr::HugrError,
+    PyHugrError,
+    "Errors that can occur while manipulating a HUGR."
+);
+
+create_py_exception!(
+    hugr::builder::BuildError,
+    PyBuildError,
+    "Error while building the HUGR."
+);
+
+create_py_exception!(
+    hugr::hugr::validate::ValidationError,
+    PyValidationError,
+    "Errors that can occur while validating a Hugr."
+);
+
+create_py_exception!(
+    hugr::hugr::serialize::HUGRSerializationError,
+    PyHUGRSerializationError,
+    "Errors that can occur while serializing a HUGR."
+);
+
+create_py_exception!(
+    tket2::json::OpConvertError,
+    PyOpConvertError,
+    "Error type for conversion between `Op` and `OpType`."
+);
 
 /// Run the validation checks on a circuit.
 #[pyfunction]

--- a/tket2-py/src/circuit.rs
+++ b/tket2-py/src/circuit.rs
@@ -71,7 +71,7 @@ create_py_exception!(
 create_py_exception!(
     tket2::json::OpConvertError,
     PyOpConvertError,
-    "Error type for conversion between `Op` and `OpType`."
+    "Error type for the conversion between tket2 and tket1 operations."
 );
 
 /// Run the validation checks on a circuit.

--- a/tket2-py/src/lib.rs
+++ b/tket2-py/src/lib.rs
@@ -4,6 +4,7 @@ pub mod optimiser;
 pub mod passes;
 pub mod pattern;
 pub mod rewrite;
+pub mod utils;
 
 use pyo3::prelude::*;
 

--- a/tket2-py/src/passes/chunks.rs
+++ b/tket2-py/src/passes/chunks.rs
@@ -8,6 +8,7 @@ use tket2::Circuit;
 
 use crate::circuit::convert::CircuitType;
 use crate::circuit::{try_with_hugr, with_hugr};
+use crate::utils::ConvertPyErr;
 
 /// Split a circuit into chunks of a given size.
 #[pyfunction]
@@ -38,7 +39,7 @@ pub struct PyCircuitChunks {
 impl PyCircuitChunks {
     /// Reassemble the chunks into a circuit.
     fn reassemble<'py>(&self, py: Python<'py>) -> PyResult<&'py PyAny> {
-        let hugr = self.clone().chunks.reassemble()?;
+        let hugr = self.clone().chunks.reassemble().convert_pyerrs()?;
         self.original_type.convert(py, hugr)
     }
 

--- a/tket2-py/src/utils.rs
+++ b/tket2-py/src/utils.rs
@@ -1,0 +1,47 @@
+//! Utility functions for the python interface.
+
+/// A trait for types wrapping rust errors that may be converted into python exception.
+///
+/// In addition to raw errors, this is implemented for wrapper types such as `Result`.
+/// [`ConvertPyErr::convert_errors`] will be called on the internal error type.
+pub trait ConvertPyErr {
+    /// The output type after conversion.
+    type Output;
+
+    /// Convert any internal errors to python errors.
+    fn convert_pyerrs(self) -> Self::Output;
+}
+
+impl ConvertPyErr for pyo3::PyErr {
+    type Output = Self;
+
+    fn convert_pyerrs(self) -> Self::Output {
+        self
+    }
+}
+
+impl<T, E> ConvertPyErr for Result<T, E>
+where
+    E: ConvertPyErr,
+{
+    type Output = Result<T, E::Output>;
+
+    fn convert_pyerrs(self) -> Self::Output {
+        self.map_err(|e| e.convert_pyerrs())
+    }
+}
+
+macro_rules! create_py_exception {
+    ($err:path, $py_err:ident, $doc:expr) => {
+        pyo3::create_exception!(tket2, $py_err, pyo3::exceptions::PyException, $doc);
+
+        impl $crate::utils::ConvertPyErr for $err {
+            type Output = pyo3::PyErr;
+
+            fn convert_pyerrs(self) -> Self::Output {
+                $py_err::new_err(<Self as std::string::ToString>::to_string(&self))
+            }
+        }
+    };
+}
+pub(crate) use create_py_exception;

--- a/tket2/src/json.rs
+++ b/tket2/src/json.rs
@@ -8,8 +8,6 @@ pub mod op;
 mod tests;
 
 use hugr::CircuitUnit;
-#[cfg(feature = "pyo3")]
-use pyo3::{create_exception, exceptions::PyException, PyErr};
 
 use std::path::Path;
 use std::{fs, io};
@@ -102,21 +100,6 @@ pub enum OpConvertError {
     /// The serialized operation is not supported.
     #[error("Cannot serialize operation: {0:?}")]
     NonSerializableInputs(OpType),
-}
-
-#[cfg(feature = "pyo3")]
-create_exception!(
-    tket2,
-    PyOpConvertError,
-    PyException,
-    "Error type for conversion between tket2's `Op` and `OpType`"
-);
-
-#[cfg(feature = "pyo3")]
-impl From<OpConvertError> for PyErr {
-    fn from(err: OpConvertError) -> Self {
-        PyOpConvertError::new_err(err.to_string())
-    }
 }
 
 /// Load a TKET1 circuit from a JSON file.

--- a/tket2/src/passes.rs
+++ b/tket2/src/passes.rs
@@ -1,9 +1,7 @@
 //! Optimisation passes and related utilities for circuits.
 
 mod commutation;
-pub use commutation::apply_greedy_commutation;
-#[cfg(feature = "pyo3")]
-pub use commutation::PyPullForwardError;
+pub use commutation::{apply_greedy_commutation, PullForwardError};
 
 pub mod chunks;
 pub use chunks::CircuitChunks;

--- a/tket2/src/passes/commutation.rs
+++ b/tket2/src/passes/commutation.rs
@@ -5,9 +5,6 @@ use hugr::{CircuitUnit, Direction, Hugr, HugrView, Node, Port, PortIndex};
 use itertools::Itertools;
 use portgraph::PortOffset;
 
-#[cfg(feature = "pyo3")]
-use pyo3::{create_exception, exceptions::PyException, PyErr};
-
 use crate::{
     circuit::{command::Command, units::filter::Qubits, Circuit},
     ops::{Pauli, Tk2Op},
@@ -202,20 +199,6 @@ pub enum PullForwardError {
     NoCommandForQb(usize),
 }
 
-#[cfg(feature = "pyo3")]
-create_exception!(
-    tket2,
-    PyPullForwardError,
-    PyException,
-    "Error in applying PullForward rewrite."
-);
-
-#[cfg(feature = "pyo3")]
-impl From<PullForwardError> for PyErr {
-    fn from(err: PullForwardError) -> Self {
-        PyPullForwardError::new_err(err.to_string())
-    }
-}
 struct PullForward {
     command: Rc<ComCommand>,
     new_nexts: HashMap<Qb, Rc<ComCommand>>,

--- a/tket2/src/passes/commutation.rs
+++ b/tket2/src/passes/commutation.rs
@@ -184,7 +184,7 @@ fn commutation_on_port(comms: &[(usize, Pauli)], port: Port) -> Option<Pauli> {
         .find_map(|(i, p)| (*i == port.index()).then_some(*p))
 }
 
-/// Error from a [`PullForward`] operation.
+/// Error from a `PullForward` operation.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub enum PullForwardError {

--- a/tket2/src/portmatching/pattern.rs
+++ b/tket2/src/portmatching/pattern.rs
@@ -13,9 +13,6 @@ use super::{
 };
 use crate::{circuit::Circuit, portmatching::NodeID};
 
-#[cfg(feature = "pyo3")]
-use pyo3::{create_exception, exceptions::PyException, PyErr};
-
 /// A pattern that match a circuit exactly
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct CircuitPattern {
@@ -133,21 +130,6 @@ pub enum InvalidPattern {
 impl From<NoRootFound> for InvalidPattern {
     fn from(_: NoRootFound) -> Self {
         InvalidPattern::NotConnected
-    }
-}
-
-#[cfg(feature = "pyo3")]
-create_exception!(
-    tket2,
-    PyInvalidPatternError,
-    PyException,
-    "Invalid circuit pattern"
-);
-
-#[cfg(feature = "pyo3")]
-impl From<InvalidPattern> for PyErr {
-    fn from(err: InvalidPattern) -> Self {
-        PyInvalidPatternError::new_err(err.to_string())
     }
 }
 


### PR DESCRIPTION
With this we can drop the `pyo3` features in hugr and portgraph.
`tket2` and `tket-json-rs` still require it, as they define some non-error pyclasses.

This requires manually converting errors by calling `convert_pyerrs` before `?`, but it is a small price to pay for not dealing with pyo3 versions across crates.