### PR TITLE
feat: Add CircuitHistory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.14.3"
-source = "git+https://github.com/CQCL/hugr?rev=0efc806f#0efc806f99888e64a0da6f639e4dbb83afebd4bf"
+source = "git+https://github.com/CQCL/hugr?rev=739cf944#739cf94404d45622ee196b1c68de6bec6a2b28d8"
 dependencies = [
  "hugr-core",
  "hugr-passes",
@@ -955,7 +955,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.14.3"
-source = "git+https://github.com/CQCL/hugr?rev=0efc806f#0efc806f99888e64a0da6f639e4dbb83afebd4bf"
+source = "git+https://github.com/CQCL/hugr?rev=739cf944#739cf94404d45622ee196b1c68de6bec6a2b28d8"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -968,7 +968,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.14.3"
-source = "git+https://github.com/CQCL/hugr?rev=0efc806f#0efc806f99888e64a0da6f639e4dbb83afebd4bf"
+source = "git+https://github.com/CQCL/hugr?rev=739cf944#739cf94404d45622ee196b1c68de6bec6a2b28d8"
 dependencies = [
  "bitvec",
  "bumpalo",
@@ -1000,7 +1000,7 @@ dependencies = [
 [[package]]
 name = "hugr-passes"
 version = "0.14.3"
-source = "git+https://github.com/CQCL/hugr?rev=0efc806f#0efc806f99888e64a0da6f639e4dbb83afebd4bf"
+source = "git+https://github.com/CQCL/hugr?rev=739cf944#739cf94404d45622ee196b1c68de6bec6a2b28d8"
 dependencies = [
  "ascent",
  "hugr-core",
@@ -2730,4 +2730,4 @@ dependencies = [
 [[patch.unused]]
 name = "hugr-model"
 version = "0.17.1"
-source = "git+https://github.com/CQCL/hugr?rev=0efc806f#0efc806f99888e64a0da6f639e4dbb83afebd4bf"
+source = "git+https://github.com/CQCL/hugr?rev=739cf944#739cf94404d45622ee196b1c68de6bec6a2b28d8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,11 @@ missing_docs = "warn"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/CQCL/hugr", rev = "0efc806f" }
-hugr-core = { git = "https://github.com/CQCL/hugr", rev = "0efc806f" }
-hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "0efc806f" }
-hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "0efc806f" }
-hugr-model = { git = "https://github.com/CQCL/hugr", rev = "0efc806f" }
+hugr = { git = "https://github.com/CQCL/hugr", rev = "739cf944" }
+hugr-core = { git = "https://github.com/CQCL/hugr", rev = "739cf944" }
+hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "739cf944" }
+hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "739cf944" }
+hugr-model = { git = "https://github.com/CQCL/hugr", rev = "739cf944" }
 # portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/tket2/src/diff/experimental.rs
