### PR TITLE
ci: Separate release-please PRs, and set a better title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "initial-version": "0.0.0",
-    "separate-pull-requests": false,
+    "separate-pull-requests": true,
     "pull-request-title-pattern": "chore(py): release${component} ${version}",
     "packages": {
         "tket2-py": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,8 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "initial-version": "0.0.0",
+    "separate-pull-requests": false,
+    "pull-request-title-pattern": "chore(py): release${component} ${version}",
     "packages": {
         "tket2-py": {
             "release-type": "python",


### PR DESCRIPTION
Small change so that `release-please`'s PR include a `(py)` tag in their title.

I also enabled separated PRs for the packages, since we don't want to release `tket2-eccs` unless needed.