### PR TITLE
feat: Use `IncomingPort` and `OutgoingPort` instead of `Port` where possible.

### DIFF
--- a/tket2/src/circuit/command.rs
+++ b/tket2/src/circuit/command.rs
@@ -8,10 +8,10 @@ use std::iter::FusedIterator;
 
 use hugr::hugr::NodeType;
 use hugr::ops::{OpTag, OpTrait};
-use itertools::Either::{Left, Right};
+use hugr::{IncomingPort, OutgoingPort};
+use itertools::Either::{self, Left, Right};
 use petgraph::visit as pv;
 
-use super::units::filter::FilteredUnits;
 use super::units::{filter, DefaultUnitLabeller, LinearUnit, UnitLabeller, Units};
 use super::Circuit;
 
@@ -53,78 +53,84 @@ impl<'circ, Circ: Circuit> Command<'circ, Circ> {
 
     /// Returns the units of this command in a given direction.
     #[inline]
-    pub fn units(&self, direction: Direction) -> Units<&'_ Self> {
-        Units::new(self.circ, self.node, direction, self)
-    }
-
-    /// Returns the linear units of this command in a given direction.
-    #[inline]
-    pub fn linear_units(&self, direction: Direction) -> FilteredUnits<filter::Linear, &Self> {
-        Units::new(self.circ, self.node, direction, self).filter_units::<filter::Linear>()
-    }
-
-    /// Returns the linear units of this command in a given direction.
-    #[inline]
-    pub fn qubits(&self, direction: Direction) -> FilteredUnits<filter::Qubits, &Self> {
-        Units::new(self.circ, self.node, direction, self).filter_units::<filter::Qubits>()
-    }
-
-    /// Returns the linear units of this command in a given direction.
-    #[inline]
-    pub fn input_qubits(&self) -> FilteredUnits<filter::Qubits, &Self> {
-        self.qubits(Direction::Incoming)
-    }
-
-    /// Returns the linear units of this command in a given direction.
-    #[inline]
-    pub fn output_qubits(&self) -> FilteredUnits<filter::Qubits, &Self> {
-        self.qubits(Direction::Outgoing)
-    }
-
-    /// Returns the units and wires of this command in a given direction.
-    #[inline]
-    pub fn unit_wires(
+    pub fn units(
         &self,
         direction: Direction,
-    ) -> impl IntoIterator<Item = (CircuitUnit, Wire)> + '_ {
-        self.units(direction)
-            .filter_map(move |(unit, port, _)| Some((unit, self.assign_wire(self.node, port)?)))
+    ) -> impl Iterator<Item = (CircuitUnit, Port, Type)> + '_ {
+        match direction {
+            Direction::Incoming => Either::Left(self.inputs().map(|(u, p, t)| (u, p.into(), t))),
+            Direction::Outgoing => Either::Right(self.outputs().map(|(u, p, t)| (u, p.into(), t))),
+        }
+    }
+
+    /// Returns the linear units of this command in a given direction.
+    #[inline]
+    pub fn linear_units(
+        &self,
+        direction: Direction,
+    ) -> impl Iterator<Item = (LinearUnit, Port, Type)> + '_ {
+        match direction {
+            Direction::Incoming => {
+                Either::Left(self.linear_inputs().map(|(u, p, t)| (u, p.into(), t)))
+            }
+            Direction::Outgoing => {
+                Either::Right(self.linear_outputs().map(|(u, p, t)| (u, p.into(), t)))
+            }
+        }
+    }
+
+    /// Returns the linear units of this command in a given direction.
+    #[inline]
+    pub fn input_qubits(&self) -> impl Iterator<Item = (LinearUnit, IncomingPort, Type)> + '_ {
+        self.inputs().filter_map(filter::filter_qubit)
+    }
+
+    /// Returns the linear units of this command in a given direction.
+    #[inline]
+    pub fn output_qubits(&self) -> impl Iterator<Item = (LinearUnit, OutgoingPort, Type)> + '_ {
+        self.outputs().filter_map(filter::filter_qubit)
     }
 
     /// Returns the output units of this command. See [`Command::units`].
     #[inline]
-    pub fn outputs(&self) -> Units<&'_ Self> {
-        self.units(Direction::Outgoing)
+    pub fn outputs(&self) -> Units<OutgoingPort, &'_ Self> {
+        Units::new(self.circ, self.node, self)
     }
 
     /// Returns the linear output units of this command. See [`Command::linear_units`].
     #[inline]