+++ b/tket2/src/diff/experimental.rs
@@ -1,0 +1,316 @@
+//! Experimental implementation of HugrView for [`CircuitHistory`].
+//!
+//! Access the implementation using the [`ExperimentalHugrWrapper`] type.
+//!
+//! ## Limitations
+//!  - Panics on histories with more than 2^16 = 65 536 diffs or which contain
+//!    a diff with more than 2^16 - 1 nodes.
+//!  - Does not implement [`HugrInternals::portgraph`] or
+//!    [`HugrInternals::base_hugr`], as these are not well defined for the
+//!    history as a whole.
+//!  - [`HugrView::nodes`] and [`HugrView::node_count`] are inefficient: they
+//!    iterate over the entire hugr. Currently, no implementation of
+//!    [`HugrView::edge_count`] is provided.
+//!
+//! Better support for this would require modifications to the [`HugrView`]
+//! and [`HugrInternals`] traits.
+
+use std::collections::BTreeSet;
+
+use derive_more::{From, Into};
+use derive_where::derive_where;
+use hugr::{
+    hugr::views::ExtractHugr,
+    ops::{OpType, DEFAULT_OPTYPE},
+    Direction, Hugr, HugrView, Node, NodeIndex, Port,
+};
+use hugr_core::hugr::internal::HugrInternals;
+use itertools::Itertools;
+
+use crate::{
+    diff::{CircuitDiff, Owned},
+    Circuit,
+};
+
+use super::CircuitHistory;
+
+/// A wrapper around a [`CircuitHistory`] which implements [`HugrView`].
+///
+/// This is experimental and has significant limitations.
+///
+/// ## Limitations
+///  - Panics on histories with more than 2^16 = 65 536 diffs or which contain
+///    a diff with more than 2^16 - 1 nodes.
+///  - Does not implement [`HugrInternals::portgraph`] or
+///    [`HugrInternals::base_hugr`], as these are not well defined for the
+///    history as a whole.
+///  - [`HugrView::nodes`] and [`HugrView::node_count`] are inefficient: they
+///    iterate over the entire hugr. Currently, no implementation of
+///    [`HugrView::edge_count`] is provided.
+#[derive(Clone, From, Into)]
+pub struct ExperimentalHugrWrapper<H: HugrView>(pub CircuitHistory<H>);
+
+impl<H: HugrView> ExperimentalHugrWrapper<H> {
+    /// View the history as a circuit
+    pub fn as_circuit(&self) -> Circuit<&ExperimentalHugrWrapper<H>> {
+        Circuit::new(self, self.root())
+    }
+
+    /// Get the underlying hugr of a diff
+    fn get_diff_hugr(&self, diff_index: usize) -> &H {
+        // Get the diff_index-th element from all_nodes()
+        let &diff_id = self
+            .0
+            .diffs
+            .all_nodes()
+            .iter()
+            .nth(diff_index)
+            .expect("invalid diff index");
+        let diff = self.0.diffs.get_node(diff_id);
+        diff.value().circuit.circuit().hugr()
+    }
+
+    fn get_diff(&self, diff_index: usize) -> CircuitDiff<H> {
+        // Get the diff_index-th element from all_nodes()
+        let &diff_id = self
+            .0
+            .diffs
+            .all_nodes()
+            .iter()
+            .nth(diff_index)
+            .expect("invalid diff index");
+        CircuitDiff(self.0.diffs.get_node_rc(diff_id))
+    }
+
+    fn get_diff_index(&self, diff: &CircuitDiff<H>) -> Option<usize> {
+        self.0
+            .diffs
+            .all_nodes()
+            .iter()
+            .position(|id| self.0.diffs.get_node_rc(*id).ptr_eq(&diff.0))
+    }
+}
+
+impl<H: HugrView> HugrView for ExperimentalHugrWrapper<H> {
+    fn contains_node(&self, node: Node) -> bool {
+        let node: CircuitHistoryNode = node.into();
+        // Get the diff_index-th element from all_nodes()
+        let diff = node.diff(self);
+        if !self.0.is_root(&diff) && diff.io_nodes().contains(&node.node()) {
+            // Non-root IO nodes are not part of the hugr
+            return false;
+        }
+        diff.as_hugr().contains_node(node.node())
+    }
+
+    fn node_count(&self) -> usize {
+        self.nodes().count()
+    }
+
+    fn edge_count(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn nodes(&self) -> impl Iterator<Item = Node> + Clone {
+        let current = self.get_io(self.root()).unwrap().to_vec();
+        let children = NodesIter {
+            visited: BTreeSet::default(),
+            current,
+            history: self,
+        };
+        [self.root_node()].into_iter().chain(children)
+    }
+
+    fn node_ports(&self, node: Node, dir: Direction) -> impl Iterator<Item = Port> + Clone {
+        let node: CircuitHistoryNode = node.into();
+        let hugr = self.get_diff_hugr(node.diff_index as usize);
+        hugr.node_ports(node.node(), dir)
+    }
+
+    fn all_node_ports(&self, node: Node) -> impl Iterator<Item = Port> + Clone {
+        let node: CircuitHistoryNode = node.into();
+        let hugr = self.get_diff_hugr(node.diff_index as usize);
+        hugr.all_node_ports(node.node())
+    }
+
+    fn linked_ports(
+        &self,
+        node: Node,
+        port: impl Into<Port>,
+    ) -> impl Iterator<Item = (Node, Port)> + Clone {
+        let node: CircuitHistoryNode = node.into();
+        let node_port = Owned {
+            owner: node.diff(self),
+            data: (node.node(), port.into()),
+        };
+        let into_node = |node_port: Owned<H, (Node, Port)>| {
+            let Owned { owner, data } = node_port;
+            let diff_index = self.get_diff_index(&owner).unwrap();
+            let node = CircuitHistoryNode::try_new(diff_index, data.0)
+                .expect("diff_index or node_index too large for CircuitHistoryNode");
+            (node.into(), data.1)
+        };
+        self.0.linked_ports(node_port).map(into_node)
+    }
+
+    fn node_connections(&self, node: Node, other: Node) -> impl Iterator<Item = [Port; 2]> + Clone {
+        let ports = self
+            .node_inputs(node)
+            .map_into()
+            .chain(self.node_outputs(node).map_into());
+        ports.flat_map(move |p| {
+            self.linked_ports(node, p)
+                .filter(move |(n, _)| n == &other)
+                .map(move |(_, other_p)| [p, other_p])
+        })
+    }
+
+    fn num_ports(&self, node: Node, dir: Direction) -> usize {
+        let node: CircuitHistoryNode = node.into();
+        let hugr = self.get_diff_hugr(node.diff_index as usize);
+        hugr.num_ports(node.node(), dir)
+    }
+
+    fn children(&self, node: Node) -> impl DoubleEndedIterator<Item = Node> + Clone {
+        let node: CircuitHistoryNode = node.into();
+        let hugr = self.get_diff_hugr(node.diff_index as usize);
+        let to_owned = move |n| {
+            CircuitHistoryNode::try_new(node.diff_index as usize, n)
+                .unwrap()
+                .into()
+        };
+        hugr.children(node.node()).map(to_owned)
+    }
+
+    fn neighbours(&self, node: Node, dir: Direction) -> impl Iterator<Item = Node> + Clone {
+        self.node_ports(node, dir)
+            .flat_map(move |p| self.linked_ports(node, p))
+            .map(|(n, _)| n)
+    }
+
+    fn all_neighbours(&self, node: Node) -> impl Iterator<Item = Node> + Clone {
+        self.neighbours(node, Direction::Incoming)
+            .chain(self.neighbours(node, Direction::Outgoing))
+    }
+
+    /// Returns the operation type of a node.
+    fn get_optype(&self, node: Node) -> &OpType {
+        match self.contains_node(node) {
+            true => {
+                let node: CircuitHistoryNode = node.into();
+                // Get the diff_index-th element from all_nodes()
+                let hugr = self.get_diff_hugr(node.diff_index as usize);
+                hugr.get_optype(node.node())
+            }
+            false => &DEFAULT_OPTYPE,
+        }
+    }
+}
+
+/// Iterator over all nodes in the graph, using a simple depth-first search
+#[derive_where(Clone)]
+struct NodesIter<'h, H: HugrView> {
+    visited: BTreeSet<Node>,
+    current: Vec<Node>,
+    history: &'h ExperimentalHugrWrapper<H>,
+}
+
+impl<'h, H: HugrView> Iterator for NodesIter<'h, H> {
+    type Item = Node;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(node) = self.current.pop() {
+            debug_assert!(self.history.contains_node(node));
+            if self.visited.insert(node) {
+                // Add all neighbours to current
+                self.current.extend(
+                    self.history
+                        .all_neighbours(node)
+                        .filter(|n| !self.visited.contains(n)),
+                );
+                return Some(node);
+            }
+        }
+        None
+    }
+}
+
+impl<H: HugrView> HugrInternals for ExperimentalHugrWrapper<H> {
+    type Portgraph<'p> = H::Portgraph<'p> where Self: 'p;
+
+    fn portgraph(&self) -> Self::Portgraph<'_> {
+        unimplemented!("no single portgraph for history")
+    }
+
+    fn base_hugr(&self) -> &hugr::Hugr {
+        unimplemented!("no single base hugr for history")
+    }
+
+    fn root_node(&self) -> hugr::Node {
+        let diff_index = self.get_diff_index(&self.0.root).unwrap();
+        let node = CircuitHistoryNode::try_new(diff_index, self.0.root.as_hugr().root_node())
+            .expect("diff_index or node_index too large for CircuitHistoryNode");
+        node.into()
+    }
+}
+
+impl<H: HugrView> ExtractHugr for ExperimentalHugrWrapper<H> {
+    fn extract_hugr(self) -> Hugr {
+        self.0.extract_hugr()
+    }
+}
+
+/// A node in the history, that can disguise as a [`Node`]
+///
+/// This is an ugly hack, where we encode the two integers of information
+/// (the diff index in the history and the node index) into a single
+/// [Node] by using the lower and upper 16 bits of the index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct CircuitHistoryNode {
+    /// The diff index this node belongs to
+    diff_index: u16,
+    /// The node index within the diff
+    node_index: u16,
+}
+
+impl CircuitHistoryNode {
+    fn try_new(diff_index: usize, node: Node) -> Option<Self> {
+        let diff_index = u16::try_from(diff_index).ok()?;
+        let node_index = u16::try_from(node.index()).ok()?;
+
+        Some(Self {
+            diff_index,
+            node_index,
+        })
+    }
+
+    fn node(&self) -> Node {
+        Node::from(portgraph::NodeIndex::new(self.node_index as usize))
+    }
+
+    fn diff<H: HugrView>(&self, history: &ExperimentalHugrWrapper<H>) -> CircuitDiff<H> {
+        history.get_diff(self.diff_index as usize)
+    }
+}
+
+impl From<Node> for CircuitHistoryNode {
+    fn from(node: Node) -> Self {
+        let index = node.index();
+        // The node index is the lower 16 bits of the node index
+        let node_index = (index & 0xFFFF) as u16;
+        // The diff index is the upper 16 bits of the node index
+        let diff_index = (index >> 16) as u16;
+        Self {
+            diff_index,
+            node_index,
+        }
+    }
+}
+
+impl From<CircuitHistoryNode> for Node {
+    fn from(node: CircuitHistoryNode) -> Self {
+        let mut index = node.node_index as usize;
+        index |= (node.diff_index as usize) << 16;
+        Node::from(portgraph::NodeIndex::new(index))
+    }
+}

