### PR TITLE
ci: Fix release wheels if condition

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -127,9 +127,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: |
-      ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v'))}} ||
-      ${{ (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v'))}} ||
+    if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) }}
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
The `if` condition that decided whether to publish to pypi always evaluate to `true` -.-

I'm still not sure why; I suspected the trailing `||` but I tested many variations and only this github expression in a single line worked as expected...
https://github.com/CQCL/tket2/actions/runs/9418704582/job/25947230967