### PR TITLE
ci: run semver-checks on a `pull_request_target` trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - main
+      - '*'
   merge_group:
     types: [checks_requested]
   workflow_dispatch: {}
@@ -220,13 +220,6 @@ jobs:
           flags: rust
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  rs-semver-checks:
-    needs: [changes, check-rs]
-    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request' }}
-    uses: CQCL/hugrverse-actions/.github/workflows/rs-semver-checks.yml@main
-    secrets:
-      GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}
 
   tests-py:
     needs: changes

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,0 +1,47 @@
+name: Rust Semver Checks
+on:
+  pull_request_target:
+    branches:
+      - main
+
+jobs:
+  # Check if changes were made to the relevant files.
+  # Always returns true if running on the default branch, to ensure all changes are throughly checked.
+  changes:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    # These outputs are always true when running after a merge to main, or if the PR has a `run-ci-checks` label.
+    outputs:
+      rust: ${{ steps.filter.outputs.rust == 'true' || steps.override.outputs.out == 'true' }}
+      python: ${{ steps.filter.outputs.python == 'true' || steps.override.outputs.out == 'true' }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Override label
+      id: override
+      run: |
+        echo "Label contains run-ci-checks: $OVERRIDE_LABEL"
+        if [ "$OVERRIDE_LABEL" == "true" ]; then
+          echo "Overriding due to label 'run-ci-checks'"
+          echo "out=true" >> $GITHUB_OUTPUT
+        elif [ "$DEFAULT_BRANCH" == "true" ]; then
+          echo "Overriding due to running on the default branch"
+          echo "out=true" >> $GITHUB_OUTPUT
+        fi
+      env:
+        OVERRIDE_LABEL: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'run-ci-checks') }}
+        DEFAULT_BRANCH: ${{ github.ref_name == github.event.repository.default_branch }}
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: .github/change-filters.yml
+
+  rs-semver-checks:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    uses: CQCL/hugrverse-actions/.github/workflows/rs-semver-checks.yml@main
+    secrets:
+      GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}


### PR DESCRIPTION
Fixes the errors we've seen with dependabot PRs (and fork PRs) failing the checks.
See https://github.com/CQCL/hugrverse-actions/issues/20

drive-by: Trigger the normal CI checks on any pull request, not only the ones targeting `main`