### PR TITLE
feat: Decode pytket op parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +389,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +472,16 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "csv"
@@ -550,6 +578,16 @@ dependencies = [
  "quote",
  "syn 2.0.71",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -731,6 +769,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1227,6 +1275,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,6 +1753,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +2016,8 @@ dependencies = [
  "lazy_static",
  "num-complex",
  "num-rational",
+ "pest",
+ "pest_derive",
  "petgraph",
  "portgraph 0.12.2",
  "portmatching",
@@ -2050,6 +2156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059d83cc991e7a42fc37bd50941885db0888e34209f8cfd9aab07ddec03bc9cf"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "typetag"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2184,12 @@ dependencies = [
  "quote",
  "syn 2.0.71",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"
@@ -2149,6 +2267,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ num-complex = "0.4"
 num-rational = "0.4"
 num_cpus = "1.16.0"
 peak_alloc = "0.2.0"
+pest = "2.7.13"
+pest_derive = "2.7.13"
 petgraph = { version = "0.6.3", default-features = false }
 priority-queue = "2.1.1"
 rayon = "1.5"

--- a/tket2/Cargo.toml
+++ b/tket2/Cargo.toml
@@ -68,6 +68,8 @@ chrono = { workspace = true }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }
 tracing = { workspace = true }
+pest = { workspace = true }
+pest_derive = { workspace = true }
 zstd = { workspace = true, optional = true }
 # Required to acces the `Package` type.
 # Remove once https://github.com/CQCL/hugr/issues/1530 is fixed.

--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -717,8 +717,6 @@ mod tests {
         assert_eq!(circ.circuit_signature().input_count(), qubits + bits);
         assert_eq!(circ.circuit_signature().output_count(), qubits + bits);
         assert_eq!(circ.qubit_count(), qubits);
-        assert_eq!(circ.num_operations(), 3);
-        assert_eq!(circ.operations().count(), 3);
 
         assert_eq!(circ.units().count(), qubits + bits);
         assert_eq!(circ.nonlinear_units().count(), bits);

--- a/tket2/src/ops.rs
+++ b/tket2/src/ops.rs
@@ -173,8 +173,8 @@ impl Tk2Op {
 }
 
 /// Initialize a new custom symbolic expression constant op from a string.
-pub fn symbolic_constant_op(arg: &str) -> OpType {
-    SympyOpDef.with_expr(arg.to_string()).into()
+pub fn symbolic_constant_op(arg: String) -> OpType {
+    SympyOpDef.with_expr(arg).into()
 }
 
 /// match against a symbolic constant

--- a/tket2/src/ops.rs
+++ b/tket2/src/ops.rs
@@ -173,8 +173,8 @@ impl Tk2Op {
 }
 
 /// Initialize a new custom symbolic expression constant op from a string.
-pub fn symbolic_constant_op(arg: String) -> OpType {
-    SympyOpDef.with_expr(arg).into()
+pub fn symbolic_constant_op(arg: &str) -> OpType {
+    SympyOpDef.with_expr(arg.to_string()).into()
 }
 
 /// match against a symbolic constant

--- a/tket2/src/serialize/pytket/decoder.rs
+++ b/tket2/src/serialize/pytket/decoder.rs
@@ -385,9 +385,6 @@ impl LoadedParameter {
         typ: LoadedParameterType,
         hugr: &mut FunctionBuilder<Hugr>,
     ) -> LoadedParameter {
-        if self.typ == typ {
-            return *self;
-        }
         match (self.typ, typ) {
             (LoadedParameterType::Float, LoadedParameterType::Rotation) => {
                 let wire = hugr
@@ -403,7 +400,10 @@ impl LoadedParameter {
                     .out_wire(0);
                 LoadedParameter::float(wire)
             }
-            _ => unreachable!("cannot convert {} to {}", self.typ, typ),
+            _ => {
+                debug_assert_eq!(self.typ, typ, "cannot convert {} to {}", self.typ, typ);
+                *self
+            }
         }
     }
 

--- a/tket2/src/serialize/pytket/decoder.rs
+++ b/tket2/src/serialize/pytket/decoder.rs
@@ -349,6 +349,9 @@ enum LoadedParameterType {
 }
 
 /// A loaded parameter in the Hugr.
+///
+/// Tracking the type of the wire lets us delay conversion between the types
+/// until they are actually needed.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 struct LoadedParameter {
     /// The type of the parameter.

--- a/tket2/src/serialize/pytket/decoder.rs
+++ b/tket2/src/serialize/pytket/decoder.rs
@@ -24,7 +24,7 @@ use super::{
     METADATA_B_REGISTERS, METADATA_OPGROUP, METADATA_PHASE, METADATA_Q_OUTPUT_REGISTERS,
     METADATA_Q_REGISTERS,
 };
-use crate::extension::rotation::{ConstRotation, RotationOp};
+use crate::extension::rotation::RotationOp;
 use crate::extension::{REGISTRY, TKET1_EXTENSION_ID};
 use crate::symbolic_constant_op;
 
@@ -282,13 +282,15 @@ impl Tk1Decoder {
                 PytketParam::InputVariable { name } => {
                     // Special case for the name "pi", inserts a `ConstRotation::PI` instead.
                     if name == "pi" {
-                        let value: Value = ConstRotation::PI.into();
+                        let value: Value = ConstF64::new(std::f64::consts::PI).into();
                         let wire = hugr.add_load_const(value);
-                        return LoadedParameter::rotation(wire);
+                        return LoadedParameter::float(wire);
                     }
 
                     // TODO: We need to add a `FunctionBuilder::add_input` function on the hugr side.
                     //       Here we just add an opaque sympy box instead.
+                    //       https://github.com/CQCL/hugr/issues/1562
+                    //       https://github.com/CQCL/tket2/issues/628
                     process(hugr, PytketParam::Sympy(name), param)
                 }
                 PytketParam::Operation { op, args } => {

--- a/tket2/src/serialize/pytket/decoder.rs
+++ b/tket2/src/serialize/pytket/decoder.rs
@@ -275,7 +275,7 @@ impl Tk1Decoder {
                 }
                 PytketParam::Sympy(expr) => {
                     // store string in custom op.
-                    let symb_op = symbolic_constant_op(expr);
+                    let symb_op = symbolic_constant_op(expr.to_string());
                     let wire = hugr.add_dataflow_op(symb_op, []).unwrap().out_wire(0);
                     LoadedParameter::rotation(wire)
                 }

--- a/tket2/src/serialize/pytket/op/native.rs
+++ b/tket2/src/serialize/pytket/op/native.rs
@@ -3,6 +3,7 @@
 use hugr::extension::prelude::{Noop, BOOL_T, QB_T};
 
 use hugr::ops::{OpTrait, OpType};
+use hugr::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
 use hugr::types::Signature;
 
 use hugr::IncomingPort;
@@ -159,7 +160,7 @@ impl NativeOp {
             let types = sig.input_types().to_owned();
             sig.input_ports()
                 .zip(types)
-                .filter(|(_, ty)| ty == &ROTATION_TYPE)
+                .filter(|(_, ty)| [ROTATION_TYPE, FLOAT64_TYPE].contains(ty))
                 .map(|(port, _)| port)
         })
     }
@@ -179,7 +180,7 @@ impl NativeOp {
                 self.input_qubits += 1;
             } else if ty == &BOOL_T {
                 self.input_bits += 1;
-            } else if ty == &ROTATION_TYPE {
+            } else if [ROTATION_TYPE, FLOAT64_TYPE].contains(ty) {
                 self.num_params += 1;
             }
         }

--- a/tket2/src/serialize/pytket/param.rs
+++ b/tket2/src/serialize/pytket/param.rs
@@ -1,0 +1,4 @@
+//! Encoding and decoding pytket operation parameters as hugr ops.
+
+pub mod decode;
+pub mod encode;

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -54,13 +54,6 @@ pub fn parse_pytket_param(param: &str) -> PytketParam<'_> {
         .next()
         .expect("The `parameter` rule can only be matched once.");
 
-    assert_eq!(
-        parsed.as_rule(),
-        Rule::expr,
-        "`parameter` does not contain rule {:?}",
-        parsed.as_rule()
-    );
-
     parse_infix_ops(parsed.into_inner())
 }
 

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -40,10 +40,7 @@ pub enum PytketParam<'a> {
     },
 }
 
-/// Parse a TKET1 parameter, add
-///
-/// Angle parameters in TKET1 are encoded as a number of half-turns,
-/// whereas HUGR uses radians.
+/// Parse a TKET1 operation parameter, and return an AST representing the expression.
 #[inline]
 pub fn parse_pytket_param(param: &str) -> PytketParam<'_> {
     let Ok(mut parsed) = ParamParser::parse(Rule::parameter, param) else {

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -206,7 +206,7 @@ mod test {
         op: FloatOps::fmax.into(),
         args: vec![PytketParam::Constant(42.), PytketParam::Sympy("unknown_op(37)")]
     })]
