### PR TITLE
refactor!: update to hugr 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,8 +858,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c5f880029c2ec70b4884f69cd5fd55c628e58830e9225a82bcea7f776ac963"
+source = "git+https://github.com/CQCL/hugr.git#c5c8a6fed22fb8aad6ac689632e0952dfcb8b94e"
 dependencies = [
  "hugr-core",
  "hugr-passes",
@@ -868,8 +867,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617a0bf998c9f809eb634a8381896a60a4d7ae418d3db2eb1c661a083c3dd16f"
+source = "git+https://github.com/CQCL/hugr.git#c5c8a6fed22fb8aad6ac689632e0952dfcb8b94e"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -884,13 +882,11 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6428f0512a92cc3495e70c709383464bf1deef7ac566f812575e28dad52273"
+source = "git+https://github.com/CQCL/hugr.git#c5c8a6fed22fb8aad6ac689632e0952dfcb8b94e"
 dependencies = [
  "bitvec",
  "bumpalo",
  "cgmath",
- "context-iterators",
  "delegate 0.13.1",
  "derive_more 1.0.0",
  "downcast-rs",
@@ -918,8 +914,7 @@ dependencies = [
 [[package]]
 name = "hugr-passes"
 version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ae6bd670bc95f716d153049574e6420fed970edde63ea228529a8df0df2838"
+source = "git+https://github.com/CQCL/hugr.git#c5c8a6fed22fb8aad6ac689632e0952dfcb8b94e"
 dependencies = [
  "hugr-core",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
 dependencies = [
  "cfg_aliases",
 ]
@@ -185,9 +185,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cast"
@@ -197,9 +197,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.36"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baee610e9452a8f6f0a1b6194ec09ff9e2d85dea54432acdae41aa0761c95d70"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "jobserver",
  "libc",
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "2.2.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e099138e1807662ff75e2cebe4ae2287add879245574489f9b1588eb5e5564ed"
+checksum = "54381ae56ad222eea3f529c692879e9c65e07945ae48d3dc4d1cb18dbec8cf44"
 dependencies = [
  "clap",
  "log",
@@ -317,14 +317,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "clio"
@@ -406,9 +406,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -539,7 +539,7 @@ checksum = "bc2323e10c92e1cf4d86e11538512e6dc03ceb586842970b6332af3d4046a046"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -581,7 +581,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "unicode-xid",
 ]
 
@@ -603,7 +603,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "fixedbitset"
@@ -739,7 +739,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.13.3"
-source = "git+https://github.com/CQCL/hugr.git#c5c8a6fed22fb8aad6ac689632e0952dfcb8b94e"
+source = "git+https://github.com/CQCL/hugr.git#bcac68d3c147e960b921927f58b2fca8c86ccdc7"
 dependencies = [
  "hugr-core",
  "hugr-passes",
@@ -867,7 +867,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.13.3"
-source = "git+https://github.com/CQCL/hugr.git#c5c8a6fed22fb8aad6ac689632e0952dfcb8b94e"
+source = "git+https://github.com/CQCL/hugr.git#bcac68d3c147e960b921927f58b2fca8c86ccdc7"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -876,13 +876,13 @@ dependencies = [
  "hugr",
  "serde",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "hugr-core"
 version = "0.13.3"
-source = "git+https://github.com/CQCL/hugr.git#c5c8a6fed22fb8aad6ac689632e0952dfcb8b94e"
+source = "git+https://github.com/CQCL/hugr.git#bcac68d3c147e960b921927f58b2fca8c86ccdc7"
 dependencies = [
  "bitvec",
  "bumpalo",
@@ -907,21 +907,21 @@ dependencies = [
  "smol_str",
  "strum",
  "strum_macros",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "typetag",
 ]
 
 [[package]]
 name = "hugr-passes"
 version = "0.13.3"
-source = "git+https://github.com/CQCL/hugr.git#c5c8a6fed22fb8aad6ac689632e0952dfcb8b94e"
+source = "git+https://github.com/CQCL/hugr.git#bcac68d3c147e960b921927f58b2fca8c86ccdc7"
 dependencies = [
  "hugr-core",
  "itertools 0.13.0",
  "lazy_static",
  "paste",
  "petgraph",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1062,7 +1062,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni"
@@ -1166,7 +1166,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1203,9 +1203,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1215,9 +1215,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
@@ -1398,7 +1398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -1422,7 +1422,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "portgraph"
@@ -1509,7 +1509,7 @@ dependencies = [
  "delegate 0.10.0",
  "petgraph",
  "serde",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1572,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1626,7 +1626,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1639,7 +1639,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1770,7 +1770,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.87",
+ "syn 2.0.89",
  "unicode-ident",
 ]
 
@@ -1791,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -1849,7 +1849,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1965,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1982,7 +1982,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1999,9 +1999,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2012,11 +2012,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.68",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2030,13 +2030,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2047,7 +2047,7 @@ checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2249,9 +2249,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2265,27 +2265,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2349,7 +2349,7 @@ checksum = "70b20a22c42c8f1cd23ce5e34f165d4d37038f5b663ad20fb6adbdf029172483"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2360,9 +2360,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-xid"
@@ -2378,9 +2378,9 @@ checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2470,7 +2470,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
@@ -2492,7 +2492,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2766,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2778,34 +2778,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "synstructure",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
  "synstructure",
 ]
 
@@ -2828,7 +2828,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.89",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ missing_docs = "warn"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-#hugr-core = { git = "https://github.com/CQCL/hugr.git" }
-#hugr = { git = "https://github.com/CQCL/hugr.git" }
-#hugr-cli = { git = "https://github.com/CQCL/hugr.git" }
+hugr-core = { git = "https://github.com/CQCL/hugr.git" }
+hugr = { git = "https://github.com/CQCL/hugr.git" }
+hugr-cli = { git = "https://github.com/CQCL/hugr.git" }
 
 [workspace.dependencies]
 

--- a/tket2-hseries/src/extension/futures.rs
+++ b/tket2-hseries/src/extension/futures.rs
@@ -3,6 +3,8 @@
 //! `Future<t>` is a linear type representing a value that will be available in
 //! the future.  It can be consumed by `Read`, returning a `t`.  It can be
 //! duplicated by `Dup`, and discarded with `Free`.
+use std::sync::Arc;
+
 use hugr::{
     builder::{BuildError, Dataflow},
     extension::{
@@ -29,12 +31,12 @@ pub const EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 
 lazy_static! {
     /// The "tket2.futures" extension.
-    pub static ref EXTENSION: Extension = {
+    pub static ref EXTENSION: Arc<Extension>  = {
         let mut ext = Extension::new(EXTENSION_ID, EXTENSION_VERSION);
         let _ = add_future_type_def(&mut ext).unwrap();
 
         FutureOpDef::load_all_ops(&mut ext).unwrap();
-        ext
+        Arc::new(ext)
     };
 
     /// Extension registry including the "tket2.futures" extension.

--- a/tket2-hseries/src/extension/futures.rs
+++ b/tket2-hseries/src/extension/futures.rs
@@ -3,7 +3,7 @@
 //! `Future<t>` is a linear type representing a value that will be available in
 //! the future.  It can be consumed by `Read`, returning a `t`.  It can be
 //! duplicated by `Dup`, and discarded with `Free`.
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use hugr::{
     builder::{BuildError, Dataflow},
@@ -32,11 +32,11 @@ pub const EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 lazy_static! {
     /// The "tket2.futures" extension.
     pub static ref EXTENSION: Arc<Extension>  = {
-        let mut ext = Extension::new(EXTENSION_ID, EXTENSION_VERSION);
-        let _ = add_future_type_def(&mut ext).unwrap();
+        Extension::new_arc(EXTENSION_ID, EXTENSION_VERSION, |ext, ext_ref| {
+            let _ = add_future_type_def(ext, ext_ref.clone()).unwrap();
 
-        FutureOpDef::load_all_ops(&mut ext).unwrap();
-        Arc::new(ext)
+            FutureOpDef::load_all_ops( ext, ext_ref).unwrap();
+        })
     };
 
     /// Extension registry including the "tket2.futures" extension.
@@ -48,12 +48,16 @@ lazy_static! {
     pub static ref FUTURE_TYPE_NAME: SmolStr = SmolStr::new_inline("Future");
 }
 
-fn add_future_type_def(ext: &mut Extension) -> Result<&TypeDef, ExtensionBuildError> {
+fn add_future_type_def(
+    ext: &mut Extension,
+    extension_ref: Weak<Extension>,
+) -> Result<&TypeDef, ExtensionBuildError> {
     ext.add_type(
         FUTURE_TYPE_NAME.to_owned(),
         vec![TypeBound::Any.into()],
         "A value that is computed asynchronously".into(),
         TypeBound::Any.into(),
+        &extension_ref,
     )
 }
 
@@ -121,7 +125,7 @@ impl MakeOpDef for FutureOpDef {
     }
 
     fn from_def(op_def: &OpDef) -> Result<Self, hugr::extension::simple_op::OpLoadError> {
-        try_from_name(op_def.name(), op_def.extension())
+        try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn description(&self) -> String {

--- a/tket2-hseries/src/extension/hseries.rs
+++ b/tket2-hseries/src/extension/hseries.rs
@@ -4,6 +4,8 @@
 //! In the case of lazy operations,
 //! laziness is represented by returning `tket2.futures.Future` classical
 //! values. Qubits are never lazy.
+use std::sync::Arc;
+
 use hugr::{
     builder::{BuildError, Dataflow},
     extension::{
@@ -39,14 +41,14 @@ pub const EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 
 lazy_static! {
     /// The "tket2.hseries" extension.
-    pub static ref EXTENSION: Extension = {
+    pub static ref EXTENSION: Arc<Extension> = {
         let mut ext = Extension::new(EXTENSION_ID, EXTENSION_VERSION).with_reqs(ExtensionSet::from_iter([
             futures::EXTENSION.name(),
             PRELUDE.name(),
             FLOAT_TYPES.name(),
         ].into_iter().cloned()));
         HSeriesOp::load_all_ops(&mut ext).unwrap();
-        ext
+        Arc::new(ext)
     };
 
     /// Extension registry including the "tket2.hseries" extension and

--- a/tket2-hseries/src/extension/hseries.rs
+++ b/tket2-hseries/src/extension/hseries.rs
@@ -42,13 +42,14 @@ pub const EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 lazy_static! {
     /// The "tket2.hseries" extension.
     pub static ref EXTENSION: Arc<Extension> = {
-        let mut ext = Extension::new(EXTENSION_ID, EXTENSION_VERSION).with_reqs(ExtensionSet::from_iter([
-            futures::EXTENSION.name(),
-            PRELUDE.name(),
-            FLOAT_TYPES.name(),
-        ].into_iter().cloned()));
-        HSeriesOp::load_all_ops(&mut ext).unwrap();
-        Arc::new(ext)
+         Extension::new_arc(EXTENSION_ID, EXTENSION_VERSION, |ext, ext_ref| {
+            ext.add_requirements(ExtensionSet::from_iter([
+                futures::EXTENSION.name(),
+                PRELUDE.name(),
+                FLOAT_TYPES.name(),
+            ].into_iter().cloned()));
+            HSeriesOp::load_all_ops( ext, ext_ref).unwrap();
+        })
     };
 
     /// Extension registry including the "tket2.hseries" extension and
@@ -110,7 +111,7 @@ impl MakeOpDef for HSeriesOp {
     }
 
     fn from_def(op_def: &OpDef) -> Result<Self, hugr::extension::simple_op::OpLoadError> {
-        try_from_name(op_def.name(), op_def.extension())
+        try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn extension(&self) -> ExtensionId {

--- a/tket2-hseries/src/extension/hseries/lower.rs
+++ b/tket2-hseries/src/extension/hseries/lower.rs
@@ -156,7 +156,7 @@ pub fn check_lowered(hugr: &impl HugrView) -> Result<(), Vec<Node>> {
         .filter_map(|node| {
             let optype = hugr.get_optype(node);
             optype.as_extension_op().and_then(|ext| {
-                (ext.def().extension() == &tket2::extension::TKET2_EXTENSION_ID).then_some(node)
+                (ext.def().extension_id() == &tket2::extension::TKET2_EXTENSION_ID).then_some(node)
             })
         })
         .collect();

--- a/tket2-hseries/src/extension/result.rs
+++ b/tket2-hseries/src/extension/result.rs
@@ -1,6 +1,8 @@
 //! This module defines the Hugr extension used to represent result reporting operations,
 //! with static string tags.
 //!
+use std::sync::Arc;
+
 use hugr::types::Signature;
 use hugr::{
     builder::{BuildError, Dataflow},
@@ -35,10 +37,10 @@ pub const EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 
 lazy_static! {
     /// The "tket2.result" extension.
-    pub static ref EXTENSION: Extension = {
+    pub static ref EXTENSION: Arc<Extension> = {
         let mut ext = Extension::new(EXTENSION_ID, EXTENSION_VERSION).with_reqs(ExtensionSet::from_iter([INT_EXTENSION_ID, FLOAT_EXTENSION_ID]));
         ResultOpDef::load_all_ops(&mut ext).unwrap();
-        ext
+        Arc::new(ext)
     };
 
     /// Extension registry including the "tket2.result" extension and

--- a/tket2-hseries/src/extension/result.rs
+++ b/tket2-hseries/src/extension/result.rs
@@ -38,9 +38,10 @@ pub const EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 lazy_static! {
     /// The "tket2.result" extension.
     pub static ref EXTENSION: Arc<Extension> = {
-        let mut ext = Extension::new(EXTENSION_ID, EXTENSION_VERSION).with_reqs(ExtensionSet::from_iter([INT_EXTENSION_ID, FLOAT_EXTENSION_ID]));
-        ResultOpDef::load_all_ops(&mut ext).unwrap();
-        Arc::new(ext)
+        Extension::new_arc(EXTENSION_ID, EXTENSION_VERSION, |ext, ext_ref| {
+            ext.add_requirements(ExtensionSet::from_iter([INT_EXTENSION_ID, FLOAT_EXTENSION_ID]));
+            ResultOpDef::load_all_ops(ext, ext_ref).unwrap();
+        })
     };
 
     /// Extension registry including the "tket2.result" extension and
@@ -196,7 +197,7 @@ impl MakeOpDef for ResultOpDef {
     }
 
     fn from_def(op_def: &OpDef) -> Result<Self, hugr::extension::simple_op::OpLoadError> {
-        try_from_name(op_def.name(), op_def.extension())
+        try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn extension(&self) -> ExtensionId {

--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -50,7 +50,7 @@ pub struct Circuit<T = Hugr> {
     /// Wrapped in an Arc to allow sharing between circuits, specially for borrowed circuits.
     ///
     /// Defaults to an standard set of quantum extensions and Hugr's std set.
-    required_extensions: Option<Arc<Vec<Extension>>>,
+    required_extensions: Option<Vec<Arc<Extension>>>,
 }
 
 impl<T: Default + HugrView> Default for Circuit<T> {
@@ -94,7 +94,7 @@ lazy_static! {
     ///
     /// We should be able to drop this once hugrs embed their required extensions.
     /// See https://github.com/CQCL/hugr/issues/1613
-    static ref DEFAULT_REQUIRED_EXTENSIONS: Vec<Extension> = extension::REGISTRY.iter().map(|(_, ext)| ext.clone()).collect();
+    static ref DEFAULT_REQUIRED_EXTENSIONS: Vec<Arc<Extension>> = extension::REGISTRY.iter().map(|(_, ext)| ext.to_owned()).collect();
 }
 /// The [IGNORED_EXTENSION_OPS] definition depends on the buggy behaviour of [`NamedOp::name`], which returns bare names instead of scoped names on some cases.
 /// Once this test starts failing it should be time to drop the `format!("prelude.{}", ...)`.
@@ -160,7 +160,7 @@ impl<T: HugrView> Circuit<T> {
     /// Note: This API is not currently public. We expect hugrs to embed their required extensions in the future,
     /// at which point this method will be removed.
     /// See https://github.com/CQCL/hugr/issues/1613
-    pub(crate) fn required_extensions(&self) -> &[Extension] {
+    pub(crate) fn required_extensions(&self) -> &[Arc<Extension>] {
         self.required_extensions
             .as_deref()
             .unwrap_or_else(|| &DEFAULT_REQUIRED_EXTENSIONS)
@@ -175,8 +175,8 @@ impl<T: HugrView> Circuit<T> {
     /// See https://github.com/CQCL/hugr/issues/1613
     pub(crate) fn set_required_extensions(
         &mut self,
-        extensions: Arc<Vec<Extension>>,
-    ) -> Option<Arc<Vec<Extension>>> {
+        extensions: Vec<Arc<Extension>>,
+    ) -> Option<Vec<Arc<Extension>>> {
         mem::replace(&mut self.required_extensions, Some(extensions))
     }
 

--- a/tket2/src/extension.rs
+++ b/tket2/src/extension.rs
@@ -2,6 +2,8 @@
 //!
 //! This includes a extension for the opaque TKET1 operations.
 
+use std::sync::Arc;
+
 use crate::serialize::pytket::OpaqueTk1Op;
 use crate::Tk2Op;
 use hugr::extension::simple_op::MakeOpDef;
@@ -40,7 +42,7 @@ pub static ref TKET1_OP_PAYLOAD : CustomType =
     TKET1_EXTENSION.get_type(&TKET1_PAYLOAD_NAME).unwrap().instantiate([]).unwrap();
 
 /// The TKET1 extension, containing the opaque TKET1 operations.
-pub static ref TKET1_EXTENSION: Extension = {
+pub static ref TKET1_EXTENSION: Arc<Extension>  = {
     let mut res = Extension::new(TKET1_EXTENSION_ID, TKET1_EXTENSION_VERSION);
 
     let tket1_op_payload = TypeParam::String;
@@ -50,7 +52,7 @@ pub static ref TKET1_EXTENSION: Extension = {
         Tk1Signature([tket1_op_payload])
     ).unwrap();
 
-    res
+    Arc::new(res)
 };
 
 /// Extension registry including the prelude, std, TKET1, and Tk2Ops extensions.
@@ -94,10 +96,10 @@ pub const TKET2_EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 
 lazy_static! {
 /// The extension definition for TKET2 ops and types.
-pub static ref TKET2_EXTENSION: Extension = {
+pub static ref TKET2_EXTENSION: Arc<Extension> = {
     let mut e = Extension::new(TKET2_EXTENSION_ID, TKET2_EXTENSION_VERSION);
     Tk2Op::load_all_ops(&mut e).expect("add fail");
     SympyOpDef.add_to_extension(&mut e).unwrap();
-    e
+   Arc::new(e)
 };
 }

--- a/tket2/src/extension.rs
+++ b/tket2/src/extension.rs
@@ -43,16 +43,14 @@ pub static ref TKET1_OP_PAYLOAD : CustomType =
 
 /// The TKET1 extension, containing the opaque TKET1 operations.
 pub static ref TKET1_EXTENSION: Arc<Extension>  = {
-    let mut res = Extension::new(TKET1_EXTENSION_ID, TKET1_EXTENSION_VERSION);
-
-    let tket1_op_payload = TypeParam::String;
-    res.add_op(
-        TKET1_OP_NAME,
-        "An opaque TKET1 operation.".into(),
-        Tk1Signature([tket1_op_payload])
-    ).unwrap();
-
-    Arc::new(res)
+    Extension::new_arc(TKET1_EXTENSION_ID, TKET1_EXTENSION_VERSION, |res, ext_ref| {
+        res.add_op(
+            TKET1_OP_NAME,
+            "An opaque TKET1 operation.".into(),
+            Tk1Signature([TypeParam::String]),
+            ext_ref
+        ).unwrap();
+    })
 };
 
 /// Extension registry including the prelude, std, TKET1, and Tk2Ops extensions.
@@ -95,11 +93,11 @@ pub const TKET2_EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("tket2.qu
 pub const TKET2_EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 
 lazy_static! {
-/// The extension definition for TKET2 ops and types.
-pub static ref TKET2_EXTENSION: Arc<Extension> = {
-    let mut e = Extension::new(TKET2_EXTENSION_ID, TKET2_EXTENSION_VERSION);
-    Tk2Op::load_all_ops(&mut e).expect("add fail");
-    SympyOpDef.add_to_extension(&mut e).unwrap();
-   Arc::new(e)
-};
+    /// The extension definition for TKET2 ops and types.
+    pub static ref TKET2_EXTENSION: Arc<Extension> = {
+        Extension::new_arc(TKET2_EXTENSION_ID, TKET2_EXTENSION_VERSION, |res, ext_ref| {
+            Tk2Op::load_all_ops(res, ext_ref).expect("add_fail");
+            SympyOpDef.add_to_extension(res, ext_ref).unwrap();
+        })
+    };
 }

--- a/tket2/src/extension/rotation.rs
+++ b/tket2/src/extension/rotation.rs
@@ -10,6 +10,7 @@ use hugr::{
 };
 use smol_str::SmolStr;
 use std::f64::consts::PI;
+use std::sync::Arc;
 use strum::{EnumIter, EnumString, IntoStaticStr};
 
 use lazy_static::lazy_static;
@@ -22,10 +23,10 @@ pub const ROTATION_EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 
 lazy_static! {
     /// The extension definition for TKET2 rotation type and ops.
-    pub static ref ROTATION_EXTENSION: Extension = {
+    pub static ref ROTATION_EXTENSION: Arc<Extension> = {
         let mut e = Extension::new(ROTATION_EXTENSION_ID, ROTATION_EXTENSION_VERSION);
         add_to_extension(&mut e);
-        e
+        Arc::new(e)
     };
 }
 

--- a/tket2/src/extension/rotation.rs
+++ b/tket2/src/extension/rotation.rs
@@ -10,7 +10,7 @@ use hugr::{
 };
 use smol_str::SmolStr;
 use std::f64::consts::PI;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use strum::{EnumIter, EnumString, IntoStaticStr};
 
 use lazy_static::lazy_static;
@@ -23,11 +23,11 @@ pub const ROTATION_EXTENSION_VERSION: Version = Version::new(0, 1, 0);
 
 lazy_static! {
     /// The extension definition for TKET2 rotation type and ops.
-    pub static ref ROTATION_EXTENSION: Arc<Extension> = {
-        let mut e = Extension::new(ROTATION_EXTENSION_ID, ROTATION_EXTENSION_VERSION);
-        add_to_extension(&mut e);
-        Arc::new(e)
-    };
+    pub static ref ROTATION_EXTENSION: Arc<Extension> =  {
+            Extension::new_arc(ROTATION_EXTENSION_ID, ROTATION_EXTENSION_VERSION, |e, extension_ref| {
+                add_to_extension(e, extension_ref);
+            }
+    )};
 }
 
 /// Identifier for the rotation type.
@@ -132,7 +132,7 @@ impl MakeOpDef for RotationOp {
     where
         Self: Sized,
     {
-        hugr::extension::simple_op::try_from_name(op_def.name(), op_def.extension())
+        hugr::extension::simple_op::try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn signature(&self) -> hugr::extension::SignatureFunc {
@@ -189,17 +189,18 @@ impl MakeRegisteredOp for RotationOp {
     }
 }
 
-pub(super) fn add_to_extension(extension: &mut Extension) {
+pub(super) fn add_to_extension(extension: &mut Extension, extension_ref: &Weak<Extension>) {
     extension
         .add_type(
             ROTATION_TYPE_ID,
             vec![],
             "rotation type expressed as number of half turns".to_owned(),
             TypeBound::Copyable.into(),
+            extension_ref,
         )
         .unwrap();
 
-    RotationOp::load_all_ops(extension).expect("add fail");
+    RotationOp::load_all_ops(extension, extension_ref).expect("add fail");
 }
 
 /// An extension trait for [Dataflow] providing methods to add

--- a/tket2/src/extension/sympy.rs
+++ b/tket2/src/extension/sympy.rs
@@ -64,7 +64,7 @@ impl MakeOpDef for SympyOpDef {
     where
         Self: Sized,
     {
-        try_from_name(op_def.name(), op_def.extension())
+        try_from_name(op_def.name(), op_def.extension_id())
     }
 
     fn signature(&self) -> hugr::extension::SignatureFunc {

--- a/tket2/src/ops.rs
+++ b/tket2/src/ops.rs
@@ -133,7 +133,7 @@ impl MakeOpDef for Tk2Op {
     }
 
     fn from_def(op_def: &OpDef) -> Result<Self, hugr::extension::simple_op::OpLoadError> {
-        try_from_name(op_def.name(), op_def.extension())
+        try_from_name(op_def.name(), op_def.extension_id())
     }
 }
 
@@ -190,7 +190,7 @@ pub(crate) fn match_symb_const_op(op: &OpType) -> Option<String> {
     };
 
     if let OpType::ExtensionOp(e) = op {
-        if e.def().name() == &SYM_OP_ID && e.def().extension() == &EXTENSION_ID {
+        if e.def().name() == &SYM_OP_ID && e.def().extension_id() == &EXTENSION_ID {
             Some(symbol_from_typeargs(e.args()))
         } else {
             None
@@ -276,7 +276,7 @@ pub(crate) mod test {
 
             let ext_op = op.into_extension_op();
             assert_eq!(ext_op.args(), &[]);
-            assert_eq!(ext_op.def().extension(), &EXTENSION_ID);
+            assert_eq!(ext_op.def().extension_id(), &EXTENSION_ID);
             let name = ext_op.def().name();
             assert_eq!(Tk2Op::from_str(name), Ok(op));
         }

--- a/tket2/src/portmatching/pattern.rs
+++ b/tket2/src/portmatching/pattern.rs
@@ -73,6 +73,7 @@ impl CircuitPattern {
             .map(|p| {
                 hugr.linked_ports(out, p)
                     .exactly_one()
+                    .ok()
                     .expect("invalid circuit")
             })
             .collect_vec();

--- a/tket2/src/serialize.rs
+++ b/tket2/src/serialize.rs
@@ -4,7 +4,6 @@
 pub mod pytket;
 
 use std::io;
-use std::sync::Arc;
 
 use hugr::extension::ExtensionRegistryError;
 use hugr::hugr::ValidationError;
@@ -107,7 +106,7 @@ impl Circuit<Hugr> {
 
         let (_module_idx, mut circ) = find_function_in_modules(modules, function_name.as_ref())?;
         if !extensions.is_empty() {
-            circ.set_required_extensions(Arc::new(extensions));
+            circ.set_required_extensions(extensions);
         }
         Ok(circ)
     }


### PR DESCRIPTION
Awaiting release



BREAKING CHANGE: Extension definitions and registries use `Arc` for sharing