### PR TITLE
feat!: update measurement and alloc operations

### DIFF
--- a/tket2-exts/src/tket2_exts/data/tket2/hseries.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/hseries.json
@@ -12,7 +12,7 @@
     "LazyMeasure": {
       "extension": "tket2.hseries",
       "name": "LazyMeasure",
-      "description": "Lazily Measure a qubit and lose it.",
+      "description": "Lazily measure a qubit and lose it.",
       "signature": {
         "params": [],
         "body": {

--- a/tket2-exts/src/tket2_exts/data/tket2/hseries.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/hseries.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "tket2.hseries",
   "extension_reqs": [
     "arithmetic.float.types",
@@ -12,7 +12,7 @@
     "LazyMeasure": {
       "extension": "tket2.hseries",
       "name": "LazyMeasure",
-      "description": "LazyMeasure",
+      "description": "Lazily Measure a qubit and lose it.",
       "signature": {
         "params": [],
         "body": {
@@ -50,7 +50,31 @@
     "Measure": {
       "extension": "tket2.hseries",
       "name": "Measure",
-      "description": "Measure",
+      "description": "Measure a qubit and lose it.",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Q"
+            }
+          ],
+          "output": [
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "MeasureReset": {
+      "extension": "tket2.hseries",
+      "name": "MeasureReset",
+      "description": "Measure a qubit and reset it to the Z |0> eigenstate.",
       "signature": {
         "params": [],
         "body": {
@@ -77,7 +101,7 @@
     "PhasedX": {
       "extension": "tket2.hseries",
       "name": "PhasedX",
-      "description": "PhasedX",
+      "description": "PhasedX gate.",
       "signature": {
         "params": [],
         "body": {
@@ -110,28 +134,10 @@
       },
       "binary": false
     },
-    "QAlloc": {
-      "extension": "tket2.hseries",
-      "name": "QAlloc",
-      "description": "QAlloc",
-      "signature": {
-        "params": [],
-        "body": {
-          "input": [],
-          "output": [
-            {
-              "t": "Q"
-            }
-          ],
-          "extension_reqs": []
-        }
-      },
-      "binary": false
-    },
     "QFree": {
       "extension": "tket2.hseries",
       "name": "QFree",
-      "description": "QFree",
+      "description": "Free a qubit (lose track of it).",
       "signature": {
         "params": [],
         "body": {
@@ -149,7 +155,7 @@
     "Reset": {
       "extension": "tket2.hseries",
       "name": "Reset",
-      "description": "Reset",
+      "description": "Reset a qubit to the Z |0> eigenstate.",
       "signature": {
         "params": [],
         "body": {
@@ -171,7 +177,7 @@
     "Rz": {
       "extension": "tket2.hseries",
       "name": "Rz",
-      "description": "Rz",
+      "description": "Rotate a qubit around the Z axis. Not physical.",
       "signature": {
         "params": [],
         "body": {
@@ -197,10 +203,37 @@
       },
       "binary": false
     },
+    "TryQAlloc": {
+      "extension": "tket2.hseries",
+      "name": "TryQAlloc",
+      "description": "Allocate a qubit in the Z |0> eigenstate.",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [],
+          "output": [
+            {
+              "t": "Sum",
+              "s": "General",
+              "rows": [
+                [],
+                [
+                  {
+                    "t": "Q"
+                  }
+                ]
+              ]
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
     "ZZMax": {
       "extension": "tket2.hseries",
       "name": "ZZMax",
-      "description": "ZZMax",
+      "description": "Maximally entangling ZZ gate.",
       "signature": {
         "params": [],
         "body": {
@@ -228,7 +261,7 @@
     "ZZPhase": {
       "extension": "tket2.hseries",
       "name": "ZZPhase",
-      "description": "ZZPhase",
+      "description": "ZZ gate with an angle.",
       "signature": {
         "params": [],
         "body": {

--- a/tket2-exts/src/tket2_exts/data/tket2/quantum.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/quantum.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "name": "tket2.quantum",
   "extension_reqs": [],
   "types": {},
@@ -203,6 +203,33 @@
             {
               "t": "Q"
             },
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "MeasureFree": {
+      "extension": "tket2.quantum",
+      "name": "MeasureFree",
+      "description": "MeasureFree",
+      "misc": {
+        "commutation": []
+      },
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Q"
+            }
+          ],
+          "output": [
             {
               "t": "Sum",
               "s": "Unit",
@@ -537,6 +564,36 @@
             },
             {
               "t": "Q"
+            }
+          ],
+          "extension_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "TryQAlloc": {
+      "extension": "tket2.quantum",
+      "name": "TryQAlloc",
+      "description": "TryQAlloc",
+      "misc": {
+        "commutation": []
+      },
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [],
+          "output": [
+            {
+              "t": "Sum",
+              "s": "General",
+              "rows": [
+                [],
+                [
+                  {
+                    "t": "Q"
+                  }
+                ]
+              ]
             }
           ],
           "extension_reqs": []

--- a/tket2-hseries/src/extension/hseries.rs
+++ b/tket2-hseries/src/extension/hseries.rs
@@ -37,7 +37,7 @@ pub use lower::{check_lowered, lower_tk2_op, LowerTk2Error, LowerTket2ToHSeriesP
 /// The "tket2.hseries" extension id.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("tket2.hseries");
 /// The "tket2.hseries" extension version.
-pub const EXTENSION_VERSION: Version = Version::new(0, 1, 0);
+pub const EXTENSION_VERSION: Version = Version::new(0, 2, 0);
 
 lazy_static! {
     /// The "tket2.hseries" extension.

--- a/tket2-hseries/src/extension/hseries.rs
+++ b/tket2-hseries/src/extension/hseries.rs
@@ -123,7 +123,7 @@ impl MakeOpDef for HSeriesOp {
     fn description(&self) -> String {
         match self {
             HSeriesOp::Measure => "Measure a qubit and lose it.",
-            HSeriesOp::LazyMeasure => "Lazily Measure a qubit and lose it.",
+            HSeriesOp::LazyMeasure => "Lazily measure a qubit and lose it.",
             HSeriesOp::Rz => "Rotate a qubit around the Z axis. Not physical.",
             HSeriesOp::PhasedX => "PhasedX gate.",
             HSeriesOp::ZZMax => "Maximally entangling ZZ gate.",

--- a/tket2-hseries/src/extension/hseries.rs
+++ b/tket2-hseries/src/extension/hseries.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use hugr::{
-    builder::{BuildError, Dataflow},
+    builder::{BuildError, Dataflow, DataflowSubContainer, SubContainer},
     extension::{
         prelude::{BOOL_T, QB_T},
         simple_op::{try_from_name, MakeOpDef, MakeRegisteredOp},
@@ -89,6 +89,7 @@ pub enum HSeriesOp {
     QAlloc,
     QFree,
     Reset,
+    MeasureReset,
 }
 
 impl MakeOpDef for HSeriesOp {
@@ -101,11 +102,12 @@ impl MakeOpDef for HSeriesOp {
             Reset => Signature::new(one_qb_row.clone(), one_qb_row),
             ZZMax => Signature::new(two_qb_row.clone(), two_qb_row),
             ZZPhase => Signature::new(type_row![QB_T, QB_T, FLOAT64_TYPE], two_qb_row),
-            Measure => Signature::new(one_qb_row, type_row![QB_T, BOOL_T]),
+            Measure => Signature::new(one_qb_row, type_row![BOOL_T]),
             Rz => Signature::new(type_row![QB_T, FLOAT64_TYPE], one_qb_row),
             PhasedX => Signature::new(type_row![QB_T, FLOAT64_TYPE, FLOAT64_TYPE], one_qb_row),
             QAlloc => Signature::new(type_row![], one_qb_row),
             QFree => Signature::new(one_qb_row, type_row![]),
+            MeasureReset => Signature::new(one_qb_row.clone(), type_row![QB_T, BOOL_T]),
         }
         .into()
     }
@@ -116,6 +118,22 @@ impl MakeOpDef for HSeriesOp {
 
     fn extension(&self) -> ExtensionId {
         EXTENSION_ID
+    }
+
+    fn description(&self) -> String {
+        match self {
+            HSeriesOp::Measure => "Measure a qubit and lose it.",
+            HSeriesOp::LazyMeasure => "Lazily Measure a qubit and lose it.",
+            HSeriesOp::Rz => "Rotate a qubit around the Z axis. Not physical.",
+            HSeriesOp::PhasedX => "PhasedX gate.",
+            HSeriesOp::ZZMax => "Maximally entangling ZZ gate.",
+            HSeriesOp::ZZPhase => "ZZ gate with an angle.",
+            HSeriesOp::QAlloc => "Allocate a qubit in the Z |0> eigenstate.",
+            HSeriesOp::QFree => "Free a qubit (lose track of it).",
+            HSeriesOp::Reset => "Reset a qubit to the Z |0> eigenstate.",
+            HSeriesOp::MeasureReset => "Measure a qubit and reset it to the Z |0> eigenstate.",
+        }
+        .to_string()
     }
 }
 
@@ -140,10 +158,8 @@ pub trait HSeriesOpBuilder: Dataflow {
     }
 
     /// Add a "tket2.hseries.Measure" op.
-    fn add_measure(&mut self, qb: Wire) -> Result<[Wire; 2], BuildError> {
-        Ok(self
-            .add_dataflow_op(HSeriesOp::Measure, [qb])?
-            .outputs_arr())
+    fn add_measure(&mut self, qb: Wire) -> Result<Wire, BuildError> {
+        Ok(self.add_dataflow_op(HSeriesOp::Measure, [qb])?.out_wire(0))
     }
 
     /// Add a "tket2.hseries.Reset" op.
@@ -188,6 +204,14 @@ pub trait HSeriesOpBuilder: Dataflow {
     fn add_qfree(&mut self, qb: Wire) -> Result<(), BuildError> {
         self.add_dataflow_op(HSeriesOp::QFree, [qb])?;
         Ok(())
+    }
+
+    /// Add a "tket2.hseries.MeasureReset" op.
+    /// This operation is equivalent to a `Measure` followed by a `Reset`.
+    fn add_measure_reset(&mut self, qb: Wire) -> Result<[Wire; 2], BuildError> {
+        Ok(self
+            .add_dataflow_op(HSeriesOp::MeasureReset, [qb])?
+            .outputs_arr())
     }
 
     /// Build a hadamard gate in terms of HSeries primitives.
@@ -344,6 +368,30 @@ pub trait HSeriesOpBuilder: Dataflow {
 
         Ok([a, b, c])
     }
+
+    /// Build a projective measurement with a conditional flip.
+    fn build_measure_flip(&mut self, qb: Wire) -> Result<[Wire; 2], BuildError> {
+        let [qb, b] = self.add_measure_reset(qb)?;
+        let mut conditional = self.conditional_builder(
+            ([type_row![], type_row![]], b),
+            [(QB_T, qb)],
+            type_row![QB_T],
+        )?;
+
+        // case 0: 0 state measured, leave alone
+        let case0 = conditional.case_builder(0)?;
+        let [qb] = case0.input_wires_arr();
+        case0.finish_with_outputs([qb])?;
+
+        // case 1: 1 state measured, flip
+        let mut case1 = conditional.case_builder(1)?;
+        let [qb] = case1.input_wires_arr();
+        let qb = case1.build_x(qb)?;
+        case1.finish_with_outputs([qb])?;
+
+        let [qb] = conditional.finish_sub_container()?.outputs_arr();
+        Ok([qb, b])
+    }
 }
 
 impl<D: Dataflow> HSeriesOpBuilder for D {}
@@ -393,7 +441,7 @@ mod test {
         let hugr = {
             let mut func_builder = FunctionBuilder::new(
                 "all_ops",
-                Signature::new(vec![QB_T, FLOAT64_TYPE], vec![QB_T, BOOL_T]),
+                Signature::new(vec![QB_T, FLOAT64_TYPE], vec![BOOL_T]),
             )
             .unwrap();
             let [q0, angle] = func_builder.input_wires_arr();
@@ -403,10 +451,11 @@ mod test {
             let [q0, q1] = func_builder.add_zz_max(q0, q1).unwrap();
             let [q0, q1] = func_builder.add_zz_phase(q0, q1, angle).unwrap();
             let q0 = func_builder.add_rz(q0, angle).unwrap();
-            let [q0, b] = func_builder.add_measure(q0).unwrap();
+            let [q0, _b] = func_builder.add_measure_reset(q0).unwrap();
+            let b = func_builder.add_measure(q0).unwrap();
             func_builder.add_qfree(q1).unwrap();
             func_builder
-                .finish_hugr_with_outputs([q0, b], &REGISTRY)
+                .finish_hugr_with_outputs([b], &REGISTRY)
                 .unwrap()
         };
         assert_matches!(hugr.validate(&REGISTRY), Ok(_));

--- a/tket2-hseries/src/lib.rs
+++ b/tket2-hseries/src/lib.rs
@@ -113,8 +113,7 @@ mod test {
     fn hseries_pass() {
         let registry = &tket2::extension::REGISTRY;
         let (mut hugr, [call_node, h_node, f_node, rx_node]) = {
-            let mut builder =
-                DFGBuilder::new(Signature::new(QB_T, vec![QB_T, BOOL_T, BOOL_T])).unwrap();
+            let mut builder = DFGBuilder::new(Signature::new(QB_T, vec![BOOL_T, BOOL_T])).unwrap();
             let func = builder
                 .define_function("func", Signature::new_endo(type_row![]))
                 .unwrap()
@@ -150,13 +149,13 @@ mod test {
             // the Measure node will be removed. A Lazy Measure and two Future
             // Reads will be added.  The Lazy Measure will be lifted and the
             // reads will be sunk.
-            let [qb, measure_result] = builder
+            let [measure_result] = builder
                 .add_dataflow_op(HSeriesOp::Measure, [qb])
                 .unwrap()
                 .outputs_arr();
 
             let hugr = builder
-                .finish_hugr_with_outputs([qb, measure_result, measure_result], registry)
+                .finish_hugr_with_outputs([measure_result, measure_result], registry)
                 .unwrap();
             (hugr, [call_node, h_node, f_node, rx_node])
         };

--- a/tket2-py/tket2/ops.py
+++ b/tket2-py/tket2/ops.py
@@ -47,7 +47,9 @@ class Tk2Op(Enum):
     Ry = auto()
     Toffoli = auto()
     Measure = auto()
+    MeasureFree = auto()
     QAlloc = auto()
+    TryQAlloc = auto()
     QFree = auto()
     Reset = auto()
 

--- a/tket2/src/extension.rs
+++ b/tket2/src/extension.rs
@@ -90,7 +90,7 @@ impl CustomSignatureFunc for Tk1Signature {
 pub const TKET2_EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("tket2.quantum");
 
 /// Current version of the TKET 2 extension
-pub const TKET2_EXTENSION_VERSION: Version = Version::new(0, 1, 0);
+pub const TKET2_EXTENSION_VERSION: Version = Version::new(0, 1, 1);
 
 lazy_static! {
     /// The extension definition for TKET2 ops and types.

--- a/tket2/src/ops.rs
+++ b/tket2/src/ops.rs
@@ -3,9 +3,10 @@ use crate::extension::sympy::{SympyOpDef, SYM_OP_ID};
 use crate::extension::TKET2_EXTENSION_ID as EXTENSION_ID;
 use hugr::ops::custom::ExtensionOp;
 use hugr::ops::NamedOp;
+use hugr::types::Type;
 use hugr::{
     extension::{
-        prelude::{BOOL_T, QB_T},
+        prelude::{option_type, BOOL_T, QB_T},
         simple_op::{try_from_name, MakeOpDef, MakeRegisteredOp},
         ExtensionId, OpDef, SignatureFunc,
     },
@@ -57,6 +58,7 @@ pub enum Tk2Op {
     Toffoli,
     Measure,
     QAlloc,
+    TryQAlloc,
     QFree,
     Reset,
 }
@@ -116,6 +118,7 @@ impl MakeOpDef for Tk2Op {
             Rz | Rx | Ry => Signature::new(type_row![QB_T, ROTATION_TYPE], one_qb_row),
             CRz => Signature::new(type_row![QB_T, QB_T, ROTATION_TYPE], type_row![QB_T; 2]),
             QAlloc => Signature::new(type_row![], one_qb_row),
+            TryQAlloc => Signature::new(type_row![], Type::from(option_type(one_qb_row))),
             QFree => Signature::new(one_qb_row, type_row![]),
         }
         .into()
@@ -167,7 +170,7 @@ impl Tk2Op {
         use Tk2Op::*;
         match self {
             H | CX | T | S | X | Y | Z | Tdg | Sdg | Rz | Rx | Toffoli | Ry | CZ | CY | CRz => true,
-            Measure | QAlloc | QFree | Reset => false,
+            Measure | QAlloc | TryQAlloc | QFree | Reset => false,
         }
     }
 }
@@ -206,16 +209,21 @@ pub(crate) mod test {
     use std::str::FromStr;
     use std::sync::Arc;
 
+    use hugr::builder::{DFGBuilder, Dataflow, DataflowHugr};
+    use hugr::extension::prelude::{option_type, QB_T};
     use hugr::extension::simple_op::MakeOpDef;
-    use hugr::extension::OpDef;
+    use hugr::extension::{prelude::UnwrapBuilder as _, OpDef};
     use hugr::ops::NamedOp;
-    use hugr::CircuitUnit;
+    use hugr::types::Signature;
+    use hugr::{type_row, CircuitUnit};
     use rstest::{fixture, rstest};
     use strum::IntoEnumIterator;
 
     use super::Tk2Op;
     use crate::circuit::Circuit;
-    use crate::extension::{TKET2_EXTENSION as EXTENSION, TKET2_EXTENSION_ID as EXTENSION_ID};
+    use crate::extension::{
+        REGISTRY, TKET2_EXTENSION as EXTENSION, TKET2_EXTENSION_ID as EXTENSION_ID,
+    };
     use crate::utils::build_simple_circuit;
     use crate::Pauli;
     fn get_opdef(op: impl NamedOp) -> Option<&'static Arc<OpDef>> {
@@ -268,6 +276,16 @@ pub(crate) mod test {
         assert_eq!(h.commands().count(), 5);
     }
 
+    #[test]
+    fn try_qalloc() {
+        let mut b = DFGBuilder::new(Signature::new(type_row![], QB_T)).unwrap();
+
+        let try_q = b.add_dataflow_op(Tk2Op::TryQAlloc, []).unwrap().out_wire(0);
+        let [q] = b
+            .build_unwrap_sum(&REGISTRY, 1, option_type(QB_T), try_q)
+            .unwrap();
+        b.finish_hugr_with_outputs([q], &REGISTRY).unwrap();
+    }
     #[test]
     fn tk2op_properties() {
         for op in Tk2Op::iter() {

--- a/tket2/src/serialize/pytket/op/native.rs
+++ b/tket2/src/serialize/pytket/op/native.rs
@@ -71,7 +71,7 @@ impl NativeOp {
             Tk2Op::Reset => Tk1OpType::Reset,
             Tk2Op::Measure => Tk1OpType::Measure,
             // These operations do not have a direct pytket counterpart.
-            Tk2Op::QAlloc | Tk2Op::QFree => {
+            Tk2Op::QAlloc | Tk2Op::QFree | Tk2Op::TryQAlloc => {
                 // These operations are implicitly supported by the encoding,
                 // they do not create an explicit pytket operation but instead
                 // add new qubits to the circuit input/output.

--- a/tket2/src/serialize/pytket/op/native.rs
+++ b/tket2/src/serialize/pytket/op/native.rs
@@ -71,6 +71,7 @@ impl NativeOp {
             Tk2Op::Reset => Tk1OpType::Reset,
             Tk2Op::Measure => Tk1OpType::Measure,
             // These operations do not have a direct pytket counterpart.
+            Tk2Op::MeasureFree => return None,
             Tk2Op::QAlloc | Tk2Op::QFree | Tk2Op::TryQAlloc => {
                 // These operations are implicitly supported by the encoding,
                 // they do not create an explicit pytket operation but instead

--- a/uv.lock
+++ b/uv.lock
@@ -790,7 +790,7 @@ wheels = [
 
 [[package]]
 name = "tket2"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "tket2-py" }
 dependencies = [
     { name = "hugr" },


### PR DESCRIPTION
Closes #691 Closes #692 Closes #693

- Add TryQAlloc and MeasureFree to "tket2.quantum"
- Lower new ops to "tket2.hseries"
- Add MeasureReset to "tket2.hseries"

BREAKING CHANGE: hseries qalloc op replaced with fallible TryQalloc
