### PR TITLE
chore: update hugr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ missing_docs = "warn"
 [workspace.dependencies]
 
 tket2 = { path = "./tket2" }
-quantinuum-hugr = { git = "https://github.com/CQCL/hugr", rev = "0edee65" }
+quantinuum-hugr = { git = "https://github.com/CQCL/hugr", rev = "25d03aa" }
 portgraph = { version = "0.11" }
 pyo3 = { version = "0.20" }
 itertools = { version = "0.12.0" }

--- a/tket2/src/circuit/units.rs
+++ b/tket2/src/circuit/units.rs
@@ -140,13 +140,9 @@ where
             Direction::Outgoing => sig.output,
             Direction::Incoming => sig.input,
         };
-        if direction == Direction::Incoming {
-            if let Some(static_port) = optype.static_input_port() {
-                if let Some(EdgeKind::Static(static_type)) = optype.port_kind(static_port) {
-                    types.to_mut().push(static_type);
-                }
-            }
-        }
+        if let Some(EdgeKind::Static(static_type)) = optype.static_port_kind(direction) {
+            types.to_mut().push(static_type);
+        };
         if let Some(EdgeKind::Static(other)) = optype.other_port_kind(direction) {
             types.to_mut().push(other);
         }

--- a/tket2/src/json/tests.rs
+++ b/tket2/src/json/tests.rs
@@ -109,8 +109,8 @@ fn circ_add_angles_constants() -> Hugr {
 
     let qb = h.input_wires().next().unwrap();
 
-    let point2 = h.add_load_const(ConstF64::new(0.2).into()).unwrap();
-    let point3 = h.add_load_const(ConstF64::new(0.3).into()).unwrap();
+    let point2 = h.add_load_const(ConstF64::new(0.2)).unwrap();
+    let point3 = h.add_load_const(ConstF64::new(0.3)).unwrap();
     let point5 = h
         .add_dataflow_op(Tk2Op::AngleAdd, [point2, point3])
         .unwrap()


### PR DESCRIPTION
Uses the new static port methods in OpType

Adds a test to ensure we're correctly using the ports methods in the Commands iterator.
(the update broke the circuits iterator)