### PR TITLE
refactor!: Remove deprecated exports

### DIFF
--- a/tket2/src/extension.rs
+++ b/tket2/src/extension.rs
@@ -21,9 +21,6 @@ pub mod rotation;
 pub mod sympy;
 
 use sympy::SympyOpDef;
-/// Backwards compatible exports.
-/// TODO: Remove in a breaking release.
-pub use sympy::{SYM_EXPR_NAME, SYM_EXPR_T, SYM_OP_ID};
 
 /// The ID of the TKET1 extension.
 pub const TKET1_EXTENSION_ID: ExtensionId = IdentList::new_unchecked("TKET1");

--- a/tket2/src/ops.rs
+++ b/tket2/src/ops.rs
@@ -1,6 +1,6 @@
 use crate::extension::rotation::ROTATION_TYPE;
-use crate::extension::sympy::SympyOpDef;
-use crate::extension::{SYM_OP_ID, TKET2_EXTENSION_ID as EXTENSION_ID};
+use crate::extension::sympy::{SympyOpDef, SYM_OP_ID};
+use crate::extension::TKET2_EXTENSION_ID as EXTENSION_ID;
 use hugr::ops::custom::ExtensionOp;
 use hugr::ops::NamedOp;
 use hugr::{

--- a/tket2/src/optimiser/badger.rs
+++ b/tket2/src/optimiser/badger.rs
@@ -179,7 +179,7 @@ where
         let circ = circ.to_owned();
         let mut best_circ = circ.clone();
         let mut best_circ_cost = self.cost(&circ);
-        let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.len());
+        let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.count());
         logger.log_best(&best_circ_cost, num_rewrites);
 
         // Hash of seen circuits. Dot not store circuits as this map gets huge
@@ -203,7 +203,7 @@ where
             if cost < best_circ_cost {
                 best_circ = circ.clone();
                 best_circ_cost = cost.clone();
-                let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.len());
+                let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.count());
                 logger.log_best(&best_circ_cost, num_rewrites);
                 last_best_time = Instant::now();
             }
@@ -338,7 +338,7 @@ where
                             if cost < best_circ_cost {
                                 best_circ = circ;
                                 best_circ_cost = cost;
-                                let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.len());
+                                let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.count());
                                 logger.log_best(&best_circ_cost, num_rewrites);
                                 if let Some(t) = opt.progress_timeout {
                                     progress_timeout_event = crossbeam_channel::at(Instant::now() + Duration::from_secs(t));
@@ -387,7 +387,7 @@ where
                     if cost < best_circ_cost {
                         best_circ = circ;
                         best_circ_cost = cost;
-                        let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.len());
+                        let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.count());
                         logger.log_best(&best_circ_cost, num_rewrites);
                     }
                 }
@@ -437,7 +437,7 @@ where
         let mut chunks =
             CircuitChunks::split_with_cost(&circ, max_chunk_cost, |op| self.strategy.op_cost(op));
 
-        let num_rewrites = circ.rewrite_trace().map(|rs| rs.len());
+        let num_rewrites = circ.rewrite_trace().map(|rs| rs.count());
         logger.log_best(circ_cost.clone(), num_rewrites);
 
         let (joins, rx_work): (Vec<_>, Vec<_>) = chunks
@@ -477,7 +477,7 @@ where
         let best_circ = chunks.reassemble()?;
         let best_circ_cost = self.cost(&best_circ);
         if best_circ_cost.clone() < circ_cost {
-            let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.len());
+            let num_rewrites = best_circ.rewrite_trace().map(|rs| rs.count());
             logger.log_best(best_circ_cost.clone(), num_rewrites);
         }
 

--- a/tket2/src/passes/commutation.rs
+++ b/tket2/src/passes/commutation.rs
@@ -281,14 +281,9 @@ impl Rewrite for PullForward {
     }
 
     fn invalidation_set(&self) -> impl Iterator<Item = Node> {
-        // TODO: This could avoid creating a vec, but it'll be easier to do once
-        // return position impl trait is available.
-        // This is done in the Rewrite trait of hugr so once that version
-        // is released, it can be updated here
-        let mut nodes = vec![self.command.node()];
+        let cmd_node = std::iter::once(self.command.node());
         let next_nodes = self.new_nexts.values().map(|c| c.node());
-        nodes.extend(next_nodes);
-        nodes.into_iter()
+        cmd_node.chain(next_nodes)
     }
 }
 

