### PR TITLE
docs: Better error reporting in portmatching

### DIFF
--- a/tket2/src/portmatching/pattern.rs
+++ b/tket2/src/portmatching/pattern.rs
@@ -132,7 +132,7 @@ impl Debug for CircuitPattern {
 #[non_exhaustive]
 pub enum InvalidPattern {
     /// An empty circuit cannot be a pattern.
-    #[error("Empty circuit are not allowed as patterns")]
+    #[error("Empty circuits are not allowed as patterns")]
     EmptyCircuit,
     /// Patterns must be connected circuits.
     #[error("The pattern is not connected")]


### PR DESCRIPTION
If the pattern had empty wires, `try_from_circuit` failed with a `NotConnected` error. This adds an `EmptyWire` variant instead.