### PR TITLE
chore: cleanup dependency inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,44 @@ missing_docs = "warn"
 [workspace.dependencies]
 
 tket2 = { path = "./tket2" }
-quantinuum-hugr = { version = "0.2" }
-portgraph = { version = "0.11" }
-pyo3 = { version = "0.20" }
-itertools = { version = "0.12.0" }
-tket-json-rs = { version = "0.3.0" }
+quantinuum-hugr = "0.2"
+portgraph = "0.11"
+pyo3 = "0.20"
+itertools = "0.12.0"
+tket-json-rs = "0.3.0"
 tracing = "0.1.37"
-portmatching = { version = "0.3.1" }
+portmatching = "0.3.1"
+bytemuck = "1.14.0"
+cgmath = "0.18.0"
+chrono = "0.4.30"
+clap = "4.4.2"
+criterion = "0.5.1"
+crossbeam-channel = "0.5.8"
+csv = "1.2.2"
+delegate = "0.12.0"
+derive_more = "0.99.17"
+downcast-rs = "1.2.0"
+fxhash = "0.2.1"
+lazy_static = "1.4.0"
+num-complex = "0.4"
+num-rational = "0.4"
+num_cpus = "1.16.0"
+peak_alloc = "0.2.0"
+petgraph = { version = "0.6.3", default-features = false }
+priority-queue = "2.0.2"
+rayon = "1.5"
+rmp-serde = "1.1.2"
+rstest = "0.18.1"
+serde = "1.0"
+serde_json = "1.0"
+serde_yaml = "0.9.22"
+smol_str = "0.2.0"
+stringreader = "0.1.1"
+strum = "0.26.1"
+strum_macros = "0.26.1"
+thiserror = "1.0.28"
+tracing-appender = "0.2.2"
+tracing-subscriber = "0.3.17"
+typetag = "0.2.8"
+urlencoding = "2.1.2"
+webbrowser = "0.8.10"

--- a/badger-optimiser/Cargo.toml
+++ b/badger-optimiser/Cargo.toml
@@ -9,16 +9,16 @@ license-file = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.4.2", features = ["derive"] }
-serde_json = "1.0"
+clap = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tket2 = { workspace = true, features = ["portmatching", "rewrite-tracing"] }
 quantinuum-hugr = { workspace = true }
 itertools = { workspace = true }
 tket-json-rs = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = "0.3.17"
-tracing-appender = "0.2.2"
-peak_alloc = { version = "0.2.0", optional = true }
+tracing-subscriber = { workspace = true }
+tracing-appender = { workspace = true }
+peak_alloc = { workspace = true, optional = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/compile-rewriter/Cargo.toml
+++ b/compile-rewriter/Cargo.toml
@@ -9,7 +9,7 @@ license-file = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.4.2", features = ["derive"] }
+clap = { workspace = true, features = ["derive"] }
 tket2 = { workspace = true, features = ["portmatching"] }
 quantinuum-hugr = { workspace = true }
 itertools = { workspace = true }

--- a/tket2-py/Cargo.toml
+++ b/tket2-py/Cargo.toml
@@ -15,13 +15,13 @@ crate-type = ["cdylib"]
 
 [dependencies]
 tket2 = { workspace = true, features = ["pyo3", "portmatching"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tket-json-rs = { workspace = true, features = ["pyo3"] }
 quantinuum-hugr = { workspace = true }
 portgraph = { workspace = true, features = ["serde"] }
 pyo3 = { workspace = true, features = ["extension-module"] }
-num_cpus = "1.16.0"
-derive_more = "0.99.17"
+num_cpus = { workspace = true }
+derive_more = { workspace = true }
 itertools = { workspace = true }
 portmatching = { workspace = true }

--- a/tket2/Cargo.toml
+++ b/tket2/Cargo.toml
@@ -27,44 +27,44 @@ rewrite-tracing = []
 default = []
 
 [dependencies]
-lazy_static = "1.4.0"
-cgmath = "0.18.0"
-num-rational = "0.4"
-num-complex = { version = "0.4", optional = true }
+lazy_static = { workspace = true }
+cgmath = { workspace = true }
+num-rational = { workspace = true }
+num-complex = { workspace = true, optional = true }
 tket-json-rs = { workspace = true }
-rayon = "1.5"
-thiserror = "1.0.28"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-downcast-rs = "1.2.0"
-priority-queue = "2.0.2"
-smol_str = "0.2.0"
-typetag = "0.2.8"
+rayon = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+downcast-rs = { workspace = true }
+priority-queue = { workspace = true }
+smol_str = { workspace = true }
+typetag = { workspace = true }
 itertools = { workspace = true }
-petgraph = { version = "0.6.3", default-features = false }
-serde_yaml = "0.9.22"
+petgraph = { workspace = true }
+serde_yaml = { workspace = true }
 portmatching = { workspace = true, optional = true, features = ["serde"] }
-derive_more = "0.99.17"
+derive_more = { workspace = true }
 quantinuum-hugr = { workspace = true }
 portgraph = { workspace = true, features = ["serde"] }
 pyo3 = { workspace = true, optional = true, features = ["multiple-pymethods"] }
-strum_macros = "0.26.1"
-strum = "0.26.1"
-fxhash = "0.2.1"
-rmp-serde = { version = "1.1.2", optional = true }
-delegate = "0.12.0"
-csv = { version = "1.2.2" }
-chrono = { version = "0.4.30" }
-bytemuck = "1.14.0"
-stringreader = "0.1.1"
-crossbeam-channel = "0.5.8"
+strum_macros = { workspace = true }
+strum = { workspace = true }
+fxhash = { workspace = true }
+rmp-serde = { workspace = true, optional = true }
+delegate = { workspace = true }
+csv = { workspace = true }
+chrono = { workspace = true }
+bytemuck = { workspace = true }
+stringreader = { workspace = true }
+crossbeam-channel = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-rstest = "0.18.1"
-criterion = { version = "0.5.1", features = ["html_reports"] }
-webbrowser = "0.8.10"
-urlencoding = "2.1.2"
+rstest = { workspace = true }
+criterion = { workspace = true, features = ["html_reports"] }
+webbrowser = { workspace = true }
+urlencoding = { workspace = true }
 
 [[bench]]
 name = "bench_main"


### PR DESCRIPTION
This is just a cleanup PR, using [`cargo-autoinherit`](https://github.com/mainmatter/cargo-autoinherit) to move common dependencies to the root workspace.