### PR TITLE
feat: Support encoding float and sympy ops

### DIFF
--- a/tket2-py/tket2/extensions/_json_defs/tket2/rotation.json
+++ b/tket2-py/tket2/extensions/_json_defs/tket2/rotation.json
@@ -19,7 +19,7 @@
     "from_halfturns": {
       "extension": "tket2.rotation",
       "name": "from_halfturns",
-      "description": "Construct rotation from number of half-turns (would be multiples of π in radians).",
+      "description": "Construct rotation from number of half-turns (would be multiples of π in radians). Returns None if the float is non-finite.",
       "signature": {
         "params": [],
         "body": {

--- a/tket2/src/extension/rotation.rs
+++ b/tket2/src/extension/rotation.rs
@@ -149,7 +149,7 @@ impl MakeOpDef for RotationOp {
     fn description(&self) -> String {
         match self {
             RotationOp::from_halfturns => {
-                "Construct rotation from number of half-turns (would be multiples of π in radians)."
+                "Construct rotation from number of half-turns (would be multiples of π in radians). Returns None if the float is non-finite."
             }
             RotationOp::to_halfturns => {
                 "Convert rotation to number of half-turns (would be multiples of π in radians)."

--- a/tket2/src/serialize/pytket.rs
+++ b/tket2/src/serialize/pytket.rs
@@ -4,6 +4,7 @@ mod decoder;
 mod encoder;
 mod op;
 
+use hugr::std_extensions::arithmetic::float_types::ConstF64;
 use hugr::types::Type;
 
 use hugr::Node;
@@ -300,15 +301,21 @@ fn try_param_to_constant(param: &str) -> Option<Value> {
     ConstRotation::new(half_turns).ok().map(Into::into)
 }
 
-/// Convert a HUGR angle constant to a TKET1 parameter.
+/// Convert a HUGR rotation or float constant to a TKET1 parameter.
 ///
 /// Angle parameters in TKET1 are encoded as a number of half-turns,
 /// whereas HUGR uses radians.
 #[inline]
 fn try_constant_to_param(val: &Value) -> Option<String> {
-    let const_angle = val.get_custom_value::<ConstRotation>()?;
-    let half_turns = const_angle.half_turns();
-    Some(half_turns.to_string())
+    if let Some(const_angle) = val.get_custom_value::<ConstRotation>() {
+        let half_turns = const_angle.half_turns();
+        Some(half_turns.to_string())
+    } else if let Some(const_float) = val.get_custom_value::<ConstF64>() {
+        let float = const_float.value();
+        Some(float.to_string())
+    } else {
+        None
+    }
 }
 
 /// A hashed register, used to identify registers in the [`Tk1Decoder::register_wire`] map,

--- a/tket2/src/serialize/pytket/op.rs
+++ b/tket2/src/serialize/pytket/op.rs
@@ -47,8 +47,12 @@ impl Tk1Op {
             }
             Ok(Some(Tk1Op::Native(native)))
         } else {
-            let opaque = OpaqueTk1Op::try_from_tket2(&op)?;
-            Ok(opaque.map(Tk1Op::Opaque))
+            // Unrecognised opaque operation. If it's an opaque tket1 op, return it.
+            // Otherwise, it's an unsupported operation and we should fail.
+            match OpaqueTk1Op::try_from_tket2(&op)? {
+                Some(opaque) => Ok(Some(Tk1Op::Opaque(opaque))),
+                None => Err(OpConvertError::UnsupportedOpSerialization(op.clone())),
+            }
         }
     }
 


### PR DESCRIPTION
So we can encode circuits that either encode sympy expressions, or use the float extension to manipulate the rotations.

Note that this does not yet support `RotationOps::from_halfturns`, since that returns an `Option<Rotation>` since unwrapping that requires control flow operations, so the parameter encoder would need to do constant propagation with parameters across control flow...

drive-by: Mention that `RotationOps::from_halfturns` is fallible in its description. This required a non-breaking update to the extension's `json` definition.