-    #[case::precedence("5-2/3x+4", PytketParam::Operation {
+    #[case::precedence("5-2/3x+4**6", PytketParam::Operation {
         op: FloatOps::fadd.into(),
         args: vec![
             PytketParam::Operation {
@@ -222,7 +222,23 @@ mod test {
                     ]}
                 ]
             },
-            PytketParam::Constant(4.)
+            PytketParam::Operation { op: FloatOps::fpow.into(), args: vec![
+                PytketParam::Constant(4.),
+                PytketParam::Constant(6.),
+            ]}
+        ]
+    })]
+    #[case::associativity("1-2-3+4", PytketParam::Operation {
+        op: FloatOps::fadd.into(),
+        args: vec![
+            PytketParam::Operation { op: FloatOps::fsub.into(), args: vec![
+                PytketParam::Operation { op: FloatOps::fsub.into(), args: vec![
+                    PytketParam::Constant(1.),
+                    PytketParam::Constant(2.),
+                ]},
+                PytketParam::Constant(3.),
+            ]},
+            PytketParam::Constant(4.),
         ]
     })]
     fn parse_param(#[case] param: &str, #[case] expected: PytketParam) {

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -21,7 +21,7 @@ use pest_derive::Parser;
 //       Either by implementing a parser, or calling out to python.
 //       For now, we just create a [`SympyOp`].
 #[derive(Debug, Clone, PartialEq)]
-pub(in crate::serialize::pytket) enum PytketParam<'a> {
+pub enum PytketParam<'a> {
     /// A constant value that can be loaded directly.
     Constant(f64),
     /// A variable that should be routed as an input.
@@ -44,7 +44,7 @@ pub(in crate::serialize::pytket) enum PytketParam<'a> {
 /// Angle parameters in TKET1 are encoded as a number of half-turns,
 /// whereas HUGR uses radians.
 #[inline]
-pub(in crate::serialize::pytket) fn parse_pytket_param(param: &str) -> PytketParam<'_> {
+pub fn parse_pytket_param(param: &str) -> PytketParam<'_> {
     let Ok(mut parsed) = ParamParser::parse(Rule::parameter, param) else {
         // The parameter could not be parsed, so we just return it as an opaque sympy expression.
         return PytketParam::Sympy(param);

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -112,6 +112,10 @@ fn parse_term(pair: Pair<'_, Rule>) -> PytketParam<'_> {
     match pair.as_rule() {
         Rule::expr => parse_infix_ops(pair.into_inner()),
         Rule::num => parse_number(pair),
+        Rule::unary_minus => PytketParam::Operation {
+            op: FloatOps::fneg.into(),
+            args: vec![parse_term(pair.into_inner().next().unwrap())],
+        },
         Rule::function_call => parse_function_call(pair),
         Rule::ident => PytketParam::InputVariable {
             name: pair.as_str(),
@@ -182,6 +186,10 @@ mod test {
     #[case::max("max(42, f64)", PytketParam::Operation {
         op: FloatOps::fmax.into(),
         args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+    })]
+    #[case::minus("-f64", PytketParam::Operation {
+        op: FloatOps::fneg.into(),
+        args: vec![PytketParam::InputVariable{name: "f64"}]
     })]
     #[case::unknown("unknown_op(42, f64)", PytketParam::Sympy("unknown_op(42, f64)"))]
     #[case::nested("max(42, unknown_op(37))", PytketParam::Operation {

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -1,4 +1,6 @@
-//! Definitions for decoding parameter expressions from pytket operations
+//! Definitions for decoding parameter expressions from pytket operations.
+//!
+//! This is based on the `pest` grammar defined in `param.pest`.
 
 use hugr::ops::OpType;
 

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -17,10 +17,6 @@ use pest_derive::Parser;
 /// unrecognized sympy expression.
 ///
 /// Return type of [`parse_pytket_param`].
-//
-// TODO: We have to decide how to parse non-trivial sympy expressions.
-//       Either by implementing a parser, or calling out to python.
-//       For now, we just create a [`SympyOp`].
 #[derive(Debug, Display, Clone, PartialEq)]
 pub enum PytketParam<'a> {
     /// A constant value that can be loaded directly.

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -143,29 +143,20 @@ fn parse_function_call(pair: Pair<'_, Rule>) -> PytketParam<'_> {
         .next()
         .expect("Function call must have a name")
         .as_str();
-    let Some(op) = get_optype(name) else {
+    let op = match name {
+        "max" => FloatOps::fmax.into(),
+        "min" => FloatOps::fmin.into(),
+        "abs" => FloatOps::fabs.into(),
+        "floor" => FloatOps::ffloor.into(),
+        "ceil" => FloatOps::fceil.into(),
+        "round" => FloatOps::fround.into(),
         // Unrecognized function name.
         // Treat it as an opaque sympy expression.
-        return PytketParam::Sympy(pair_str);
+        _ => return PytketParam::Sympy(pair_str),
     };
 
     let args = args.map(|arg| parse_term(arg)).collect::<Vec<_>>();
     PytketParam::Operation { op, args }
-}
-
-/// Returns the optype given a function name.
-///
-/// If the function name is not recognized, returns `None`.
-fn get_optype(name: &str) -> Option<OpType> {
-    match name {
-        "max" => Some(FloatOps::fmax.into()),
-        "min" => Some(FloatOps::fmin.into()),
-        "abs" => Some(FloatOps::fabs.into()),
-        "floor" => Some(FloatOps::ffloor.into()),
-        "ceil" => Some(FloatOps::fceil.into()),
-        "round" => Some(FloatOps::fround.into()),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -224,6 +224,7 @@ mod test {
         args: vec![PytketParam::InputVariable{name: "f64"}]
     })]
     #[case::unknown("unknown_op(42, f64)", PytketParam::Sympy("unknown_op(42, f64)"))]
+    #[case::unknown_no_params("unknown_op()", PytketParam::Sympy("unknown_op()"))]
     #[case::nested("max(42, unknown_op(37))", PytketParam::Operation {
         op: FloatOps::fmax.into(),
         args: vec![PytketParam::Constant(42.), PytketParam::Sympy("unknown_op(37)")]

--- a/tket2/src/serialize/pytket/param/decode.rs
+++ b/tket2/src/serialize/pytket/param/decode.rs
@@ -1,0 +1,195 @@
+//! Definitions for decoding parameter expressions from pytket operations
+
+use hugr::ops::OpType;
+
+use hugr::std_extensions::arithmetic::float_ops::FloatOps;
+use pest::iterators::{Pair, Pairs};
+use pest::pratt_parser::PrattParser;
+use pest::Parser;
+use pest_derive::Parser;
+
+/// The parsed AST for a pytket operation parameter.
+///
+/// The leafs of the AST are either a constant value, a variable name, or an
+/// unrecognized sympy expression.
+///
+/// Return type of [`parse_pytket_param`].
+//
+// TODO: We have to decide how to parse non-trivial sympy expressions.
+//       Either by implementing a parser, or calling out to python.
+//       For now, we just create a [`SympyOp`].
+#[derive(Debug, Clone, PartialEq)]
+pub(in crate::serialize::pytket) enum PytketParam<'a> {
+    /// A constant value that can be loaded directly.
+    Constant(f64),
+    /// A variable that should be routed as an input.
+    InputVariable {
+        /// The variable name.
+        name: &'a str,
+    },
+    /// Unrecognized sympy expression.
+    /// Will be emitted as a [`SympyOp`].
+    Sympy(&'a str),
+    /// An operation on some nested expressions.
+    Operation {
+        op: OpType,
+        args: Vec<PytketParam<'a>>,
+    },
+}
+
+/// Parse a TKET1 parameter, add
+///
+/// Angle parameters in TKET1 are encoded as a number of half-turns,
+/// whereas HUGR uses radians.
+#[inline]
+pub(in crate::serialize::pytket) fn parse_pytket_param(param: &str) -> PytketParam<'_> {
+    let Ok(mut parsed) = ParamParser::parse(Rule::parameter, param) else {
+        // The parameter could not be parsed, so we just return it as an opaque sympy expression.
+        return PytketParam::Sympy(param);
+    };
+    let parsed = parsed
+        .next()
+        .expect("The `parameter` rule can only be matched once.");
+
+    assert_eq!(
+        parsed.as_rule(),
+        Rule::expr,
+        "`parameter` does not contain rule {:?}",
+        parsed.as_rule()
+    );
+
+    parse_infix_ops(parsed.into_inner())
+}
+
+#[derive(Parser)]
+#[grammar = "serialize/pytket/param/param.pest"]
+struct ParamParser;
+
+lazy_static::lazy_static! {
+    /// Precedence parser used to define the order of infix operations.
+    ///
+    /// Based on the calculator example from `pest`.
+    /// https://pest.rs/book/examples/calculator.html
+    static ref PRATT_PARSER: PrattParser<Rule> = {
+        use pest::pratt_parser::{Assoc::*, Op};
+        use Rule::*;
+
+        // Precedence is defined lowest to highest
+        PrattParser::new()
+            // Addition and subtract have equal precedence
+            .op(Op::infix(add, Left) | Op::infix(subtract, Left))
+            .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
+            .op(Op::infix(power, Left))
+    };
+}
+
+/// Parse a match of the [`Rule::expr`] rule.
+///
+/// This takes a sequence of rule matches alternating [`Rule::term`]s and infix operations.
+fn parse_infix_ops(pairs: Pairs<'_, Rule>) -> PytketParam<'_> {
+    PRATT_PARSER
+        .map_primary(|primary| parse_term(primary))
+        .map_infix(|lhs, op, rhs| {
+            let op = match op.as_rule() {
+                Rule::add => FloatOps::fadd,
+                Rule::subtract => FloatOps::fsub,
+                Rule::multiply => FloatOps::fmul,
+                Rule::divide => FloatOps::fdiv,
+                Rule::power => FloatOps::fpow,
+                rule => unreachable!("Expr::parse expected infix operation, found {:?}", rule),
+            }
+            .into();
+            PytketParam::Operation {
+                op,
+                args: vec![lhs, rhs],
+            }
+        })
+        .parse(pairs)
+}
+
+/// Parse a match of the silent [`Rule::term`] rule.
+fn parse_term(pair: Pair<'_, Rule>) -> PytketParam<'_> {
+    match pair.as_rule() {
+        Rule::expr => parse_infix_ops(pair.into_inner()),
+        Rule::num => parse_number(pair),
+        Rule::function_call => parse_function_call(pair),
+        Rule::ident => PytketParam::InputVariable {
+            name: pair.as_str(),
+        },
+        rule => unreachable!("Term::parse expected a term, found {:?}", rule),
+    }
+}
+
+/// Parse a match of the [`Rule::num`] rule.
+fn parse_number(pair: Pair<'_, Rule>) -> PytketParam<'_> {
+    let num = pair.as_str();
+    let half_turns = num
+        .parse::<f64>()
+        .unwrap_or_else(|_| panic!("`num` rule matched invalid number \"{num}\""));
+    PytketParam::Constant(half_turns)
+}
+
+/// Parse a match of the [`Rule::function_call`] rule.
+fn parse_function_call(pair: Pair<'_, Rule>) -> PytketParam<'_> {
+    let pair_str = pair.as_str();
+    let mut args = pair.into_inner();
+    let name = args
+        .next()
+        .expect("Function call must have a name")
+        .as_str();
+    let Some(op) = get_optype(name) else {
+        // Unrecognized function name.
+        // Treat it as an opaque sympy expression.
+        return PytketParam::Sympy(pair_str);
+    };
+
+    let args = args.map(|arg| parse_term(arg)).collect::<Vec<_>>();
+    PytketParam::Operation { op, args }
+}
+
+/// Returns the optype given a function name.
+///
+/// If the function name is not recognized, returns `None`.
+fn get_optype(name: &str) -> Option<OpType> {
+    match name {
+        "max" => Some(FloatOps::fmax.into()),
+        "min" => Some(FloatOps::fmin.into()),
+        "abs" => Some(FloatOps::fabs.into()),
+        "floor" => Some(FloatOps::ffloor.into()),
+        "ceil" => Some(FloatOps::fceil.into()),
+        "round" => Some(FloatOps::fround.into()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::int("42", PytketParam::Constant(42.0))]
+    #[case::float("42.37", PytketParam::Constant(42.37))]
+    #[case::float_pointless("37.", PytketParam::Constant(37.))]
+    #[case::exp("42e4", PytketParam::Constant(42e4))]
+    #[case::neg("-42.55", PytketParam::Constant(-42.55))]
+    #[case::parens("(42)", PytketParam::Constant(42.))]
+    #[case::var("f64", PytketParam::InputVariable{name: "f64"})]
+    #[case::add("42 + f64", PytketParam::Operation {
+        op: FloatOps::fadd.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+    })]
+    #[case::max("max(42, f64)", PytketParam::Operation {
+        op: FloatOps::fmax.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+    })]
+    #[case::unknown("unknown_op(42, f64)", PytketParam::Sympy("unknown_op(42, f64)"))]
+    #[case::nested("max(42, unknown_op(37))", PytketParam::Operation {
+        op: FloatOps::fmax.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::Sympy("unknown_op(37)")]
+    })]
+    fn parse_param(#[case] param: &str, #[case] expected: PytketParam) {
+        let parsed = parse_pytket_param(param);
+        assert_eq!(parsed, expected)
+    }
+}

