### PR TITLE
fix: `extract_dfg` inserting the output node with an invalid child order

### DIFF
--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -11,6 +11,7 @@ use std::iter::Sum;
 pub use command::{Command, CommandIterator};
 pub use hash::CircuitHash;
 use hugr::hugr::views::{DescendantsGraph, ExtractHugr, HierarchyView};
+use hugr_core::hugr::internal::HugrMutInternals;
 use itertools::Either::{Left, Right};
 
 use hugr::hugr::hugrmut::HugrMut;
@@ -317,7 +318,11 @@ impl<T: HugrView> Circuit<T> {
         } else {
             let view: DescendantsGraph = DescendantsGraph::try_new(&self.hugr, self.parent)
                 .expect("Circuit parent was not a dataflow container.");
-            view.extract_hugr().into()
+            let mut hugr = view.extract_hugr();
+            // TODO: Remove this once hugr 0.6.0 gets released.
+            // https://github.com/CQCL/hugr/pull/1239
+            hugr.set_num_ports(hugr.root(), 0, 0);
+            hugr.into()
         };
         extract_dfg::rewrite_into_dfg(&mut circ)?;
         Ok(circ)

--- a/tket2/src/circuit/extract_dfg.rs
+++ b/tket2/src/circuit/extract_dfg.rs
@@ -47,7 +47,7 @@ fn remove_cfg_empty_output_tuple(
     signature: FunctionType,
 ) -> Result<FunctionType, CircuitMutError> {
     let sig = signature;
-    let parent = circ.parent();
+    let input_node = circ.input_node();
 
     let output_node = circ.output_node();
     let output_nodetype = circ.hugr.get_nodetype(output_node).clone();
@@ -89,8 +89,8 @@ fn remove_cfg_empty_output_tuple(
     let new_op = Output {
         types: new_types.clone().into(),
     };
-    let new_node = hugr.add_node_with_parent(
-        parent,
+    let new_node = hugr.add_node_after(
+        input_node,
         NodeType::new(
             new_op,
             output_nodetype

--- a/tket2/src/passes/pytket.rs
+++ b/tket2/src/passes/pytket.rs
@@ -166,7 +166,5 @@ mod test {
             .signature(lowered_circ.output_node())
             .unwrap();
         assert_eq!(lowered_sig.output(), output_sig.input());
-        println!("Lowered circuit: {}", lowered_sig);
-        println!("Output node: {}", output_sig);
     }
 }


### PR DESCRIPTION
When replacing a CFG's output with the correct DFG output operation, we inserted the new node at the end of the container's children, instead of just after the input.

Includes a new unit test which simulates a circuit definition from guppy, where we can run the `lower_to_pytket` pass.