### PR TITLE
ci: Fix incorrect wheels name on publish

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: read
 
+env:
+  MODULE_DIR: tket2-py
+
 jobs:
   # Check if the tag matches the package name,
   # or if the workflow is running on a non-release event.
@@ -67,6 +70,7 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
           manylinux: auto
+          working-directory: ${{ env.MODULE_DIR }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -100,6 +104,7 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
           manylinux: musllinux_1_2
+          working-directory: ${{ env.MODULE_DIR }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -129,6 +134,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
+          working-directory: ${{ env.MODULE_DIR }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -157,6 +163,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: 'true'
+          working-directory: ${{ env.MODULE_DIR }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -174,6 +181,7 @@ jobs:
         with:
           command: sdist
           args: --out dist
+          working-directory: ${{ env.MODULE_DIR }}
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
@@ -194,3 +202,4 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
+          working-directory: ${{ env.MODULE_DIR }}

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ check:
 
 # Compile the wheels for the python package.
 build:
-    uv run maturin build --release
+    cd tket2-py && uv run maturin build --release
 
 # Run all the tests.
 test language="[rust|python]" : (_run_lang language \


### PR DESCRIPTION
Fixes #586, which was broken when we moved `pyproject.toml` in #546.

Running `maturin build` from the root dir tries to build the workspace project, creating an invalid wheel name. This PR updates the ci job and the `just build` command to run maturin from inside `/hugr-py/`.

Maturin is still configured as a build tool in the workspace so that `maturin develop` works everywhere. In that case we don't care about the project name.