### PR TITLE
chore: Replace build.rs with lint config in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ repository = "https://github.com/CQCL/tket2"
 license = "Apache-2.0"
 
 [workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci_run)'] }
 missing_docs = "warn"
 
 [workspace.dependencies]

--- a/tket2/build.rs
+++ b/tket2/build.rs
@@ -1,7 +1,0 @@
-//! Build script for the `tket2` crate.
-
-fn main() {
-    // We use a `ci_run` RUSTFLAG to indicate that we are running a CI check,
-    // so we can reject debug code using some tools defined in `utils.rs`.
-    println!("cargo:rustc-check-cfg=cfg(ci_run)");
-}


### PR DESCRIPTION
Rust 1.80 [just dropped](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html), adding a lint option that allows us to avoid the `build.rs` definition added in https://github.com/CQCL/tket2/pull/386.
(The nightly lint got updated before hitting beta, so there shouldn't be compatibility problems there).