### PR TITLE
ci: Build wheels using the python's stable ABI

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/tket2-py/Cargo.toml
+++ b/tket2-py/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { workspace = true }
 tket-json-rs = { workspace = true, features = ["pyo3"] }
 hugr = { workspace = true }
 portgraph = { workspace = true, features = ["serde"] }
-pyo3 = { workspace = true, features = ["py-clone"] }
+pyo3 = { workspace = true, features = ["py-clone", "abi3-py310"] }
 num_cpus = { workspace = true }
 derive_more = { workspace = true, features = ["into", "from"] }
 itertools = { workspace = true }


### PR DESCRIPTION
test wheels building run:
https://github.com/CQCL/tket2/actions/runs/12357204894

Closes #724 

drive-by: Update `macos` runner for the mac x86 wheels build job to `macos-13`, as `-12` has been deprecated.