### PR TITLE
chore: Don't `cargo test` tket2-py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
       - id: cargo-test
         name: cargo test
         description: Run tests with `cargo test`.
-        entry: uv run -- cargo test --all-features --workspace
+        entry: uv run -- cargo test --all-features
         language: system
         files: \.rs$
         pass_filenames: false

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ build:
 # Run all the tests.
 test language="[rust|python]" : (_run_lang language \
         "uv run cargo test --all-features" \
-        "uv run maturin develop && uv run pytest"
+        "uv run maturin develop --uv && uv run pytest"
     )
 
 # Auto-fix all clippy warnings.

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ build:
 
 # Run all the tests.
 test language="[rust|python]" : (_run_lang language \
-        "uv run cargo test --all-features --workspace" \
+        "uv run cargo test --all-features" \
         "uv run maturin develop && uv run pytest"
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,6 @@
 version = 1
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
-    "python_full_version < '3.13'",
-    "python_full_version >= '3.13'",
 ]
 
 [manifest]
@@ -784,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "tket2"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "tket2-py" }
 dependencies = [
     { name = "hugr" },


### PR DESCRIPTION
`tket2-py` does not have rust tests.
Running `cargo test --workspace` on a clean macos installation fails with linking errors due to pyo3 trying to link python libs.

```
note: ld: warning: search path '/install/lib' not found
          ld: library 'python3.12' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This seems to be a known [issue with pyo3](https://pyo3.rs/v0.13.2/faq#i-cant-run-cargo-test-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror).

This PR removes the `--workspace` flag on the local test commands. We'll still test the workspace's default members.