### PR TITLE
ci: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,18 @@ updates:
     commit-message:
       # Use a conventional commit tag
       prefix: "chore(deps-rs)"
+    groups:
+      hugr:
+        patterns: ["hugr*"]
+      dev:
+        dependency-type: "development"
+        update-types: ["patch", "minor"]
+      patch:
+        update-types: ["patch"]
+      minor:
+        update-types: ["minor"]
+      # Major updates still generate individual PRs
+
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
@@ -19,6 +31,18 @@ updates:
     commit-message:
       # Use a conventional commit tag
       prefix: "chore(deps-py)"
+    groups:
+      hugr:
+        patterns: ["hugr*"]
+      dev:
+        dependency-type: "development"
+        update-types: ["patch", "minor"]
+      patch:
+        update-types: ["patch"]
+      minor:
+        update-types: ["minor"]
+      # Major updates still generate individual PRs
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Closes #462

Tries to avoid the flood of package updates by grouping them into categories.
- Hugr packages get their own group
- Dev dependencies get grouped together as long as they are not breaking changes.
- Patch releases and minor releases get their own groups
- Any major release gets its own PR

<img width="569" alt="image" src="https://github.com/user-attachments/assets/b77387ba-0518-49b6-9d18-65f31825b4a6">
