### PR TITLE
ci: Avoid building wheels on unrelated releases, split pypi tokens

### DIFF
--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -1,4 +1,4 @@
-name: Build and publish pure python wheels
+name: Pure Python wheels 🐍
 # Builds and publishes the pure wheels on pypi.
 #
 # This does not include the main `tket2-py` package, which is built using maturin.
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build-publish:
-    name: Build and publish wheels
+    name: Package and publish wheels
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,23 +28,38 @@ jobs:
           - 'tket2-eccs'
 
     steps:
+      # Check the release tag against the package name
+      #
+      # Skip the workflow when triggered by a release event for any other package.
+      - name: Check tag
+        run: |
+          echo "run=$SHOULD_RUN" >> $GITHUB_ENV
+        env:
+          SHOULD_RUN: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.name)) ) }}
+
       - uses: actions/checkout@v4
+        if: ${{ github.job.steps.check-tag.outputs.run == 'true' }}
       - name: Run sccache-cache
+        if: ${{ github.job.steps.check-tag.outputs.run == 'true' }}
         uses: mozilla-actions/sccache-action@v0.0.5
       - name: Install poetry
+        if: ${{ github.job.steps.check-tag.outputs.run == 'true' }}
         run: pipx install poetry
       - name: Set up Python '3.10'
+        if: ${{ github.job.steps.check-tag.outputs.run == 'true' }}
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: "poetry"
 
       - name: Build sdist and wheels
+        if: ${{ github.job.steps.check-tag.outputs.run == 'true' }}
         run: |
           cd ${{ matrix.package }}
           poetry build -o ../dist
 
       - name: Upload the built packages as artifacts
+        if: ${{ github.job.steps.check-tag.outputs.run == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.package }}-sdist

--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -24,9 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        package:
-          - 'tket2-eccs'
-
+        target:
+          - { name: tket2-eccs, key_secret: PYPI_PUBLISH_TKET2_ECCS }
     steps:
       # Check the release tag against the package name
       #
@@ -55,21 +54,21 @@ jobs:
       - name: Build sdist and wheels
         if: ${{ github.job.steps.check-tag.outputs.run == 'true' }}
         run: |
-          cd ${{ matrix.package }}
+          cd ${{ matrix.target.name }}
           poetry build -o ../dist
 
       - name: Upload the built packages as artifacts
         if: ${{ github.job.steps.check-tag.outputs.run == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.package }}-sdist
+          name: build-${{ matrix.target.name }}-sdist
           path: |
             dist/*.tar.gz
             dist/*.whl
 
       - name: Publish to PyPI
-        if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.package)) ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.package)) ) }}
+        if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.name)) ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.name)) ) }}
         run: |
-          cd ${{ matrix.package }}
-          poetry config pypi-token.pypi ${{ secrets.PYPI_PUBLISH }}
+          cd ${{ matrix.target.name }}
+          poetry config pypi-token.pypi ${{ secrets[matrix.target.key_secret] }}
           poetry publish --dist-dir ../dist --skip-existing

--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -32,7 +32,7 @@ jobs:
       # Skip the workflow when triggered by a release event for any other package.
       - name: Check tag
         run: |
-          echo "run=$SHOULD_RUN" >> $GITHUB_ENV
+          echo "run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         env:
           SHOULD_RUN: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.name)) ) }}
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_PUBLISH }}
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_PUBLISH_TKET2 }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -27,7 +27,14 @@ jobs:
     name: Check tag
     runs-on: ubuntu-latest
     outputs:
-      run: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) }}
+      run: ${{ steps.check-tag.outputs.run }}
+    steps:
+      - name: Check tag
+        id: check-tag
+        run: |
+          echo "run=$SHOULD_RUN" >> $GITHUB_OUTPUT
+        env:
+          SHOULD_RUN: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) }}
 
   linux:
     needs: check-tag

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -5,7 +5,7 @@
 #
 #     maturin generate-ci github > .github/workflows/python-wheels.yml
 #
-# And edit the `on:` action triggers and the filters in `jobs.release.if`.
+# And merge the changes into this file.
 name: Python wheels 🐍
 
 on:
@@ -21,7 +21,17 @@ permissions:
   contents: read
 
 jobs:
+  # Check if the tag matches the package name,
+  # or if the workflow is running on a non-release event.
+  check-tag:
+    name: Check tag
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) }}
+
   linux:
+    needs: check-tag
+    if: ${{ needs.check-tag.outputs.run == 'true' }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -57,6 +67,8 @@ jobs:
           path: dist
 
   musllinux:
+    needs: check-tag
+    if: ${{ needs.check-tag.outputs.run == 'true' }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -88,6 +100,8 @@ jobs:
           path: dist
 
   windows:
+    needs: check-tag
+    if: ${{ needs.check-tag.outputs.run == 'true' }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -115,6 +129,8 @@ jobs:
           path: dist
 
   macos:
+    needs: check-tag
+    if: ${{ needs.check-tag.outputs.run == 'true' }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -141,6 +157,8 @@ jobs:
           path: dist
 
   sdist:
+    needs: check-tag
+    if: ${{ needs.check-tag.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -158,8 +176,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) }}
     needs: [linux, musllinux, windows, macos, sdist]
+    if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket2-py-v') ) }}
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI


### PR DESCRIPTION
- Stops the wheel building jobs from running on releases of other packages.
  Adding a release for `tket2-eccs` caused `tket2` wheels to be built. Since that's an expensive workflow, this filters it out.
  We continue to build for all platforms on each commit to `main`. We may want to skip some platforms in the future.
  
- Splits the pypi token used for publishing `tket2-py` and `tket2-eccs`.
  Scoped tokens only give permissions to a single project. Splitting the tokens here will let us replace the currently unrestricted token.