### PR TITLE
feat: expose Tk2Op name

### DIFF
--- a/tket2/src/circuit/command.rs
+++ b/tket2/src/circuit/command.rs
@@ -501,8 +501,7 @@ mod test {
 
         assert_eq!(CommandIterator::new(&circ).count(), 3);
 
-        // TODO: Expose the operation names directly in Tk2Op to clean this up
-        let tk2op_name = |op: Tk2Op| <Tk2Op as Into<OpType>>::into(op).name();
+        let tk2op_name = |op: Tk2Op| op.exposed_name();
 
         let mut commands = CommandIterator::new(&circ);
         assert_eq!(commands.size_hint(), (3, Some(3)));

--- a/tket2/src/ops.rs
+++ b/tket2/src/ops.rs
@@ -70,6 +70,13 @@ pub enum Tk2Op {
     Reset,
 }
 
+impl Tk2Op {
+    #[allow(dead_code)]
+    fn exposed_name(&self) -> smol_str::SmolStr {
+        <Tk2Op as Into<OpType>>::into(*self).name()
+    }
+}
+
 /// Whether an op is a given Tk2Op.
 pub fn op_matches(op: &OpType, tk2op: Tk2Op) -> bool {
     op.name() == <Tk2Op as Into<OpType>>::into(tk2op).name()

--- a/tket2/src/ops.rs
+++ b/tket2/src/ops.rs
@@ -71,15 +71,15 @@ pub enum Tk2Op {
 }
 
 impl Tk2Op {
-    #[allow(dead_code)]
-    fn exposed_name(&self) -> smol_str::SmolStr {
+    /// Expose the operation names directly in Tk2Op
+    pub fn exposed_name(&self) -> smol_str::SmolStr {
         <Tk2Op as Into<OpType>>::into(*self).name()
     }
 }
 
 /// Whether an op is a given Tk2Op.
 pub fn op_matches(op: &OpType, tk2op: Tk2Op) -> bool {
-    op.name() == <Tk2Op as Into<OpType>>::into(tk2op).name()
+    op.name() == tk2op.exposed_name()
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, EnumIter, Display, PartialEq, PartialOrd)]

--- a/tket2/src/passes/commutation.rs
+++ b/tket2/src/passes/commutation.rs
@@ -281,6 +281,8 @@ impl Rewrite for PullForward {
     fn invalidation_set(&self) -> Self::InvalidationSet<'_> {
         // TODO: This could avoid creating a vec, but it'll be easier to do once
         // return position impl trait is available.
+        // RPITIT requires 1.75 stable in December 2023
+        // could change Rewrite trait to take that into account if using that version
         let mut nodes = vec![self.command.node()];
         let next_nodes = self.new_nexts.values().map(|c| c.node());
         nodes.extend(next_nodes);

--- a/tket2/src/passes/commutation.rs
+++ b/tket2/src/passes/commutation.rs
@@ -281,8 +281,8 @@ impl Rewrite for PullForward {
     fn invalidation_set(&self) -> Self::InvalidationSet<'_> {
         // TODO: This could avoid creating a vec, but it'll be easier to do once
         // return position impl trait is available.
-        // RPITIT requires 1.75 stable in December 2023
-        // could change Rewrite trait to take that into account if using that version
+        // This is done in the Rewrite trait of hugr so once that version
+        // is released, it can be updated here
         let mut nodes = vec![self.command.node()];
         let next_nodes = self.new_nexts.values().map(|c| c.node());
         nodes.extend(next_nodes);


### PR DESCRIPTION
a TODO was written for exposing the name as a public function on Tk2Op to avoid intos at caller

also update the comment on the impl of Rewrite of PullForward to reflect change in hugr