### PR TITLE
fix: Commands iterator ignoring the hierarchy.

### DIFF
--- a/tket2/src/circuit/command.rs
+++ b/tket2/src/circuit/command.rs
@@ -6,6 +6,7 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::iter::FusedIterator;
 
+use hugr::hugr::views::{HierarchyView, SiblingGraph};
 use hugr::hugr::NodeType;
 use hugr::ops::{OpTag, OpTrait};
 use hugr::{HugrView, IncomingPort, OutgoingPort};
@@ -237,12 +238,14 @@ type NodeWalker = pv::Topo<Node, HashSet<Node>>;
 pub struct CommandIterator<'circ, T> {
     /// The circuit.
     circ: &'circ Circuit<T>,
+    /// A view of the top-level region of the circuit.
+    region: SiblingGraph<'circ>,
     /// Toposorted nodes.
     nodes: NodeWalker,
     /// Last wire for each [`LinearUnit`] in the circuit.
     wire_unit: HashMap<Wire, usize>,
-    /// Remaining commands, not counting I/O nodes.
-    remaining: usize,
+    /// Maximum number of remaining commands, not counting I/O nodes nor root nodes.
+    max_remaining: usize,
     /// Delayed output of constant and load const nodes. Contains nodes that
     /// haven't been yielded yet.
     ///
@@ -275,13 +278,16 @@ impl<'circ, T: HugrView> CommandIterator<'circ, T> {
             .map(|(linear_unit, port, _)| (Wire::new(circ.input_node(), port), linear_unit.index()))
             .collect();
 
-        let nodes = pv::Topo::new(&circ.hugr().as_petgraph());
+        let region: SiblingGraph = SiblingGraph::try_new(circ.hugr(), circ.parent()).unwrap();
+        let node_count = region.node_count();
+        let nodes = pv::Topo::new(&region.as_petgraph());
         Self {
             circ,
+            region,
             nodes,
             wire_unit,
             // Ignore the input and output nodes, and the root.
-            remaining: circ.hugr().node_count() - 3,
+            max_remaining: node_count - 3,
             delayed_consts: HashSet::new(),
             delayed_consumers: HashMap::new(),
             delayed_node: None,
@@ -296,7 +302,12 @@ impl<'circ, T: HugrView> CommandIterator<'circ, T> {
         let node = self
             .delayed_node
             .take()
-            .or_else(|| self.nodes.next(&self.circ.hugr().as_petgraph()))?;
+            .or_else(|| self.nodes.next(&self.region.as_petgraph()))?;
+        if node == self.circ.parent() {
+            // Ignore the root of the circuit.
+            // This will only happen once.
+            return self.next_node();
+        }
 
         // If this node is a constant or load const node, delay it.
         let tag = self.circ.hugr().get_optype(node).tag();
@@ -432,7 +443,7 @@ impl<'circ, T: HugrView> Iterator for CommandIterator<'circ, T> {
             let node = self.next_node()?;
             // Process the node, returning a command if it's not an input or output.
             if let Some((input_linear_units, output_linear_units)) = self.process_node(node) {
-                self.remaining -= 1;
+                self.max_remaining -= 1;
                 return Some(Command {
                     circ: self.circ,
                     node,
@@ -445,7 +456,7 @@ impl<'circ, T: HugrView> Iterator for CommandIterator<'circ, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.remaining, Some(self.remaining))
+        (0, Some(self.max_remaining))
     }
 }
 
@@ -456,7 +467,7 @@ impl<'circ, T: HugrView> std::fmt::Debug for CommandIterator<'circ, T> {
         f.debug_struct("CommandIterator")
             .field("circuit name", &self.circ.name())
             .field("wire_unit", &self.wire_unit)
-            .field("remaining", &self.remaining)
+            .field("max_remaining", &self.max_remaining)
             .finish()
     }
 }
@@ -535,7 +546,7 @@ mod test {
         let tk2op_name = |op: Tk2Op| op.exposed_name();
 
         let mut commands = CommandIterator::new(&circ);
-        assert_eq!(commands.size_hint(), (3, Some(3)));
+        assert_eq!(commands.size_hint(), (0, Some(3)));
 
         let hadamard = commands.next().unwrap();
         assert_eq!(hadamard.optype().name().as_str(), tk2op_name(Tk2Op::H));


### PR DESCRIPTION
The commands iterator did a toposort on the whole Hugr, ignoring the hierarchy.
This generated problems with #370, since circuits may now be nested somewhere in the hugr.
It would also have caused problems with circuit boxes, but we don't support that yet here.

We use a `SiblingGraph` now, to ensure that we only explore the top-level region of the circuit.
Subcircuits will be returned as a single command.

Adds a `build_module_with_circuit` helper to build circuits inside modules.

Closes #42.