--- a/tket2/src/diff/history.rs
+++ b/tket2/src/diff/history.rs
@@ -1,0 +1,518 @@
+//! History of circuit transformations.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    hash::Hash,
+};
+
+use derive_where::derive_where;
+use hugr::{hugr::hugrmut::HugrMut, Hugr, HugrView, Node, Port};
+use itertools::Itertools;
+use relrc::RelRcGraph;
+
+use crate::{circuit::HashError, Circuit};
+
+use super::{CircuitDiff, CircuitDiffData, CircuitDiffError, CircuitDiffPtr, InvalidNodes, Owned};
+
+/// A set of compatible diffs
+#[derive_where(Clone)]
+pub struct CircuitHistory<H> {
+    /// The root of the history that dominates all other diffs
+    pub(super) root: CircuitDiff<H>,
+    /// The set of diffs in the history, stored as a relrc graph
+    pub(super) diffs: RelRcGraph<CircuitDiffData<H>, InvalidNodes>,
+}
+
+impl<H: HugrView> CircuitHistory<H> {
+    /// Create a (trivial) history from a circuit
+    ///
+    /// This will fail if the conversion from circuit to diff fails.
+    pub fn try_from_circuit(circuit: Circuit<H>) -> Result<Self, HashError> {
+        let diff = CircuitDiff::try_from_circuit(circuit)?;
+        Ok(Self::from_diff(diff))
+    }
+
+    /// Create a new history for a single diff
+    ///
+    /// This will include `diff` and all its ancestors
+    pub fn from_diff(diff: CircuitDiff<H>) -> Self {
+        let graph = RelRcGraph::from_sinks(vec![diff.0]);
+        let root = get_root(&graph).expect("no unique root found").into();
+        Self { root, diffs: graph }
+    }
+
+    /// Create the joint history of multiple diffs
+    ///
+    /// This will fail if any of the diffs are incompatible, returning a
+    /// [`CircuitDiffError::ConflictingDiffs`] in that case.
+    pub fn try_from_diffs(
+        diffs: impl IntoIterator<Item = CircuitDiff<H>>,
+    ) -> Result<Self, CircuitDiffError> {
+        let mut histories = diffs.into_iter().map(Self::from_diff);
+        histories
+            .try_fold(None, |mut acc: Option<Self>, diff| {
+                if let Some(acc) = acc.as_mut() {
+                    acc.merge(diff)?;
+                } else {
+                    acc = Some(diff);
+                }
+                Ok(acc)
+            })
+            .and_then(|res| res.ok_or(CircuitDiffError::EmptyHistory))
+    }
+
+    /// Merge two histories
+    ///
+    /// This will fail if the histories are incompatible, returning a
+    /// [`CircuitDiffError::ConflictingDiffs`] in that case.
+    pub fn merge(&mut self, other: Self) -> Result<(), CircuitDiffError> {
+        if !self.root.0.ptr_eq(&other.root.0) {
+            // TODO: we currently disallow merging histories with distinct roots
+            // in the future, this could instead compute the dominator node of
+            // the two histories and merge the histories at that node
+            return Err(CircuitDiffError::DistinctRoots);
+        }
+        self.diffs.merge(other.diffs, |_, self_edges, other_edges| {
+            let self_invalidated = self_edges.iter().flat_map(|e| e.value());
+            let other_invalidated = other_edges.iter().flat_map(|e| e.value());
+            let mut invalidated = self_invalidated.chain(other_invalidated);
+            if invalidated.all_unique() {
+                Ok(())
+            } else {
+                Err(CircuitDiffError::ConflictingDiffs)
+            }
+        })
+    }
+
+    /// Check if a diff is in the history
+    pub fn contains_diff(&self, diff: &CircuitDiff<H>) -> bool {
+        self.diffs.all_nodes().contains(&(&diff.0).into())
+    }
+
+    /// Check if a diff is the root of the history
+    pub fn is_root(&self, diff: &CircuitDiff<H>) -> bool {
+        self.root.0.ptr_eq(&diff.0)
+    }
+
+    /// Check if a port is valid in the history
+    ///
+    /// A port is valid if a) its owner is in the history, b) the port is not
+    /// invalidated by any child diff in the history and c) it is not
+    /// the input or output port of a non-root diff.
+    pub fn is_valid_port(&self, node_port: &Owned<H, (Node, Port)>) -> bool {
+        let diff = &node_port.owner;
+        let node = node_port.data.0;
+        // check a) the owner is in the history
+        if !self.contains_diff(&diff) {
+            return false;
+        }
+        // check c) it is not the input or output port of a non-root diff
+        if !self.is_root(diff) && diff.io_nodes().contains(&node) {
+            return false;
+        }
+        // check b) the port is not invalidated by any child diff
+        let mut out_edges = diff.0.all_outgoing().into_iter().filter(|e| {
+            let target = e.target();
+            self.contains_diff(&CircuitDiff(target.clone()))
+        });
+        out_edges.all(|e| !e.value().contains(&node))
+    }
+
+    /// Get the valid ports opposite to a given port in `self`
+    ///
+    /// The set of edges given by [`Self::linked_ports`] always defines a valid
+    /// Hugr.
+    pub fn linked_ports(
+        &self,
+        node_port: Owned<H, (Node, Port)>,
+    ) -> impl Iterator<Item = Owned<H, (Node, Port)>> + Clone + '_ {
+        let valid_diff = |diff: &CircuitDiff<H>| self.contains_diff(diff);
+        self.equivalent_ports(node_port, valid_diff)
+            .flat_map(|node_port| {
+                let (node, port) = node_port.data;
+                let diff = node_port.owner;
+                let to_owned = |data| Owned {
+                    owner: diff.clone(),
+                    data,
+                };
+                diff.as_hugr()
+                    .linked_ports(node, port)
+                    .map(to_owned)
+                    .collect_vec()
+            })
+            .filter(|node_port| self.is_valid_port(&node_port))
+            .unique_by(|node_port| (node_port.owner.as_ptr(), node_port.data))
+    }
+
+    /// All ports equivalent to a given port.
+    ///
+    /// The returned ports may not be in `self`. Will traverse all ancestors
+    /// and descendants of `node_port` for as long as `valid_diff` returns
+    /// true.
+    pub fn equivalent_ports(
+        &self,
+        node_port: Owned<H, (Node, Port)>,
+        valid_diff: impl FnMut(&CircuitDiff<H>) -> bool + Clone,
+    ) -> impl Iterator<Item = Owned<H, (Node, Port)>> + Clone {
+        let current = VecDeque::from([node_port]);
+        EquivalentPortsIter {
+            visited: BTreeSet::new(),
+            current,
+            valid_diff,
+        }
+    }
+
+    /// Build a hugr equivalent to the history
+    pub fn extract_hugr(&self) -> Hugr {
+        use super::experimental::ExperimentalHugrWrapper;
+        let exp_self = ExperimentalHugrWrapper(self.clone());
+        let mut hugr = Hugr::new(exp_self.get_optype(exp_self.root()).clone());
+        let hugr_root = hugr.root();
+
+        let mut node_map = BTreeMap::new();
+
+        // Add input/output node
+        let [in_node, out_node] = exp_self.get_io(exp_self.root()).unwrap();
+        let new_in_node =
+            hugr.add_node_with_parent(hugr_root, exp_self.get_optype(in_node).clone());
+        node_map.insert(in_node, new_in_node);
+        let new_out_node =
+            hugr.add_node_with_parent(hugr_root, exp_self.get_optype(out_node).clone());
+        node_map.insert(out_node, new_out_node);
+
+        // Add all other nodes
+        for node in exp_self.nodes() {
+            if ![in_node, out_node, exp_self.root()].contains(&node) {
+                let new_node =
+                    hugr.add_node_with_parent(hugr_root, exp_self.get_optype(node).clone());
+                node_map.insert(node, new_node);
+            }
+        }
+
+        // Add all edges
+        for (&old_out_node, &new_out_node) in node_map.iter() {
+            for out_port in exp_self.node_outputs(old_out_node) {
+                for (old_in_node, in_port) in exp_self.linked_inputs(old_out_node, out_port) {
+                    let new_in_node = node_map[&old_in_node];
+                    hugr.connect(new_out_node, out_port, new_in_node, in_port);
+                }
+            }
+        }
+
+        hugr
+    }
+}
+
+/// Return the unique node with no parents in `graph`
+fn get_root<N: Hash, E: Hash>(graph: &relrc::RelRcGraph<N, E>) -> Option<relrc::RelRc<N, E>> {
+    let nodes = graph.all_nodes().iter().map(|&n| graph.get_node_rc(n));
+    nodes
+        .filter(|n| n.all_parents().next().is_none())
+        .exactly_one()
+        .ok()
+}
+
+/// Iterator over all equivalent ports in a history
+#[derive_where(Clone; F)]
+pub struct EquivalentPortsIter<H, F> {
+    visited: BTreeSet<(CircuitDiffPtr<H>, Node, Port)>,
+    current: VecDeque<Owned<H, (Node, Port)>>,
+    valid_diff: F,
+}
+
+fn get_key<H>(node_port: &Owned<H, (Node, Port)>) -> (CircuitDiffPtr<H>, Node, Port) {
+    (node_port.owner.as_ptr(), node_port.data.0, node_port.data.1)
+}
+
+impl<H: HugrView, F: FnMut(&CircuitDiff<H>) -> bool> Iterator for EquivalentPortsIter<H, F> {
+    type Item = Owned<H, (Node, Port)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let node_port = self.current.pop_front()?;
+            if self.visited.insert(get_key(&node_port)) {
+                let Owned { owner, data } = &node_port;
+                let neighbours = owner
+                    .equivalent_children_ports(data.0, data.1)
+                    .chain(owner.equivalent_parent_ports(data.0, data.1));
+                self.current.extend(
+                    neighbours
+                        .filter(|p| !self.visited.contains(&get_key(p)))
+                        .filter(|p| (self.valid_diff)(&p.owner)),
+                );
+                return Some(node_port);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use hugr::{
+        builder::{DFGBuilder, Dataflow, HugrBuilder},
+        extension::prelude::qb_t,
+        hugr::views::SiblingSubgraph,
+        types::Signature,
+        Hugr, HugrView, Node, SimpleReplacement,
+    };
+    use itertools::Itertools;
+    use portgraph::NodeIndex;
+    use rstest::{fixture, rstest};
+
+    use crate::{
+        circuit::CircuitHash,
+        diff::{experimental::ExperimentalHugrWrapper, CircuitDiff, CircuitHistory},
+        extension::rotation::{rotation_type, RotationOp},
+        rewrite::CircuitRewrite,
+        Circuit, Tk2Op,
+    };
+
+    struct CircuitAndThreeRewrites {
+        /// A test circuit
+        circuit: Circuit<Hugr>,
+        /// Three replacements to be applied as diffs
+        diff_replacements: [CircuitRewrite; 3],
+        /// Three replacements to be applied in the "traditional" way that are
+        /// equivalent to the diff replacements
+        flat_replacements: [CircuitRewrite; 3],
+    }
+
+    #[fixture]
+    fn circuit_and_three_rewrites() -> CircuitAndThreeRewrites {
+        // Create the main circuit with [rz(a), rz(b), h, rx(a+b), h]
+        let sum_ab;
+        let circuit = {
+            let mut builder = DFGBuilder::new(Signature::new(
+                vec![qb_t(), rotation_type(), rotation_type()], // qb, a, b
+                vec![qb_t()],
+            ))
+            .unwrap();
+
+            let [qb, a, b] = builder.input_wires_arr();
+
+            // Gate 1: rz(a)
+            let op1 = builder.add_dataflow_op(Tk2Op::Rz, vec![qb, a]).unwrap();
+            let [qb1] = op1.outputs_arr();
+
+            // Gate 2: rz(b)
+            let op2 = builder.add_dataflow_op(Tk2Op::Rz, vec![qb1, b]).unwrap();
+            let [qb2] = op2.outputs_arr();
+
+            // Gate 3: h
+            let op3 = builder.add_dataflow_op(Tk2Op::H, vec![qb2]).unwrap();
+            let [qb3] = op3.outputs_arr();
+
+            // Gate 4: rx(a+b)
+            let op_add = builder
+                .add_dataflow_op(RotationOp::radd, vec![a, b])
+                .unwrap();
+            sum_ab = op_add.outputs().next();
+            let op4 = builder
+                .add_dataflow_op(Tk2Op::Rx, vec![qb3, sum_ab.unwrap()])
+                .unwrap();
+            let [qb4] = op4.outputs_arr();
+
+            // Gate 5: h
+            let op5 = builder.add_dataflow_op(Tk2Op::H, vec![qb4]).unwrap();
+            let [qb_final] = op5.outputs_arr();
+
+            builder.set_outputs(vec![qb_final]).unwrap();
+            let hugr = builder.finish_hugr().unwrap();
+            let root = hugr.root();
+            Circuit::new(hugr, root)
+        };
+
+        // Create the three replacements
+        let mut flat_replacements = Vec::with_capacity(3);
+        let mut diff_replacements = Vec::with_capacity(3);
+
+        // 1. Merge rz(a) rz(b) into rz(a+b)
+        let replacement: CircuitRewrite = {
+            let subgraph = SiblingSubgraph::try_from_nodes(
+                (3..=4).map(NodeIndex::new).map_into().collect_vec(),
+                circuit.hugr(),
+            )
+            .unwrap();
+            let repl = {
+                let mut builder = DFGBuilder::new(Signature::new(
+                    vec![qb_t(), rotation_type(), rotation_type()],
+                    vec![qb_t()],
+                ))
+                .unwrap();
+                let [qb, a, b] = builder.input_wires_arr();
+                let op_add = builder
+                    .add_dataflow_op(RotationOp::radd, vec![a, b])
+                    .unwrap();
+                let [sum] = op_add.outputs_arr();
+                let op_rz = builder.add_dataflow_op(Tk2Op::Rz, vec![qb, sum]).unwrap();
+                let [qb_out] = op_rz.outputs_arr();
+                builder.set_outputs(vec![qb_out]).unwrap();
+                builder.finish_hugr().unwrap()
+            };
+            let repl_circ = Circuit::new(&repl, repl.root());
+            let nu_inp = repl
+                .all_linked_inputs(repl_circ.input_node())
+                .zip(circuit.hugr().all_linked_inputs(circuit.input_node()))
+                .collect();
+            let nu_out = {
+                let last_node: Node = NodeIndex::new(4).into();
+                (circuit.hugr().linked_inputs(last_node, 0))
+                    .zip(repl.node_inputs(repl_circ.output_node()))
+                    .collect()
+            };
+            SimpleReplacement::new(subgraph, repl, nu_inp, nu_out).into()
+        };
+        diff_replacements.push(replacement.clone());
+        flat_replacements.push(replacement);
+
+        // 2. Replace h rx(x) h with rz(x)
+        let replacement: CircuitRewrite = {
+            let subgraph = SiblingSubgraph::try_from_nodes(
+                [5, 9, 10].map(NodeIndex::new).map(Into::into),
+                circuit.hugr(),
+            )
+            .unwrap();
+            let repl = {
+                let mut builder =
+                    DFGBuilder::new(Signature::new(vec![qb_t(), rotation_type()], vec![qb_t()]))
+                        .unwrap();
+                let [qb, x] = builder.input_wires_arr();
+                let op_rz = builder.add_dataflow_op(Tk2Op::Rz, vec![qb, x]).unwrap();
+                let [qb_out] = op_rz.outputs_arr();
+                builder.set_outputs(vec![qb_out]).unwrap();
+                builder.finish_hugr().unwrap()
+            };
+            let repl_circ = Circuit::new(&repl, repl.root());
+            let nu_inp = {
+                let sum_ab_target = circuit
+                    .hugr()
+                    .single_linked_input(sum_ab.unwrap().node(), sum_ab.unwrap().source())
+                    .unwrap();
+                let first_node: Node = NodeIndex::new(5).into();
+                repl.all_linked_inputs(repl_circ.input_node())
+                    .zip([(first_node, 0.into()), sum_ab_target])
+                    .collect()
+            };
+            let nu_out = HashMap::from_iter([((circuit.output_node(), 0.into()), 0.into())]);
+            SimpleReplacement::new(subgraph, repl, nu_inp, nu_out).into()
+        };
+        diff_replacements.push(replacement.clone());
+        flat_replacements.push(replacement);
+
+        // 3. Merge rz(x) rz(y) into rz(x + y)
+        let replacement: CircuitRewrite = {
+            let subgraph = {
+                let mut circuit = circuit.clone();
+                flat_replacements[0].clone().apply(&mut circuit).unwrap();
+                flat_replacements[1].clone().apply(&mut circuit).unwrap();
+                SiblingSubgraph::try_from_nodes(
+                    [15, 16].map(NodeIndex::new).map(Into::into),
+                    circuit.hugr(),
+                )
+                .unwrap()
+            };
+            let repl = {
+                let mut builder = DFGBuilder::new(Signature::new(
+                    vec![qb_t(), rotation_type(), rotation_type()],
+                    vec![qb_t()],
+                ))
+                .unwrap();
+                let [qb, x, y] = builder.input_wires_arr();
+                let op_add = builder
+                    .add_dataflow_op(RotationOp::radd, vec![x, y])
+                    .unwrap();
+                let [sum] = op_add.outputs_arr();
+                let op_rz = builder.add_dataflow_op(Tk2Op::Rz, vec![qb, sum]).unwrap();
+                let [qb_out] = op_rz.outputs_arr();
+                builder.set_outputs(vec![qb_out]).unwrap();
+                builder.finish_hugr().unwrap()
+            };
+            let repl_circ = Circuit::new(&repl, repl.root());
+            let nu_inp = {
+                let first_rz: Node = NodeIndex::new(15).into();
+                let second_rz: Node = NodeIndex::new(16).into();
+                repl.all_linked_inputs(repl_circ.input_node())
+                    .zip([
+                        (first_rz, 0.into()),
+                        (first_rz, 1.into()),
+                        (second_rz, 1.into()),
+                    ])
+                    .collect()
+            };
+            let nu_out = HashMap::from_iter([((circuit.output_node(), 0.into()), 0.into())]);
+            SimpleReplacement::new(subgraph, repl, nu_inp, nu_out).into()
+        };
+        diff_replacements.push(replacement.clone());
+        flat_replacements.push(replacement); // dummy
+
+        let diff_replacements: [CircuitRewrite; 3] = diff_replacements.try_into().unwrap();
+        let flat_replacements: [CircuitRewrite; 3] = flat_replacements.try_into().unwrap();
+        CircuitAndThreeRewrites {
+            circuit,
+            diff_replacements,
+            flat_replacements,
+        }
+    }
+
+    fn compare_hashes(circuit: &Circuit<Hugr>, diffs: impl IntoIterator<Item = CircuitDiff>) {
+        let flat_hash = circuit.circuit_hash().unwrap();
+        let history = CircuitHistory::try_from_diffs(diffs).unwrap();
+        let exp_history: ExperimentalHugrWrapper<_> = history.into();
+        let diff_hash = exp_history.circuit_hash().unwrap();
+        assert_eq!(flat_hash, diff_hash);
+    }
+
+    #[rstest]
+    fn test_history(circuit_and_three_rewrites: CircuitAndThreeRewrites) {
+        let CircuitAndThreeRewrites {
+            mut circuit,
+            diff_replacements: [diff_rw1, diff_rw2, _diff_rw3],
+            flat_replacements: [flat_rw1, flat_rw2, flat_rw3],
+        } = circuit_and_three_rewrites;
+
+        // let history = CircuitHistory::try_from_circuit(circuit.clone()).unwrap();
+        let diff = CircuitDiff::try_from_circuit(circuit.clone()).unwrap();
+
+        flat_rw1.apply(&mut circuit).unwrap();
+        let new_diff1 = diff.apply_rewrite(diff_rw1).unwrap();
+        compare_hashes(&circuit, [new_diff1.clone()]);
+
+        flat_rw2.apply(&mut circuit).unwrap();
+        let new_diff2 = diff.apply_rewrite(diff_rw2).unwrap();
+        compare_hashes(&circuit, [new_diff1.clone(), new_diff2.clone()]);
+
+        flat_rw3.apply(&mut circuit).unwrap();
+        println!("{}", circuit.mermaid_string());
+        // println!(
+        //     "{}",
+        //     CircuitHistory::try_from_diffs([new_diff1.clone(), new_diff2.clone()])
+        //         .unwrap()
+        //         .extract_hugr()
+        //         .mermaid_string()
+        // );
+        // let new_diff3 = diff.apply_rewrite(diff_rw3).unwrap();
+        // compare_hashes(
+        //     &circuit,
+        //     [new_diff1.clone(), new_diff2.clone(), new_diff3.clone()],
+        // );
+        unimplemented!("finish with a rewrite that overlaps with the previous diffs");
+    }
+
+    #[rstest]
+    fn test_extract_hugr(circuit_and_three_rewrites: CircuitAndThreeRewrites) {
+        let CircuitAndThreeRewrites {
+            circuit,
+            diff_replacements: [diff_rw1, diff_rw2, _],
+            ..
+        } = circuit_and_three_rewrites;
+
+        let diff = CircuitDiff::try_from_circuit(circuit).unwrap();
+        let new_diff1 = diff.apply_rewrite(diff_rw1).unwrap();
+        let new_diff2 = diff.apply_rewrite(diff_rw2).unwrap();
+
+        let history = CircuitHistory::try_from_diffs([new_diff1, new_diff2]).unwrap();
+        insta::assert_snapshot!(history.extract_hugr().mermaid_string());
+    }
+}

--- a/tket2/src/diff/snapshots/tket2__diff__history__tests__extract_hugr.snap
+++ b/tket2/src/diff/snapshots/tket2__diff__history__tests__extract_hugr.snap
@@ -1,0 +1,23 @@
+---
+source: tket2/src/diff/history.rs
+expression: history.extract_hugr().mermaid_string()
+---
+graph LR
+    subgraph 0 ["(0) DFG"]
+        direction LR
+        1["(1) Input"]
+        2["(2) Output"]
+        3["(3) tket2.quantum.Rz"]
+        4["(4) tket2.rotation.radd"]
+        5["(5) tket2.rotation.radd"]
+        6["(6) tket2.quantum.Rz"]
+        1--"0:0<br>qubit"-->6
+        1--"1:0<br>rotation"-->4
+        1--"1:0<br>rotation"-->5
+        1--"1:1<br>rotation"-->5
+        1--"2:1<br>rotation"-->4
+        3--"0:0<br>qubit"-->2
+        4--"0:1<br>rotation"-->3
+        5--"0:1<br>rotation"-->6
+        6--"0:0<br>qubit"-->3
+    end


### PR DESCRIPTION
I'm putting this out here for discussion. My main question: **how should I expose the hugr-like interface of `CircuitHistory`?**. I've proposed an implementation of `HugrView` on a wrapper type `ExperimentalHugrWrapper` of the circuit history. See `src/diff/experimental.rs`. 

A `CircuitHistory` is always equivalent to a valid Hugr, but implementing `HugrView` is difficult because
- there is no "base hugr", so implementing `HugrInternals` is impossible. This could be implemented if the base hugr was node specific, i.e. `fn base_hugr(&self, node: Node) -> &Hugr`
- the `hugr::Node` type is fixed, but in a CircuitHistory the "natural" node index is a pair `(Hugr, Node)`, i.e. an index/ref to the correct hugr in the history, along with a node within it. Right now, I have "solved" this with the world's greatest hack, using the integer within `Node` to encode both a hugr index and the node index. This will overflow at `2^16` which we are bound to reach pretty quickly
- Enumerating all nodes and counting them requires traversing the hugr, so this is a slow operation. Same with edge_count