### PR TITLE
fix(tket2-py): Replace `with_hugr` helpers with `with_circ`, keeping the circuit parent.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
 name = "tket2-py"
 version = "0.0.0"
 dependencies = [
+ "cool_asserts",
  "derive_more",
  "hugr",
  "itertools 0.13.0",
@@ -1856,6 +1857,7 @@ dependencies = [
  "portgraph 0.12.1",
  "portmatching",
  "pyo3",
+ "rstest",
  "serde",
  "serde_json",
  "strum",

--- a/tket2-py/Cargo.toml
+++ b/tket2-py/Cargo.toml
@@ -19,7 +19,9 @@ test = false
 bench = false
 
 [dependencies]
-tket2 = { path = "../tket2", version = "0.1.0-alpha.1", features = ["portmatching"] }
+tket2 = { path = "../tket2", version = "0.1.0-alpha.1", features = [
+    "portmatching",
+] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tket-json-rs = { workspace = true, features = ["pyo3"] }
@@ -31,3 +33,7 @@ derive_more = { workspace = true }
 itertools = { workspace = true }
 portmatching = { workspace = true }
 strum = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+cool_asserts = { workspace = true }

--- a/tket2-py/src/circuit.rs
+++ b/tket2-py/src/circuit.rs
@@ -23,7 +23,7 @@ use tket_json_rs::circuit_json::SerialCircuit;
 use crate::utils::create_py_exception;
 use crate::utils::ConvertPyErr;
 
-pub use self::convert::{try_update_hugr, try_with_hugr, update_hugr, with_hugr, CircuitType};
+pub use self::convert::{try_update_circ, try_with_circ, update_circ, with_circ, CircuitType};
 pub use self::cost::PyCircuitCost;
 use self::tk2circuit::Dfg;
 pub use self::tk2circuit::Tk2Circuit;
@@ -88,19 +88,19 @@ create_py_exception!(
 /// Run the validation checks on a circuit.
 #[pyfunction]
 pub fn validate_circuit(c: &Bound<PyAny>) -> PyResult<()> {
-    try_with_hugr(c, |hugr, _| hugr.validate(&REGISTRY))
+    try_with_circ(c, |circ, _| circ.hugr().validate(&REGISTRY))
 }
 
 /// Return a Graphviz DOT string representation of the circuit.
 #[pyfunction]
 pub fn render_circuit_dot(c: &Bound<PyAny>) -> PyResult<String> {
-    with_hugr(c, |hugr, _| hugr.dot_string())
+    with_circ(c, |hugr, _| hugr.dot_string())
 }
 
 /// Return a Mermaid diagram representation of the circuit.
 #[pyfunction]
 pub fn render_circuit_mermaid(c: &Bound<PyAny>) -> PyResult<String> {
-    with_hugr(c, |hugr, _| hugr.mermaid_string())
+    with_circ(c, |hugr, _| hugr.mermaid_string())
 }
 
 /// A [`hugr::Node`] wrapper for Python.

--- a/tket2-py/src/circuit/convert.rs
+++ b/tket2-py/src/circuit/convert.rs
@@ -110,3 +110,29 @@ where
         typ.convert(py, circ)
     })
 }
+
+#[cfg(test)]
+mod test {
+    use crate::utils::test::make_module_tk2_circuit;
+
+    use super::*;
+    use cool_asserts::assert_matches;
+    use pyo3::prelude::*;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_with_circ() -> PyResult<()> {
+        pyo3::prepare_freethreaded_python();
+        Python::with_gil(|py| {
+            let circ = make_module_tk2_circuit(py)?;
+
+            with_circ(&circ, |circ, typ| {
+                assert_eq!(typ, CircuitType::Tket2);
+
+                let parent_optype = circ.hugr().get_optype(circ.parent());
+                assert_matches!(parent_optype, OpType::FuncDefn(_));
+            })
+        })?;
+        Ok(())
+    }
+}

--- a/tket2-py/src/circuit/tk2circuit.rs
+++ b/tket2-py/src/circuit/tk2circuit.rs
@@ -31,7 +31,7 @@ use crate::rewrite::PyCircuitRewrite;
 use crate::types::PyHugrType;
 use crate::utils::{into_vec, ConvertPyErr};
 
-use super::{cost, with_hugr, PyCircuitCost, PyNode, PyWire};
+use super::{cost, with_circ, PyCircuitCost, PyNode, PyWire};
 
 /// A circuit in tket2 format.
 ///
@@ -69,7 +69,7 @@ impl Tk2Circuit {
     #[new]
     pub fn new(circ: &Bound<PyAny>) -> PyResult<Self> {
         Ok(Self {
-            circ: with_hugr(circ, |hugr, _| hugr)?.into(),
+            circ: with_circ(circ, |hugr, _| hugr)?,
         })
     }
 

--- a/tket2-py/src/optimiser.rs
+++ b/tket2-py/src/optimiser.rs
@@ -8,7 +8,7 @@ use tket2::optimiser::badger::BadgerOptions;
 use tket2::optimiser::{BadgerLogger, DefaultBadgerOptimiser};
 use tket2::Circuit;
 
-use crate::circuit::update_hugr;
+use crate::circuit::update_circ;
 
 /// The module definition
 pub fn module(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
@@ -96,10 +96,7 @@ impl PyBadgerOptimiser {
             split_circuit: split_circ.unwrap_or(false),
             queue_size: queue_size.unwrap_or(100),
         };
-        update_hugr(circ, |circ, _| {
-            self.optimise(circ.into(), log_progress, options)
-                .into_hugr()
-        })
+        update_circ(circ, |circ, _| self.optimise(circ, log_progress, options))
     }
 }
 

--- a/tket2-py/src/pattern/portmatching.rs
+++ b/tket2-py/src/pattern/portmatching.rs
@@ -9,7 +9,7 @@ use pyo3::{prelude::*, types::PyIterator};
 
 use tket2::portmatching::{CircuitPattern, PatternMatch, PatternMatcher};
 
-use crate::circuit::{try_with_hugr, with_hugr, PyNode};
+use crate::circuit::{try_with_circ, with_circ, PyNode};
 
 /// A pattern that match a circuit exactly
 ///
@@ -30,9 +30,7 @@ impl PyCircuitPattern {
     /// Construct a pattern from a TKET1 circuit
     #[new]
     pub fn from_circuit(circ: &Bound<PyAny>) -> PyResult<Self> {
-        let pattern = try_with_hugr(circ, |circ, _| {
-            CircuitPattern::try_from_circuit(&circ.into())
-        })?;
+        let pattern = try_with_circ(circ, |circ, _| CircuitPattern::try_from_circuit(&circ))?;
         Ok(pattern.into())
     }
 
@@ -82,19 +80,16 @@ impl PyPatternMatcher {
 
     /// Find one convex match in a circuit.
     pub fn find_match(&self, circ: &Bound<PyAny>) -> PyResult<Option<PyPatternMatch>> {
-        with_hugr(circ, |circ, _| {
-            self.matcher
-                .find_matches_iter(&circ.into())
-                .next()
-                .map(Into::into)
+        with_circ(circ, |circ, _| {
+            self.matcher.find_matches_iter(&circ).next().map(Into::into)
         })
     }
 
     /// Find all convex matches in a circuit.
     pub fn find_matches(&self, circ: &Bound<PyAny>) -> PyResult<Vec<PyPatternMatch>> {
-        with_hugr(circ, |circ, _| {
+        with_circ(circ, |circ, _| {
             self.matcher
-                .find_matches(&circ.into())
+                .find_matches(&circ)
                 .into_iter()
                 .map_into()
                 .collect()

--- a/tket2-py/src/utils.rs
+++ b/tket2-py/src/utils.rs
@@ -1,5 +1,16 @@
 //! Utility functions for the python interface.
 
+use hugr::builder::{
+    BuildError, CircuitBuilder, Container, Dataflow, DataflowSubContainer, FunctionBuilder,
+    HugrBuilder, ModuleBuilder,
+};
+use hugr::extension::prelude::QB_T;
+use hugr::extension::PRELUDE_REGISTRY;
+use hugr::ops::handle::NodeHandle;
+use hugr::types::FunctionType;
+use hugr::Hugr;
+use itertools::Itertools;
+use tket2::Circuit;
 /// A trait for types wrapping rust errors that may be converted into python exception.
 ///
 /// In addition to raw errors, this is implemented for wrapper types such as `Result`.
@@ -45,9 +56,51 @@ macro_rules! create_py_exception {
     };
 }
 pub(crate) use create_py_exception;
-use itertools::Itertools;
 
 /// Convert an iterator of one type into vector of another type.
 pub fn into_vec<T, S: From<T>>(v: impl IntoIterator<Item = T>) -> Vec<S> {
     v.into_iter().map_into().collect()
+}
+
+/// Utility for building a module with a single circuit definition.
+#[allow(unused)]
+pub(crate) fn build_module_with_circuit<F>(num_qubits: usize, f: F) -> Result<Circuit, BuildError>
+where
+    F: FnOnce(&mut CircuitBuilder<FunctionBuilder<&mut Hugr>>) -> Result<(), BuildError>,
+{
+    let mut builder = ModuleBuilder::new();
+    let circ = {
+        let qb_row = vec![QB_T; num_qubits];
+        let circ_signature = FunctionType::new(qb_row.clone(), qb_row);
+        let mut dfg = builder.define_function("main", circ_signature.into())?;
+        let mut circ = dfg.as_circuit(dfg.input_wires());
+        f(&mut circ)?;
+        let qbs = circ.finish();
+        dfg.finish_with_outputs(qbs)?
+    };
+    let hugr = builder.finish_hugr(&PRELUDE_REGISTRY)?;
+    Ok(Circuit::new(hugr, circ.node()))
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use pyo3::{Bound, PyResult, Python};
+    use tket2::Tk2Op;
+
+    use crate::circuit::Tk2Circuit;
+
+    use super::build_module_with_circuit;
+
+    /// Generates a simple tket2 circuit for testing,
+    /// defined as a function inside a module.
+    pub fn make_module_tk2_circuit<'py>(py: Python<'py>) -> PyResult<Bound<'py, Tk2Circuit>> {
+        let circ = build_module_with_circuit(2, |circ| {
+            circ.append(Tk2Op::H, [0])?;
+            circ.append(Tk2Op::CX, [0, 1])?;
+            circ.append(Tk2Op::X, [1])?;
+            Ok(())
+        })
+        .unwrap();
+        Bound::new(py, Tk2Circuit { circ })
+    }
 }


### PR DESCRIPTION
Avoids unwrapping the hugr inside `Tk2Circuit`.
This caused problems with circuits with non-root parents. Circuits defined in guppy ended up pointing to the root module instead of the chosen function definition.

Adds the first rust-side test for `tket2-py`.
I'm pretty sure I'll have to install the python interpreter in the CI rust test job, but let's see the error first.