### PR TITLE
chore: Run ci on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - '*'
   merge_group:
     types: [checks_requested]
   workflow_dispatch: {}


### PR DESCRIPTION
The '*' pattern does not match branch names with slashes.