-    pub fn linear_outputs(&self) -> FilteredUnits<filter::Linear, &Self> {
-        self.linear_units(Direction::Outgoing)
+    pub fn linear_outputs(&self) -> impl Iterator<Item = (LinearUnit, OutgoingPort, Type)> + '_ {
+        self.outputs().filter_map(filter::filter_linear)
     }
 
-    /// Returns the output units and wires of this command. See [`Command::unit_wires`].
+    /// Returns the output units and wires of this command.
     #[inline]
-    pub fn output_wires(&self) -> impl IntoIterator<Item = (CircuitUnit, Wire)> + '_ {
-        self.unit_wires(Direction::Outgoing)
+    pub fn output_wires(&self) -> impl Iterator<Item = (CircuitUnit, Wire)> + '_ {
+        self.outputs().filter_map(move |(unit, port, _typ)| {
+            let w = self.assign_wire(self.node, port.into())?;
+            Some((unit, w))
+        })
     }
 
     /// Returns the output units of this command.
     #[inline]
-    pub fn inputs(&self) -> Units<&'_ Self> {
-        self.units(Direction::Incoming)
+    pub fn inputs(&self) -> Units<IncomingPort, &'_ Self> {
+        Units::new_reversed(self.circ, self.node, self)
     }
 
     /// Returns the linear input units of this command. See [`Command::linear_units`].
     #[inline]
-    pub fn linear_inputs(&self) -> FilteredUnits<filter::Linear, &Self> {
-        self.linear_units(Direction::Incoming)
+    pub fn linear_inputs(&self) -> impl Iterator<Item = (LinearUnit, IncomingPort, Type)> + '_ {
+        self.inputs().filter_map(filter::filter_linear)
     }
 
-    /// Returns the input units and wires of this command. See [`Command::unit_wires`].
+    /// Returns the input units and wires of this command.
     #[inline]
     pub fn input_wires(&self) -> impl IntoIterator<Item = (CircuitUnit, Wire)> + '_ {
-        self.unit_wires(Direction::Incoming)
+        self.outputs().filter_map(move |(unit, port, _typ)| {
+            let w = self.assign_wire(self.node, port.into())?;
+            Some((unit, w))
+        })
     }
 
     /// Returns the number of inputs of this command.
@@ -274,10 +280,7 @@ where
         // TODO: `with_wires` combinator for `Units`?
         let wire_unit = circ
             .linear_units()
-            .map(|(linear_unit, port, _)| {
-                let port = port.as_outgoing().unwrap();
-                (Wire::new(circ.input(), port), linear_unit.index())
-            })
+            .map(|(linear_unit, port, _)| (Wire::new(circ.input(), port), linear_unit.index()))
             .collect();
 
         let nodes = pv::Topo::new(&circ.as_petgraph());
@@ -374,32 +377,30 @@ where
         // required to construct a `Command`.
         //
         // Updates the map tracking the last wire of linear units.
-        let linear_units: Vec<_> =
-            Units::new(self.circ, node, Direction::Outgoing, DefaultUnitLabeller)
-                .filter_units::<filter::Linear>()
-                .map(|(_, port, _)| {
-                    // Find the linear unit id for this port.
-                    let linear_id = self
-                        .follow_linear_port(node, port)
-                        .and_then(|input_port| {
-                            let input_port = input_port.as_incoming().unwrap();
-                            self.circ.linked_outputs(node, input_port).next()
-                        })
-                        .and_then(|(from, from_port)| {
-                            // Remove the old wire from the map (if there was one)
-                            self.wire_unit.remove(&Wire::new(from, from_port))
-                        })
-                        .unwrap_or({
-                            // New linear unit found. Assign it a new id.
-                            self.wire_unit.len()
-                        });
-                    // Update the map tracking the linear units
-                    let port = port.as_outgoing().unwrap();
-                    let new_wire = Wire::new(node, port);
-                    self.wire_unit.insert(new_wire, linear_id);
-                    LinearUnit::new(linear_id)
-                })
-                .collect();
+        let linear_units: Vec<_> = Units::new(self.circ, node, DefaultUnitLabeller)
+            .filter_map(filter::filter_linear)
+            .map(|(_, port, _)| {
+                // Find the linear unit id for this port.
+                let linear_id = self
+                    .follow_linear_port(node, port)
+                    .and_then(|input_port| {
+                        let input_port = input_port.as_incoming().unwrap();
+                        self.circ.linked_outputs(node, input_port).next()
+                    })
+                    .and_then(|(from, from_port)| {
+                        // Remove the old wire from the map (if there was one)
+                        self.wire_unit.remove(&Wire::new(from, from_port))
+                    })
+                    .unwrap_or({
+                        // New linear unit found. Assign it a new id.
+                        self.wire_unit.len()
+                    });
+                // Update the map tracking the linear units
+                let new_wire = Wire::new(node, port);
+                self.wire_unit.insert(new_wire, linear_id);
+                LinearUnit::new(linear_id)
+            })
+            .collect();
 
         Some(linear_units)
     }
@@ -410,7 +411,8 @@ where
     /// In the future we may want to have a more general mechanism to handle this.
     //
     // Note that `Command::linear_units` assumes this behaviour.
-    fn follow_linear_port(&self, node: Node, port: Port) -> Option<Port> {
+    fn follow_linear_port(&self, node: Node, port: impl Into<Port>) -> Option<Port> {
+        let port = port.into();
         let optype = self.circ.get_optype(node);
         if !optype.port_kind(port)?.is_linear() {
             return None;

--- a/tket2/src/circuit/units.rs
+++ b/tket2/src/circuit/units.rs
@@ -13,17 +13,15 @@
 //! [`Command`]: super::command::Command
 
 pub mod filter;
-pub use filter::FilteredUnits;
 
 use std::iter::FusedIterator;
+use std::marker::PhantomData;
 
 use hugr::types::{EdgeKind, Type, TypeRow};
-use hugr::CircuitUnit;
+use hugr::{CircuitUnit, IncomingPort, OutgoingPort};
 use hugr::{Direction, Node, Port, Wire};
 
 use crate::utils::type_is_linear;
-
-use self::filter::UnitFilter;
 
 use super::Circuit;
 
@@ -61,11 +59,9 @@ impl TryFrom<CircuitUnit> for LinearUnit {
 }
 /// An iterator over the units in the input or output boundary of a [Node].
 #[derive(Clone, Debug)]
-pub struct Units<UL = DefaultUnitLabeller> {
+pub struct Units<P, UL = DefaultUnitLabeller> {
     /// The node of the circuit.
     node: Node,
-    /// The direction of the boundary.
-    direction: Direction,
     /// The types of the boundary.
     types: TypeRow,
     /// The current index in the type row.
@@ -77,40 +73,57 @@ pub struct Units<UL = DefaultUnitLabeller> {
     ///
     /// The default type is `()`, which assigns new linear ids sequentially.
     unit_labeller: UL,
+    /// The type of port yield by the iterator.
+    _port: PhantomData<P>,
 }
 
-impl Units<DefaultUnitLabeller> {
+impl Units<OutgoingPort, DefaultUnitLabeller> {
     /// Create a new iterator over the input units of a circuit.
     ///
     /// This iterator will yield all units originating from the circuit's input
     /// node.
     #[inline]
     pub(super) fn new_circ_input(circuit: &impl Circuit) -> Self {
-        Self::new(
-            circuit,
-            circuit.input(),
-            Direction::Outgoing,
-            DefaultUnitLabeller,
-        )
+        Self::new(circuit, circuit.input(), DefaultUnitLabeller)
     }
 }
 
-impl<UL> Units<UL>
+impl<UL> Units<OutgoingPort, UL>
 where
     UL: UnitLabeller,
 {
-    /// Apply a [`UnitFilter`] to the iterator's output, possibly unwrapping the
-    /// [`CircuitUnit`] into either a linear unit or a wire.
-    pub fn filter_units<F: UnitFilter>(self) -> FilteredUnits<F, UL> {
-        self.filter_map(F::accept)
-    }
-
     /// Create a new iterator over the units of a node.
-    //
-    // Note that this ignores any incoming linear unit labels, and just assigns
-    // new unit ids sequentially.
+    ///
+    /// This iterator will yield all units originating from the given node,
+    /// and return the corresponding outgoing ports.
     #[inline]
-    pub(super) fn new(
+    pub(super) fn new(circuit: &impl Circuit, node: Node, unit_labeller: UL) -> Self {
+        Self::new_with_dir(circuit, node, Direction::Outgoing, unit_labeller)
+    }
+}
+
+impl<UL> Units<IncomingPort, UL>
+where
+    UL: UnitLabeller,
+{
+    /// Create a new reversed iterator over the units of a node.
+    ///
+    /// This iterator will yield all units reaching the given node,
+    /// and return the corresponding incoming ports.
+    #[inline]
+    pub(super) fn new_reversed(circuit: &impl Circuit, node: Node, unit_labeller: UL) -> Self {
+        Self::new_with_dir(circuit, node, Direction::Incoming, unit_labeller)
+    }
+}
+
+impl<P, UL> Units<P, UL>
+where
+    P: Into<Port> + Copy,
+    UL: UnitLabeller,
+{
+    /// Create a new iterator over the units of a node.
+    #[inline]
+    fn new_with_dir(
         circuit: &impl Circuit,
         node: Node,
         direction: Direction,
@@ -118,11 +131,11 @@ where
     ) -> Self {
         Self {
             node,
-            direction,
             types: Self::init_types(circuit, node, direction),
             pos: 0,
             linear_count: 0,
             unit_labeller,
+            _port: PhantomData,
         }
     }
 
@@ -154,31 +167,27 @@ where
     /// Calls [`UnitLabeller::assign_linear`] to assign a linear unit id to the linear ports.
     /// Non-linear ports are assigned [`CircuitUnit::Wire`]s via [`UnitLabeller::assign_wire`].
     #[inline]
-    fn make_value(&self, typ: &Type, port: Port) -> Option<(CircuitUnit, Port, Type)> {
+    fn make_value(&self, typ: &Type, port: P) -> Option<(CircuitUnit, P, Type)> {
         let unit = if type_is_linear(typ) {
             let linear_unit =
                 self.unit_labeller
-                    .assign_linear(self.node, port, self.linear_count - 1);
+                    .assign_linear(self.node, port.into(), self.linear_count - 1);
             CircuitUnit::Linear(linear_unit.index())
         } else {
-            let wire = self.unit_labeller.assign_wire(self.node, port)?;
+            let wire = self.unit_labeller.assign_wire(self.node, port.into())?;
             CircuitUnit::Wire(wire)
         };
         Some((unit, port, typ.clone()))
     }
-}
 
-impl<UL> Iterator for Units<UL>
-where
-    UL: UnitLabeller,
-{
-    type Item = (CircuitUnit, Port, Type);
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
+    /// Advances the iterator and returns the next value.
+    fn next_generic(&mut self) -> Option<(CircuitUnit, P, Type)>
+    where
+        P: From<usize>,
+    {
         loop {
             let typ = self.types.get(self.pos)?;
-            let port = Port::new(self.direction, self.pos);
+            let port = P::from(self.pos);
             self.pos += 1;
             if type_is_linear(typ) {
                 self.linear_count += 1;
@@ -188,21 +197,47 @@ where
             }
         }
     }
+}
+
+impl<UL> Iterator for Units<OutgoingPort, UL>
+where
+    UL: UnitLabeller,
+{
+    type Item = (CircuitUnit, OutgoingPort, Type);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_generic()
+    }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.types.len() - self.pos;
-        if self.direction == Direction::Outgoing {
-            (len, Some(len))
-        } else {
-            // Even when yielding every unit, a disconnected input non-linear
-            // port cannot be assigned a `CircuitUnit::Wire` and so it will be
-            // skipped.
-            (0, Some(len))
-        }
+        (len, Some(len))
     }
 }
 
-impl<UL> FusedIterator for Units<UL> where UL: UnitLabeller {}
+impl<UL> Iterator for Units<IncomingPort, UL>
+where
+    UL: UnitLabeller,
+{
+    type Item = (CircuitUnit, IncomingPort, Type);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_generic()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.types.len() - self.pos;
+        // Even when yielding every unit, a disconnected input non-linear
+        // port cannot be assigned a `CircuitUnit::Wire` and so it will be
+        // skipped.
+        (0, Some(len))
+    }
+}
+
+impl<UL> FusedIterator for Units<OutgoingPort, UL> where UL: UnitLabeller {}
+impl<UL> FusedIterator for Units<IncomingPort, UL> where UL: UnitLabeller {}
 
 /// A trait for assigning linear unit ids and wires to ports of a node.
 pub trait UnitLabeller {

--- a/tket2/src/circuit/units/filter.rs
+++ b/tket2/src/circuit/units/filter.rs
@@ -4,69 +4,32 @@
 use hugr::extension::prelude;
 use hugr::types::Type;
 use hugr::CircuitUnit;
-use hugr::{Port, Wire};
+use hugr::Wire;
 
-use super::{DefaultUnitLabeller, LinearUnit, Units};
+use super::LinearUnit;
 
-/// A filtered units iterator
-pub type FilteredUnits<F, UL = DefaultUnitLabeller> = std::iter::FilterMap<
-    Units<UL>,
-    fn((CircuitUnit, Port, Type)) -> Option<<F as UnitFilter>::Item>,
->;
-
-/// A filter over a [`Units`] iterator.
-pub trait UnitFilter {
-    /// The item yielded by the filtered iterator.
-    type Item;
-
-    /// Filter a [`Units`] iterator item, and unwrap it into a `Self::Item` if
-    /// it's accepted.
-    fn accept(item: (CircuitUnit, Port, Type)) -> Option<Self::Item>;
-}
-
-/// A unit filter that accepts linear units.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct Linear;
-
-/// A unit filter that accepts qubits, a subset of [`Linear`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct Qubits;
-
-/// A unit filter that accepts non-linear units.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct NonLinear;
-
-impl UnitFilter for Linear {
-    type Item = (LinearUnit, Port, Type);
-
-    fn accept(item: (CircuitUnit, Port, Type)) -> Option<Self::Item> {
-        match item {
-            (CircuitUnit::Linear(unit), port, typ) => Some((LinearUnit::new(unit), port, typ)),
-            _ => None,
-        }
+/// A unit filter that return only linear units.
+pub fn filter_linear<P>(item: (CircuitUnit, P, Type)) -> Option<(LinearUnit, P, Type)> {
+    match item {
+        (CircuitUnit::Linear(unit), port, typ) => Some((LinearUnit::new(unit), port, typ)),
+        _ => None,
     }
 }
 
-impl UnitFilter for Qubits {
-    type Item = (LinearUnit, Port, Type);
-
-    fn accept(item: (CircuitUnit, Port, Type)) -> Option<Self::Item> {
-        match item {
-            (CircuitUnit::Linear(unit), port, typ) if typ == prelude::QB_T => {
-                Some((LinearUnit::new(unit), port, typ))
-            }
-            _ => None,
+/// A unit filter that return only qubits, a subset of [`filter_linear`].
+pub fn filter_qubit<P>(item: (CircuitUnit, P, Type)) -> Option<(LinearUnit, P, Type)> {
+    match item {
+        (CircuitUnit::Linear(unit), port, typ) if typ == prelude::QB_T => {
+            Some((LinearUnit::new(unit), port, typ))
         }
+        _ => None,
     }
 }
 
-impl UnitFilter for NonLinear {
-    type Item = (Wire, Port, Type);
-
-    fn accept(item: (CircuitUnit, Port, Type)) -> Option<Self::Item> {
-        match item {
-            (CircuitUnit::Wire(wire), port, typ) => Some((wire, port, typ)),
-            _ => None,
-        }
+/// A unit filter that return only non-linear units.
+pub fn filter_non_linear<P>(item: (CircuitUnit, P, Type)) -> Option<(Wire, P, Type)> {
+    match item {
+        (CircuitUnit::Wire(wire), port, typ) => Some((wire, port, typ)),
+        _ => None,
     }
 }

--- a/tket2/src/passes/commutation.rs
+++ b/tket2/src/passes/commutation.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use portgraph::PortOffset;
 
 use crate::{
-    circuit::{command::Command, units::filter::Qubits, Circuit},
+    circuit::{command::Command, Circuit},
     ops::{Pauli, Tk2Op},
 };
 
@@ -72,7 +72,7 @@ fn add_to_slice(slice: &mut Slice, com: Rc<ComCommand>) {
 fn load_slices(circ: &impl Circuit) -> SliceVec {
     let mut slices = vec![];
 
-    let n_qbs = circ.units().filter_units::<Qubits>().count();
+    let n_qbs = circ.qubit_count();
     let mut qubit_free_slice = vec![0; n_qbs];
 
     for command in circ.commands().filter(|c| is_slice_op(circ, c.node())) {


### PR DESCRIPTION
Mostly a refactor. The `Units` struct required some API changes so the iterator can return the kind of port matching its direction.

Closes #220 