### PR TITLE
ci: Add workflow to build and upload Python wheels

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,0 +1,56 @@
+on:
+  push:
+    tags:
+      - "v*"
+    branches:
+      - main
+
+name: Create Python wheel and push to internal repo
+
+jobs:
+  build-upload-hosted-wheels:
+    name: Build and upload wheels for hosted Github OSes
+    strategy:
+      matrix:
+        os: ['ubuntu-22.06']
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Rust stable toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install cargo-edit (to update version number)
+      run: cargo install cargo-edit
+
+    - name: Cache poetry
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-${{ matrix.python-version }}-poetry-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+
+    - name: Set up Poetry
+      run: |
+        pip install poetry
+        poetry run pip install --upgrade pip
+        poetry install
+
+    - name: Update Cargo version based on tags
+      run: cargo set-version $(dunamai from any --style semver --bump)
+
+    - name: Build Python wheel for ${{ matrix.os }}
+      run: poetry run maturin build
+
+    - name: Upload Python wheel for ${{ matrix.os }}
+      run: poetry run maturin upload --repository-url "https://cqcpythonrepository.azurewebsites.net/"
+      env:
+        MATURIN_USERNAME: ${{ secrets.??? }}
+        MATURIN_PASSWORD: ${{ secrets.??? }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 packages = [{ include = "tket2-py" }]
 
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.10,<4.0"
 
 [tool.poetry.dev-dependencies]
 maturin = "^1.3.0"
@@ -20,6 +20,7 @@ pytket = "*"
 pytest = "^7.1.2"
 pytest-cov = "^4.1.0"
 ruff = "^0.1.3"
+dunamai = "^1.19.0"
 
 [build-system]
 requires = ["maturin~=1.3"]


### PR DESCRIPTION
Changes:
* New workflow runs when a tag is created, and when there's a push to main.
* Workflow builds Python wheels using maturin, and uses dunamai to make sure that wheels for non-tag pushes have sensible versions (with 'dev' in them as appropriate).
* Workflow also uploads the wheels to our private Python repo.

Still to do:
* Sort out the credentials for the uploads.