### PR TITLE
ci: Fix py coverage not getting uploaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.python == 'true' }}
     runs-on: ubuntu-latest
-    name: tests (Python)
+    name: tests (Python, coverage)
     steps:
       - uses: actions/checkout@v4
       - uses: mozilla-actions/sccache-action@v0.0.6
@@ -249,29 +249,12 @@ jobs:
         run: uv sync --python ${{ env.PYTHON_LOWEST }}
       - name: Run python tests with coverage instrumentation
         run: uv run pytest --cov=./ --cov-report=xml
-      - name: Upload coverage output artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: py-coverage
-          path: coverage.xml
-
-  coverage-py:
-    name: Upload Python coverage 🐍
-    needs: [changes, tests-py, check-py]
-    # Run only if there are changes in the relevant files and the check job passed or was skipped
-    if: needs.changes.outputs.python == 'true' && github.event_name != 'merge_group'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: py-coverage
-          path: coverage.xml
       - name: Upload python coverage to codecov.io
+        if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
-          # Avoids matching against a "coverage.xml" directory from the artifact download
+          # Ensures we only upload this file
           disable_search: true
           name: python
           flags: python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
           files: coverage.json
           name: rust
           flags: rust
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   rs-semver-checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
     name: Upload Python coverage 🐍
     needs: [changes, tests-py, check-py]
     # Run only if there are changes in the relevant files and the check job passed or was skipped
-    if: always() && !failure() && !cancelled() && needs.changes.outputs.python == 'true' && github.event_name != 'merge_group'
+    if: needs.changes.outputs.python == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -269,9 +269,12 @@ jobs:
       - name: Upload python coverage to codecov.io
         uses: codecov/codecov-action@v4
         with:
-          files: coverage.xml
+          files: ./coverage.xml
+          # Avoids matching against a "coverage.xml" directory from the artifact download
+          disable_search: true
           name: python
           flags: python
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # Ensure that serialized extensions match rust implementation

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Codecov coverage report configuration
+
+# Ignore tests and binaries
+ignore:
+  - "tket2-py/test"
+  - "scripts"
+  - "test_files"
+
+# Coverage groups config
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    # Use previous coverage if one is not available for the current commit.
+    #
+    # (E.g. if the PR doesn't modify a subproject, we don't submit a coverage report for it.)
+    carryforward: true


### PR DESCRIPTION
At some point it seems the python coverage step started failing ~~due to some invalid auto-discovered coverage files (I think `download-artifact` creates a directory with the file's name, and we ended up with a `IsADirectoryError`)~~.
https://github.com/CQCL/tket2/actions/runs/11706568650/job/32604131200?pr=680#step:4:57

This change tries to fix that by disabling the automatic discovery, and makes the step fail if the upload fails in the future.

drive-by: Copy `codecov.yml` config from hugr