### PR TITLE
refactor: setup pypi trusted publishing

### DIFF
--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -26,11 +26,15 @@ jobs:
   build-publish:
     name: Package and publish wheels
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     strategy:
       matrix:
         target:
-          - { dir: tket2-eccs, name: tket2_eccs, key_secret: PYPI_PUBLISH_TKET2_ECCS }
-          - { dir: tket2-exts, name: tket2_exts, key_secret: PYPI_PUBLISH_TKET2_EXTS }
+          - { dir: tket2-eccs, name: tket2_eccs}
+          - { dir: tket2-exts, name: tket2_exts}
     steps:
       # Check the release tag against the package name
       #
@@ -79,7 +83,7 @@ jobs:
           uv run -f dist --with ${{ matrix.target.name }} --refresh-package ${{ matrix.target.name }} --no-project -- python -c "import ${{ matrix.target.name }}"
           uvx twine check --strict dist/*
 
-      - name: Publish to PyPI
+      - name: Report 
         if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) ) }}
         run: |
           echo "Publishing to PyPI..."
@@ -87,8 +91,9 @@ jobs:
           echo "  - event_name: ${{ github.event_name }}"
           echo "  - ref_type: ${{ github.ref_type }}"
           echo "  - ref: ${{ github.ref }}"
-          uvx twine upload --skip-existing --verbose dist/*
-        env:
-          TWINE_NON_INTERACTIVE: 1
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets[matrix.target.key_secret] }}
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          skip-existing: true

--- a/tket2-exts/README.md
+++ b/tket2-exts/README.md
@@ -8,7 +8,8 @@
   [py-version]: https://img.shields.io/pypi/pyversions/tket2-exts
   [pypi]: https://img.shields.io/pypi/v/tket2-exts
 
-This is an auxiliary Python package containing HUGR extension definitions for `tket2`.
+This is an auxiliary Python package containing HUGR extension definitions for `tket2`
+operations and types.
 
 This package is intended to be used as an internal dependency for `tket2`.
 See https://pypi.org/project/tket2/ for the main package.


### PR DESCRIPTION
contains a trivial readme change so I can test publishing a patch update to tket2-exts

https://docs.pypi.org/trusted-publishers/using-a-publisher/

https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment