### PR TITLE
chore: Use local ruff and mypy for pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,21 +32,36 @@ repos:
       - id: check-docstring-first
       - id: debug-statements
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.0
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
-    hooks:
-      - id: mypy
-        additional_dependencies: [pydantic]
-
   - repo: local
     hooks:
+      - id: poetry-install
+        name: sync poetry deps
+        description: Ensure development tools are installed.
+        entry: poetry install --sync
+        language: system
+        files: poetry.lock
+        pass_filenames: false
+      - id: ruff-format
+        name: ruff format
+        description: Format python code with `ruff`.
+        entry: poetry run ruff format
+        language: system
+        files: \.py$
+        pass_filenames: false
+      - id: ruff-check
+        name: ruff
+        description: Check python code with `ruff`.
+        entry: poetry run ruff check --fix --exit-non-zero-on-fix
+        language: system
+        files: \.py$
+        pass_filenames: false
+      - id: mypy-check
+        name: mypy
+        description: Check python code with `mypy`.
+        entry: poetry run mypy .
+        language: system
+        files: \.py$
+        pass_filenames: false
       - id: cargo-fmt
         name: cargo format
         description: Format rust code with `cargo fmt`.


### PR DESCRIPTION
Ensures that the checks run by pre-commit are the same as the ones run in CI, and the `ruff` and `mypy` versions are always controlled by `pyproject.toml`.
Before, we used pre-commit actions with their own versions that needed to be updated separately and tended to get out of date.