### PR TITLE
ci: whitelist packages to release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,6 +4,9 @@
 # Open the release PR as a draft
 pr_draft = true
 
+# Default to not processing the packages
+release = false
+
 # Enforce adding the project name in the git tag, to avoid collisions with python.
 # (This would normally only be enabled once there are multiple packages in the workspace)
 git_tag_name = "{{ package }}-v{{ version }}"
@@ -24,3 +27,10 @@ commit_parsers = [
     { message = "^revert", group = "Reverted changes", skip = true },
     { message = "^ci", group = "CI", skip = true },
 ]
+
+[[package]]
+name = "tket2"
+release = true
+
+# Temporarily disabled until the first manual release
+publish = false


### PR DESCRIPTION
Otherwise release-plz tries to generate changelogs for `tket2-py` and the binary tools.
https://github.com/CQCL/tket2/pull/357

<img width="426" alt="image" src="https://github.com/CQCL/tket2/assets/121866228/b62e8599-7526-450a-8bdc-acb9a6364e19">
