### PR TITLE
ci: Use `uv --frozen` instead of `--locked`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ env:
   RUSTC_WRAPPER: "sccache"
   # Pinned version for the uv package manager
   UV_VERSION: "0.4.20"
+  UV_FROZEN: 1
   # The highest and lowest supported Python versions, used for testing
   PYTHON_HIGHEST: "3.12"
   PYTHON_LOWEST: "3.10"
@@ -95,7 +96,7 @@ jobs:
       - name: Install Python ${{ env.PYTHON_HIGHEST }}
         run: uv python install ${{ env.PYTHON_HIGHEST }}
       - name: Setup dependencies
-        run: uv sync --locked --python ${{ env.PYTHON_HIGHEST }}
+        run: uv sync --python ${{ env.PYTHON_HIGHEST }}
       - name: Type check with mypy
         run: uv run mypy .
       - name: Check formatting with ruff
@@ -244,7 +245,7 @@ jobs:
       - name: Install Python ${{ env.PYTHON_LOWEST }}
         run: uv python install ${{ env.PYTHON_LOWEST }}
       - name: Setup dependencies
-        run: uv sync --locked --python ${{ env.PYTHON_LOWEST }}
+        run: uv sync --python ${{ env.PYTHON_LOWEST }}
       - name: Run python tests with coverage instrumentation
         run: uv run pytest --cov=./ --cov-report=xml
       - name: Upload coverage output artifact


### PR DESCRIPTION
We'll try to use the current lock file, instead of failing if the uv.lock get's update (by e.g. a minor dependency bump)