### PR TITLE
chore!: Update `hugr 0.14.3`, `portgraph 0.13.1`, and `petgraph 0.7.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
+
+[[package]]
 name = "duplicate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,8 +922,9 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.14.2"
-source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e8fb919d87dd5b9c1ba077a289c765b6e184c832768fb4a5dc9e1e05793564"
 dependencies = [
  "hugr-core",
  "hugr-passes",
@@ -925,8 +932,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.14.2"
-source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207ce216fc76a3f2e56bb27483502468d6b8758e6c7a8a777cdf8d64459043cf"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -938,15 +946,16 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.14.2"
-source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79da6020b18a6c63bd81acb9b86370820ba63062519b9d10ed75a0561f3143d1"
 dependencies = [
  "bitvec",
  "bumpalo",
  "cgmath",
  "delegate 0.13.2",
  "derive_more 1.0.0",
- "downcast-rs",
+ "downcast-rs 2.0.1",
  "enum_dispatch",
  "fxhash",
  "html-escape",
@@ -956,7 +965,7 @@ dependencies = [
  "num-rational",
  "paste",
  "petgraph 0.7.1",
- "portgraph 0.13.0",
+ "portgraph 0.13.1",
  "regex",
  "semver",
  "serde",
@@ -970,8 +979,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-passes"
-version = "0.14.2"
-source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dff9354c0133cddd4f9060af2f4ec531dc479c1a65ed5474785f5b39478422"
 dependencies = [
  "ascent",
  "hugr-core",
@@ -979,7 +989,7 @@ dependencies = [
  "lazy_static",
  "paste",
  "petgraph 0.7.1",
- "portgraph 0.13.0",
+ "portgraph 0.13.1",
  "thiserror 2.0.11",
 ]
 
@@ -1424,8 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "portgraph"
-version = "0.13.0"
-source = "git+https://github.com/CQCL/portgraph?rev=68b96ac737e0c285d8c543b2d74a7aa80a18202c#68b96ac737e0c285d8c543b2d74a7aa80a18202c"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fcb76974f489d449dce2409cd132171194e3c75b67f69ecfa533ac761b77b3"
 dependencies = [
  "bitvec",
  "delegate 0.13.2",
@@ -2056,7 +2067,7 @@ dependencies = [
  "csv",
  "delegate 0.13.2",
  "derive_more 1.0.0",
- "downcast-rs",
+ "downcast-rs 1.2.1",
  "fxhash",
  "hugr",
  "hugr-core",
@@ -2068,7 +2079,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "petgraph 0.7.1",
- "portgraph 0.13.0",
+ "portgraph 0.13.1",
  "portmatching",
  "priority-queue",
  "rayon",
@@ -2117,7 +2128,7 @@ dependencies = [
  "hugr",
  "itertools 0.13.0",
  "num_cpus",
- "portgraph 0.13.0",
+ "portgraph 0.13.1",
  "portmatching",
  "pyo3",
  "rstest",
@@ -2635,8 +2646,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "hugr-model"
-version = "0.17.0"
-source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,11 +91,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -147,10 +148,10 @@ dependencies = [
  "duplicate",
  "itertools 0.12.1",
  "lazy_static",
- "petgraph",
+ "petgraph 0.6.5",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -184,9 +185,9 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -212,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.3"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
+checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
 dependencies = [
  "cfg_aliases",
 ]
@@ -251,9 +252,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -365,7 +366,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -581,7 +582,7 @@ checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -601,7 +602,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -614,7 +615,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -634,7 +635,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "unicode-xid",
 ]
 
@@ -675,7 +676,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -715,6 +716,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "funty"
@@ -778,7 +785,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -837,10 +844,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.1"
+name = "getrandom"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
@@ -898,9 +916,8 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c8f4a7f778b70a6528fb620f9df31931d9eaad518287d7d25faabba8714f3f"
+version = "0.14.2"
+source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"
 dependencies = [
  "hugr-core",
  "hugr-passes",
@@ -908,9 +925,8 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5906f571c65f74ec9f7aac92d1d52bf1a1837d736d4bd131d3d81b13c057068"
+version = "0.14.2"
+source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -922,9 +938,8 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967ce11e97050617c536d37c5b12d2b0eecb2f9f6da24e4bc5d19faf5cf1fafa"
+version = "0.14.2"
+source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"
 dependencies = [
  "bitvec",
  "bumpalo",
@@ -936,12 +951,12 @@ dependencies = [
  "fxhash",
  "html-escape",
  "indexmap",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "num-rational",
  "paste",
- "petgraph",
- "portgraph 0.12.3",
+ "petgraph 0.7.1",
+ "portgraph 0.13.0",
  "regex",
  "semver",
  "serde",
@@ -949,24 +964,23 @@ dependencies = [
  "smol_str",
  "strum",
  "strum_macros",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
  "typetag",
 ]
 
 [[package]]
 name = "hugr-passes"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a12944d441477c4f086c106891fa22e5a29ac2fd011c0caf898e4d28aeb2a05"
+version = "0.14.2"
+source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"
 dependencies = [
  "ascent",
  "hugr-core",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "paste",
- "petgraph",
- "portgraph 0.12.3",
- "thiserror 2.0.8",
+ "petgraph 0.7.1",
+ "portgraph 0.13.0",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1025,9 +1039,12 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
+checksum = "3b31349d02fe60f80bbbab1a9402364cad7460626d6030494b08ac4a2075bf81"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is-terminal"
@@ -1074,6 +1091,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1106,15 +1132,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -1128,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"
@@ -1272,7 +1298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
  "ucd-trie",
 ]
 
@@ -1296,7 +1322,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1316,15 +1342,25 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
  "indexmap",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1381,24 +1417,22 @@ dependencies = [
  "bitvec",
  "context-iterators",
  "delegate 0.10.0",
- "petgraph",
+ "petgraph 0.6.5",
  "serde",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "portgraph"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfec2c00343ab6227cb3da08a1c9bed2d79fc379d040ce98582e81e825f96d1"
+version = "0.13.0"
+source = "git+https://github.com/CQCL/portgraph?rev=68b96ac737e0c285d8c543b2d74a7aa80a18202c#68b96ac737e0c285d8c543b2d74a7aa80a18202c"
 dependencies = [
  "bitvec",
- "context-iterators",
  "delegate 0.13.2",
- "itertools 0.13.0",
- "petgraph",
+ "itertools 0.14.0",
+ "petgraph 0.7.1",
  "serde",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1411,7 +1445,7 @@ dependencies = [
  "bitvec",
  "derive_more 0.99.18",
  "itertools 0.10.5",
- "petgraph",
+ "petgraph 0.6.5",
  "portgraph 0.8.0",
  "rustc-hash",
  "serde",
@@ -1446,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1500,7 +1534,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1513,7 +1547,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1528,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1653,7 +1687,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.90",
+ "syn 2.0.96",
  "unicode-ident",
 ]
 
@@ -1674,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags",
  "errno",
@@ -1687,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -1714,9 +1748,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 dependencies = [
  "serde",
 ]
@@ -1738,7 +1772,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1832,7 +1866,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1848,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1871,12 +1905,13 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1893,11 +1928,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.8"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.8",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1908,18 +1943,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.8"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2032,8 +2067,8 @@ dependencies = [
  "num-rational",
  "pest",
  "pest_derive",
- "petgraph",
- "portgraph 0.12.3",
+ "petgraph 0.7.1",
+ "portgraph 0.13.0",
  "portmatching",
  "priority-queue",
  "rayon",
@@ -2062,7 +2097,7 @@ dependencies = [
  "hugr-cli",
  "itertools 0.13.0",
  "lazy_static",
- "petgraph",
+ "petgraph 0.7.1",
  "rstest",
  "serde",
  "serde_json",
@@ -2082,7 +2117,7 @@ dependencies = [
  "hugr",
  "itertools 0.13.0",
  "num_cpus",
- "portgraph 0.12.3",
+ "portgraph 0.13.0",
  "portmatching",
  "pyo3",
  "rstest",
@@ -2141,7 +2176,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2212,7 +2247,7 @@ checksum = "d9d30226ac9cbd2d1ff775f74e8febdab985dab14fb14aa2582c29a92d5555dc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2253,18 +2288,18 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2283,35 +2318,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2319,28 +2361,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2527,9 +2572,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -2560,7 +2605,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2590,3 +2635,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "hugr-model"
+version = "0.17.0"
+source = "git+https://github.com/CQCL/hugr?rev=09bd748398ce5afb39f5628d838756ccc03fc775#09bd748398ce5afb39f5628d838756ccc03fc775"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,20 +26,20 @@ missing_docs = "warn"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
-hugr-core = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
-hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
-hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
-hugr-model = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
-portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
+# hugr = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+# hugr-core = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+# hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+# hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+# hugr-model = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+# portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]
 
 # Make sure to run `just recompile-eccs` if the hugr serialisation format changes.
-hugr = "0.14.2"
-hugr-core = "0.14.2"
-hugr-cli = "0.14.2"
-portgraph = "0.13.0"
+hugr = "0.14.3"
+hugr-core = "0.14.3"
+hugr-cli = "0.14.3"
+portgraph = "0.13.1"
 pyo3 = "0.23.4"
 itertools = "0.13.0"
 tket-json-rs = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,19 +26,20 @@ missing_docs = "warn"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-# hugr = { git = "https://github.com/CQCL/hugr", ref = "1e9eee2" }
-# hugr-core = { git = "https://github.com/CQCL/hugr", ref = "1e9eee2" }
-# hugr-passes = { git = "https://github.com/CQCL/hugr", ref = "1e9eee2" }
-# hugr-cli = { git = "https://github.com/CQCL/hugr", ref = "1e9eee2" }
-# hugr-model = { git = "https://github.com/CQCL/hugr", ref = "1e9eee2" }
+hugr = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+hugr-core = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+hugr-model = { git = "https://github.com/CQCL/hugr", rev = "09bd748398ce5afb39f5628d838756ccc03fc775" }
+portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]
 
 # Make sure to run `just recompile-eccs` if the hugr serialisation format changes.
-hugr = "0.14.1"
-hugr-core = "0.14.1"
-hugr-cli = "0.14.1"
-portgraph = "0.12"
+hugr = "0.14.2"
+hugr-core = "0.14.2"
+hugr-cli = "0.14.2"
+portgraph = "0.13.0"
 pyo3 = "0.23.4"
 itertools = "0.13.0"
 tket-json-rs = "0.7.1"
@@ -63,7 +64,7 @@ num_cpus = "1.16.0"
 peak_alloc = "0.2.0"
 pest = "2.7.15"
 pest_derive = "2.7.15"
-petgraph = { version = "0.6.3", default-features = false }
+petgraph = { version = "0.7.1", default-features = false }
 priority-queue = "2.1.1"
 rayon = "1.5"
 rmp-serde = "1.1.2"


### PR DESCRIPTION
Currently waiting for the package releases.

Requires the fix in https://github.com/CQCL/portgraph/pull/178.

BREAKING CHANGE: Bumped `hugr` dependency to `0.15`