--- a/tket2/src/serialize/pytket/param/encode.rs
+++ b/tket2/src/serialize/pytket/param/encode.rs
@@ -62,6 +62,17 @@ pub fn fold_param_op(optype: &OpType, inputs: &[&str]) -> Option<String> {
 #[inline]
 fn try_constant_to_param(val: &Value) -> Option<String> {
     if let Some(const_angle) = val.get_custom_value::<ConstRotation>() {
+        // Special case for pi rotations
+        if const_angle == &ConstRotation::PI {
+            return Some("pi".to_string());
+        } else if const_angle == &ConstRotation::PI_2 {
+            return Some("pi/2".to_string());
+        } else if const_angle == &ConstRotation::PI_4 {
+            return Some("pi/4".to_string());
+        } else if const_angle == &ConstRotation::TAU {
+            return Some("2pi".to_string());
+        }
+
         let half_turns = const_angle.half_turns();
         Some(half_turns.to_string())
     } else if let Some(const_float) = val.get_custom_value::<ConstF64>() {

--- a/tket2/src/serialize/pytket/param/encode.rs
+++ b/tket2/src/serialize/pytket/param/encode.rs
@@ -14,10 +14,7 @@ use crate::ops::match_symb_const_op;
 /// The folded op must have a single string output.
 ///
 /// Returns `None` if the operation cannot be folded.
-pub(in crate::serialize::pytket) fn fold_param_op(
-    optype: &OpType,
-    inputs: &[&str],
-) -> Option<String> {
+pub fn fold_param_op(optype: &OpType, inputs: &[&str]) -> Option<String> {
     let param = match optype {
         OpType::Const(const_op) => {
             // New constant, register it if it can be interpreted as a parameter.

--- a/tket2/src/serialize/pytket/param/encode.rs
+++ b/tket2/src/serialize/pytket/param/encode.rs
@@ -1,0 +1,122 @@
+//! Definitions for encoding hugr graphs into pytket op parameters.
+
+use hugr::ops::{OpType, Value};
+use hugr::std_extensions::arithmetic::float_ops::FloatOps;
+use hugr::std_extensions::arithmetic::float_types::ConstF64;
+
+use crate::extension::rotation::{ConstRotation, RotationOp};
+use crate::extension::sympy::SympyOp;
+use crate::ops::match_symb_const_op;
+
+/// Fold a rotation or float operation into a string, given the string
+/// representations of its inputs.
+///
+/// The folded op must have a single string output.
+///
+/// Returns `None` if the operation cannot be folded.
+pub(in crate::serialize::pytket) fn fold_param_op(
+    optype: &OpType,
+    inputs: &[&str],
+) -> Option<String> {
+    let param = match optype {
+        OpType::Const(const_op) => {
+            // New constant, register it if it can be interpreted as a parameter.
+            match try_constant_to_param(const_op.value()) {
+                Some(param) => param,
+                None => return None,
+            }
+        }
+        OpType::LoadConstant(_op_type) => {
+            // Re-use the parameter from the input.
+            inputs[0].to_string()
+        }
+        // Encode some angle and float operations directly as strings using
+        // the already encoded inputs. Fail if the operation is not
+        // supported, and let the operation encoding process it instead.
+        OpType::ExtensionOp(_) => {
+            if let Some(s) = optype
+                .cast::<RotationOp>()
+                .and_then(|op| encode_rotation_op(&op, inputs))
+            {
+                s
+            } else if let Some(s) = optype
+                .cast::<FloatOps>()
+                .and_then(|op| encode_float_op(&op, inputs))
+            {
+                s
+            } else if let Some(s) = optype
+                .cast::<SympyOp>()
+                .and_then(|op| encode_sympy_op(&op, inputs))
+            {
+                s
+            } else {
+                return None;
+            }
+        }
+        _ => match_symb_const_op(optype)?.to_string(),
+    };
+    Some(param)
+}
+
+/// Convert a HUGR rotation or float constant to a TKET1 parameter.
+///
+/// Angle parameters in TKET1 are encoded as a number of half-turns,
+/// whereas HUGR uses radians.
+#[inline]
+fn try_constant_to_param(val: &Value) -> Option<String> {
+    if let Some(const_angle) = val.get_custom_value::<ConstRotation>() {
+        let half_turns = const_angle.half_turns();
+        Some(half_turns.to_string())
+    } else if let Some(const_float) = val.get_custom_value::<ConstF64>() {
+        let float = const_float.value();
+        Some(float.to_string())
+    } else {
+        None
+    }
+}
+
+/// Encode an [`RotationOp`]s as a string, given its encoded inputs.
+///
+/// `inputs` contains the expressions to compute each input.
+fn encode_rotation_op(op: &RotationOp, inputs: &[&str]) -> Option<String> {
+    let s = match op {
+        RotationOp::radd => format!("({} + {})", inputs[0], inputs[1]),
+        // Encode/decode the rotation as pytket parameters, expressed as half-turns.
+        // Note that the tracked parameter strings are always written in half-turns,
+        // so the conversion here is a no-op.
+        RotationOp::to_halfturns => inputs[0].to_string(),
+        RotationOp::from_halfturns_unchecked => inputs[0].to_string(),
+        // The checked conversion returns an option, which we do not support.
+        RotationOp::from_halfturns => return None,
+    };
+    Some(s)
+}
+
+/// Encode an [`FloatOps`] as a string, given its encoded inputs.
+fn encode_float_op(op: &FloatOps, inputs: &[&str]) -> Option<String> {
+    let s = match op {
+        FloatOps::fadd => format!("({} + {})", inputs[0], inputs[1]),
+        FloatOps::fsub => format!("({} - {})", inputs[0], inputs[1]),
+        FloatOps::fneg => format!("(-{})", inputs[0]),
+        FloatOps::fmul => format!("({} * {})", inputs[0], inputs[1]),
+        FloatOps::fdiv => format!("({} / {})", inputs[0], inputs[1]),
+        FloatOps::fpow => format!("({} ** {})", inputs[0], inputs[1]),
+        FloatOps::ffloor => format!("floor({})", inputs[0]),
+        FloatOps::fceil => format!("ceil({})", inputs[0]),
+        FloatOps::fround => format!("round({})", inputs[0]),
+        FloatOps::fmax => format!("max({}, {})", inputs[0], inputs[1]),
+        FloatOps::fmin => format!("min({}, {})", inputs[0], inputs[1]),
+        FloatOps::fabs => format!("abs({})", inputs[0]),
+        _ => return None,
+    };
+    Some(s)
+}
+
+/// Encode a [`SympyOp`]s as a string.
+fn encode_sympy_op(op: &SympyOp, inputs: &[&str]) -> Option<String> {
+    if !inputs.is_empty() {
+        return None;
+    }
+
+    Some(op.expr.clone())
+}

--- a/tket2/src/serialize/pytket/param/encode.rs
+++ b/tket2/src/serialize/pytket/param/encode.rs
@@ -62,22 +62,17 @@ pub fn fold_param_op(optype: &OpType, inputs: &[&str]) -> Option<String> {
 #[inline]
 fn try_constant_to_param(val: &Value) -> Option<String> {
     if let Some(const_angle) = val.get_custom_value::<ConstRotation>() {
-        // Special case for pi rotations
-        if const_angle == &ConstRotation::PI {
-            return Some("pi".to_string());
-        } else if const_angle == &ConstRotation::PI_2 {
-            return Some("pi/2".to_string());
-        } else if const_angle == &ConstRotation::PI_4 {
-            return Some("pi/4".to_string());
-        } else if const_angle == &ConstRotation::TAU {
-            return Some("2pi".to_string());
-        }
-
         let half_turns = const_angle.half_turns();
         Some(half_turns.to_string())
     } else if let Some(const_float) = val.get_custom_value::<ConstF64>() {
         let float = const_float.value();
-        Some(float.to_string())
+
+        // Special case for pi rotations
+        if float == std::f64::consts::PI {
+            Some("pi".to_string())
+        } else {
+            Some(float.to_string())
+        }
     } else {
         None
     }

--- a/tket2/src/serialize/pytket/param/param.pest
+++ b/tket2/src/serialize/pytket/param/param.pest
@@ -3,17 +3,22 @@
 //! The grammar is a subset of sympy expressions,
 //! unrecognised expressions will be boxed opaquely.
 
-// operation and variable identifiers
+/// Operation and variable identifiers
+///
+/// The atomic marker `@` ensures no whitespace is present inside.
 ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_" )* }
+/// Alias for `ident`.
 variable = _{ ident }
 
-// Explicit numeric constants.
-positive_num = @{
-    ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
+/// Explicit numeric constants.
+///
+/// The atomic marker `@` ensures no whitespace is present inside.
+num = @{
+    "-"?
+    ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
     ~ ("." ~ ASCII_DIGIT*)?
     ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
 }
-num = @{ "-"? ~ positive_num }
 
 /// Infix operations (e.g. `2 + 2`),
 ///
@@ -24,19 +29,27 @@ infix_operator = _{ add | subtract | multiply | divide | power }
     multiply  = { "*" }
     divide    = { "/" }
     power     = { "**" }
+
 /// Function calls like (`max(2,4)`)
 function_call = { ident ~ ( "()" | "(" ~ expr ~ ("," ~ expr)* ~ ","? ~ ")") }
 /// Unary negation, with a special identifier
 unary_minus = { "-" ~ term }
+
 /// Implicit multiplication lets us write expressions like `2x`.
 /// This has higher precedence that `infix_operator`s.
-/// The second match is a subset of `term`.
+///
+/// The second match is a subset of `term`, picked to avoid ambiguity.
+/// If we used `term` directly, the expression `5-2` could be interpreted as `5 * (-2)`.
 implicit_multiply = { num ~ ("(" ~ expr ~ ")" | function_call | variable) }
 
 /// Expressions are sequences of terms and infix operators
 expr = { term ~ (infix_operator ~ term)* }
+/// A standalone term, with no infix operators at the root.
 term = _{ "(" ~ expr ~ ")" | implicit_multiply | num | unary_minus | function_call | variable }
 
+/// Main entry point of the parser. Ensures we always parse the whole input.
 parameter = _{ SOI ~ expr ~ EOI }
 
+/// Allowed whitespace characters.
+/// Each `~` separator in the preceding rules can contain any number of these (including zero).
 WHITESPACE = _{ " " | "\t" }

--- a/tket2/src/serialize/pytket/param/param.pest
+++ b/tket2/src/serialize/pytket/param/param.pest
@@ -8,14 +8,16 @@ ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_" )* }
 variable = _{ ident }
 
 // Explicit numeric constants.
-num = @{
-    "-"?
-    ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
+positive_num = @{
+    ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
     ~ ("." ~ ASCII_DIGIT*)?
     ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
 }
+num = @{ "-"? ~ positive_num }
 
 /// Infix operations (e.g. `2 + 2`),
+///
+/// The rust parser defines the operator precedence between these.
 infix_operator = _{ add | subtract | multiply | divide | power }
     add       = { "+" }
     subtract  = { "-" }
@@ -26,10 +28,14 @@ infix_operator = _{ add | subtract | multiply | divide | power }
 function_call = { ident ~ "(" ~ expr ~ ("," ~ expr)* ~ ","? ~ ")" }
 /// Unary negation, with a special identifier
 unary_minus = { "-" ~ term }
+/// Implicit multiplication lets us write expressions like `2x`.
+/// This has higher precedence that `infix_operator`s.
+/// The second match is a subset of `term`.
+implicit_multiply = { num ~ ("(" ~ expr ~ ")" | function_call | variable) }
 
 /// Expressions are sequences of terms and infix operators
 expr = { term ~ (infix_operator ~ term)* }
-term = _{ "(" ~ expr ~ ")" | num | unary_minus | function_call | variable }
+term = _{ "(" ~ expr ~ ")" | implicit_multiply | num | unary_minus | function_call | variable }
 
 parameter = _{ SOI ~ expr ~ EOI }
 

--- a/tket2/src/serialize/pytket/param/param.pest
+++ b/tket2/src/serialize/pytket/param/param.pest
@@ -23,12 +23,12 @@ num = @{
 /// Infix operations (e.g. `2 + 2`),
 ///
 /// The rust parser defines the operator precedence between these.
-infix_operator = _{ add | subtract | multiply | divide | power }
+infix_operator = _{ add | subtract | power | multiply | divide }
     add       = { "+" }
     subtract  = { "-" }
+    power     = { "**" }
     multiply  = { "*" }
     divide    = { "/" }
-    power     = { "**" }
 
 /// Function calls like (`max(2,4)`)
 function_call = { ident ~ ( "()" | "(" ~ expr ~ ("," ~ expr)* ~ ","? ~ ")") }

--- a/tket2/src/serialize/pytket/param/param.pest
+++ b/tket2/src/serialize/pytket/param/param.pest
@@ -25,7 +25,7 @@ infix_operator = _{ add | subtract | multiply | divide | power }
     divide    = { "/" }
     power     = { "**" }
 /// Function calls like (`max(2,4)`)
-function_call = { ident ~ "(" ~ expr ~ ("," ~ expr)* ~ ","? ~ ")" }
+function_call = { ident ~ ( "()" | "(" ~ expr ~ ("," ~ expr)* ~ ","? ~ ")") }
 /// Unary negation, with a special identifier
 unary_minus = { "-" ~ term }
 /// Implicit multiplication lets us write expressions like `2x`.

--- a/tket2/src/serialize/pytket/param/param.pest
+++ b/tket2/src/serialize/pytket/param/param.pest
@@ -1,0 +1,34 @@
+//! A parser grammar for pytket operation parameters
+//!
+//! The grammar is a subset of sympy expressions,
+//! unrecognised expressions will be boxed opaquely.
+
+// operation and variable identifiers
+ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_" )* }
+variable = _{ ident }
+
+// Explicit numeric constants.
+num = @{
+    "-"?
+    ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
+    ~ ("." ~ ASCII_DIGIT*)?
+    ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
+}
+
+// Operation can either be infix (e.g. `2 + 2`),
+infix_operator = _{ add | subtract | multiply | divide | power }
+    add       = { "+" }
+    subtract  = { "-" }
+    multiply  = { "*" }
+    divide    = { "/" }
+    power     = { "**" }
+// or function calls like (`max(2,4)`)
+function_call = { ident ~ "(" ~ expr ~ ("," ~ expr)* ~ ","? ~ ")" }
+
+
+expr = { term ~ (infix_operator ~ term)* }
+term = _{ "(" ~ expr ~ ")" | num | function_call | variable }
+
+parameter = _{ SOI ~ expr ~ EOI }
+
+WHITESPACE = _{ " " | "\t" }

--- a/tket2/src/serialize/pytket/param/param.pest
+++ b/tket2/src/serialize/pytket/param/param.pest
@@ -15,19 +15,21 @@ num = @{
     ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
 }
 
-// Operation can either be infix (e.g. `2 + 2`),
+/// Infix operations (e.g. `2 + 2`),
 infix_operator = _{ add | subtract | multiply | divide | power }
     add       = { "+" }
     subtract  = { "-" }
     multiply  = { "*" }
     divide    = { "/" }
     power     = { "**" }
-// or function calls like (`max(2,4)`)
+/// Function calls like (`max(2,4)`)
 function_call = { ident ~ "(" ~ expr ~ ("," ~ expr)* ~ ","? ~ ")" }
+/// Unary negation, with a special identifier
+unary_minus = { "-" ~ term }
 
-
+/// Expressions are sequences of terms and infix operators
 expr = { term ~ (infix_operator ~ term)* }
-term = _{ "(" ~ expr ~ ")" | num | function_call | variable }
+term = _{ "(" ~ expr ~ ")" | num | unary_minus | function_call | variable }
 
 parameter = _{ SOI ~ expr ~ EOI }
 

--- a/tket2/src/serialize/pytket/tests.rs
+++ b/tket2/src/serialize/pytket/tests.rs
@@ -63,8 +63,8 @@ const PARAMETERIZED: &str = r#"{
         "commands": [
             {"args":[["q",[0]]],"op":{"type":"H"}},
             {"args":[["q",[1]],["q",[0]]],"op":{"type":"CX"}},
-            {"args":[["q",[0]]],"op":{"params":["1.5707963267948966/pi"],"type":"Rz"}},
-            {"args": [["q", [0]]], "op": {"params": ["3.141596/pi", "alpha", "0.7853981633974483/pi"], "type": "TK1"}}
+            {"args":[["q",[0]]],"op":{"params":["(1.5707963267948966 / pi)"],"type":"Rz"}},
+            {"args": [["q", [0]]], "op": {"params": ["(3.141596 / pi)", "alpha", "(0.7853981633974483 / pi)"], "type": "TK1"}}
         ],
         "created_qubits": [],
         "discarded_qubits": [],

--- a/tket2/tests/badger_termination.rs
+++ b/tket2/tests/badger_termination.rs
@@ -61,5 +61,5 @@ fn badger_termination(simple_circ: Circuit, nam_4_2: DefaultBadgerOptimiser) {
             ..Default::default()
         },
     );
-    assert_eq!(opt_circ.commands().count(), 11);
+    assert_eq!(opt_circ.commands().count(), 14);
 }


### PR DESCRIPTION
This is an alternative to #635, using pure-rust instead of calling to python so we can keep the pytket decoder on the `tket2` crate.

Improves parsing of pytket operation parameters by defining a grammar and parser for sympy expressions using `pest` (based on the [calculator example](https://pest.rs/book/examples/calculator.html) for infix operation precedence).

- Unrecognized operations are still put inside an opaque `SympyOp`, but that should be easy to change in the future.
- I tested multiple sympy expressions to ensure we are able to parse them, but unrecognized ones will also fallback to `SympyOp`.

This is still missing routing parameters to hugr inputs (#628), as it is blocked by https://github.com/CQCL/hugr/issues/1562.

drive-by: Move the pytket parameter encoding/decoding routines to `::serialize::pytket::param::{de,en}code`.

Closes #637.