### PR TITLE
feat: Add `tket2.rotation.from_halfturns_unchecked` op

### DIFF
--- a/tket2-py/tket2/extensions/_json_defs/tket2/rotation.json
+++ b/tket2-py/tket2/extensions/_json_defs/tket2/rotation.json
@@ -55,6 +55,36 @@
       },
       "binary": false
     },
+    "from_halfturns_unchecked": {
+      "extension": "tket2.rotation",
+      "name": "from_halfturns_unchecked",
+      "description": "Construct rotation from number of half-turns (would be multiples of π in radians). Panics if the float is non-finite.",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "tket2.rotation",
+              "id": "rotation",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
     "radd": {
       "extension": "tket2.rotation",
       "name": "radd",

--- a/tket2/src/extension/rotation.rs
+++ b/tket2/src/extension/rotation.rs
@@ -110,8 +110,12 @@ impl CustomConst for ConstRotation {
 #[non_exhaustive]
 /// Rotation operations
 pub enum RotationOp {
-    /// Construct rotation from number of half-turns (would be multiples of π in radians).
+    /// Construct rotation from a floating point number of half-turns (would be multiples of π in radians).
+    /// Returns an Option, failing when the input is NaN or infinite.
     from_halfturns,
+    /// Construct rotation from a floating point number of half-turns (would be multiples of π in radians).
+    /// Panics if the input is NaN or infinite.
+    from_halfturns_unchecked,
     /// Convert rotation to number of half-turns (would be multiples of π in radians).
     to_halfturns,
     /// Add two angles together (experimental, may be removed, use float addition
@@ -135,6 +139,9 @@ impl MakeOpDef for RotationOp {
                 type_row![FLOAT64_TYPE],
                 Type::from(option_type(type_row![ROTATION_TYPE])),
             ),
+            RotationOp::from_halfturns_unchecked => {
+                Signature::new(type_row![FLOAT64_TYPE], type_row![ROTATION_TYPE])
+            }
             RotationOp::to_halfturns => {
                 Signature::new(type_row![ROTATION_TYPE], type_row![FLOAT64_TYPE])
             }
@@ -150,6 +157,9 @@ impl MakeOpDef for RotationOp {
         match self {
             RotationOp::from_halfturns => {
                 "Construct rotation from number of half-turns (would be multiples of π in radians). Returns None if the float is non-finite."
+            }
+            RotationOp::from_halfturns_unchecked => {
+                "Construct rotation from number of half-turns (would be multiples of π in radians). Panics if the float is non-finite."
             }
             RotationOp::to_halfturns => {
                 "Convert rotation to number of half-turns (would be multiples of π in radians)."
@@ -193,14 +203,21 @@ pub(super) fn add_to_extension(extension: &mut Extension) {
 /// An extension trait for [Dataflow] providing methods to add
 /// "tket2.rotation" operations.
 pub trait RotationOpBuilder: Dataflow {
-    /// Add a "tket2.rotation.fromturns" op.
+    /// Add a "tket2.rotation.from_halfturns" op.
     fn add_from_halfturns(&mut self, turns: Wire) -> Result<Wire, BuildError> {
         Ok(self
             .add_dataflow_op(RotationOp::from_halfturns, [turns])?
             .out_wire(0))
     }
 
-    /// Add a "tket2.rotation.toturns" op.
+    /// Add a "tket2.rotation.from_halfturns_unchecked" op.
+    fn add_from_halfturns_unchecked(&mut self, turns: Wire) -> Result<Wire, BuildError> {
+        Ok(self
+            .add_dataflow_op(RotationOp::from_halfturns_unchecked, [turns])?
+            .out_wire(0))
+    }
+
+    /// Add a "tket2.rotation.to_halfturns" op.
     fn add_to_halfturns(&mut self, rotation: Wire) -> Result<Wire, BuildError> {
         Ok(self
             .add_dataflow_op(RotationOp::to_halfturns, [rotation])?
@@ -262,15 +279,16 @@ mod test {
     fn test_builder() {
         let mut builder = DFGBuilder::new(Signature::new(
             ROTATION_TYPE,
-            Type::from(option_type(ROTATION_TYPE)),
+            vec![Type::from(option_type(ROTATION_TYPE)), ROTATION_TYPE],
         ))
         .unwrap();
 
         let [rotation] = builder.input_wires_arr();
         let turns = builder.add_to_halfturns(rotation).unwrap();
         let mb_rotation = builder.add_from_halfturns(turns).unwrap();
+        let unwrapped_rotation = builder.add_from_halfturns_unchecked(turns).unwrap();
         let _hugr = builder
-            .finish_hugr_with_outputs([mb_rotation], &REGISTRY)
+            .finish_hugr_with_outputs([mb_rotation, unwrapped_rotation], &REGISTRY)
             .unwrap();
     }
 

--- a/tket2/src/serialize/pytket/encoder.rs
+++ b/tket2/src/serialize/pytket/encoder.rs
@@ -579,8 +579,6 @@ impl ParameterTracker {
         let input_count = if let Some(signature) = optype.dataflow_signature() {
             // Only consider commands where all inputs and some outputs are
             // parameters that we can track.
-            //
-            // TODO: We should track Option<T> parameters too, `RotationOp::from_halfturns` returns options.
             const TRACKED_PARAMS: [Type; 2] = [ROTATION_TYPE, FLOAT64_TYPE];
             let all_inputs = signature
                 .input()
@@ -691,7 +689,9 @@ impl ParameterTracker {
             // Note that the tracked parameter strings are always written in half-turns,
             // so the conversion here is a no-op.
             RotationOp::to_halfturns => inputs[0].clone(),
-            RotationOp::from_halfturns => inputs[0].clone(),
+            RotationOp::from_halfturns_unchecked => inputs[0].clone(),
+            // The checked conversion returns an option, which we do not support.
+            RotationOp::from_halfturns => return None,
         };
         Some(s)
     }


### PR DESCRIPTION
This is an operation that we are able to process while encoding pytket circuits.
We expect guppy to emit this instead of adding explicit panics to unwrap the fallible result.

The pytket encoder should now support float wires.

Closes #630
I'll open a followup issue on guppy