--- a/tket2/src/rewrite/strategy.rs
+++ b/tket2/src/rewrite/strategy.rs
@@ -349,20 +349,6 @@ impl LexicographicCostFunction<fn(&OpType) -> usize, 2> {
         Self::cx_count().into_greedy_strategy()
     }
 
-    /// Non-increasing rewrite strategy based on CX count.
-    ///
-    /// A fine-grained cost function given by the total number of quantum gates
-    /// is used to rank circuits with equal CX count.
-    ///
-    /// This is probably a good default for NISQ-y circuit optimisation.
-    ///
-    /// Deprecated: Use `default_cx_strategy` instead.
-    // TODO: Remove this method in the next breaking release.
-    #[deprecated(since = "0.5.1", note = "Use `default_cx_strategy` instead.")]
-    pub fn default_cx() -> ExhaustiveGreedyStrategy<Self> {
-        Self::default_cx_strategy()
-    }
-
     /// Non-increasing rewrite cost function based on CX gate count.
     ///
     /// A fine-grained cost function given by the total number of quantum gates

--- a/tket2/src/rewrite/strategy.rs
+++ b/tket2/src/rewrite/strategy.rs
@@ -514,11 +514,11 @@ mod tests {
         let mut circ = n_cx(10);
         let cx_gates = circ.commands().map(|cmd| cmd.node()).collect_vec();
 
-        assert_eq!(circ.rewrite_trace(), None);
+        assert!(circ.rewrite_trace().is_none());
         circ.enable_rewrite_tracing();
         match REWRITE_TRACING_ENABLED {
-            true => assert_eq!(circ.rewrite_trace(), Some(vec![])),
-            false => assert_eq!(circ.rewrite_trace(), None),
+            true => assert_eq!(circ.rewrite_trace().unwrap().collect_vec(), []),
+            false => assert!(circ.rewrite_trace().is_none()),
         }
 
         let rws = [
@@ -534,7 +534,7 @@ mod tests {
         assert_eq!(rewritten[0].circ.num_operations(), 5);
 
         if REWRITE_TRACING_ENABLED {
-            assert_eq!(rewritten[0].circ.rewrite_trace().unwrap().len(), 3);
+            assert_eq!(rewritten[0].circ.rewrite_trace().unwrap().count(), 3);
         }
     }
 
@@ -561,15 +561,15 @@ mod tests {
             // Each strategy branch applies a single rewrite, composed of
             // multiple individual elements from `rws`.
             assert_eq!(
-                rewritten[0].circ.rewrite_trace().unwrap(),
+                rewritten[0].circ.rewrite_trace().unwrap().collect_vec(),
                 vec![RewriteTrace::new(3)]
             );
             assert_eq!(
-                rewritten[1].circ.rewrite_trace().unwrap(),
+                rewritten[1].circ.rewrite_trace().unwrap().collect_vec(),
                 vec![RewriteTrace::new(2)]
             );
             assert_eq!(
-                rewritten[2].circ.rewrite_trace().unwrap(),
+                rewritten[2].circ.rewrite_trace().unwrap().collect_vec(),
                 vec![RewriteTrace::new(1)]
             );
         }

--- a/tket2/src/rewrite/trace.rs
+++ b/tket2/src/rewrite/trace.rs
@@ -112,15 +112,13 @@ impl<T: HugrMut> Circuit<T> {
     /// Returns the traces of rewrites applied to the circuit.
     ///
     /// Returns `None` if rewrite tracing is not enabled for this circuit.
-    //
-    // TODO return an `impl Iterator` once rust 1.75 lands.
     #[inline]
-    pub fn rewrite_trace(&self) -> Option<Vec<RewriteTrace>> {
+    pub fn rewrite_trace(&self) -> Option<impl Iterator<Item = RewriteTrace> + '_> {
         if !REWRITE_TRACING_ENABLED {
             return None;
         }
         let meta = self.hugr().get_metadata(self.parent(), METADATA_REWRITES)?;
         let rewrites = meta.as_array()?;
-        Some(rewrites.iter().map_into().collect_vec())
+        Some(rewrites.iter().map_into())
     }
 }


### PR DESCRIPTION
Drops some deprecated exports.

drive-by: Remove a couple TODOs about impl iterators.

BREAKING CHANGE: Renamed `LexicographicCostFunction::default_cx` to `LexicographicCostFunction::default_cx_strategy`. Removed sympy constant re-exports in `sympy::extension`. 