### PR TITLE
feat: add "tket2.qsystem.random" extension

### DIFF
--- a/tket2-exts/src/tket2_exts/__init__.py
+++ b/tket2-exts/src/tket2_exts/__init__.py
@@ -27,6 +27,11 @@ def qsystem() -> Extension:
 
 
 @functools.cache
+def qsystem_random() -> Extension:
+    return load_extension("tket2.qsystem.random")
+
+
+@functools.cache
 def qsystem_utils() -> Extension:
     return load_extension("tket2.qsystem.utils")
 

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -14,7 +14,7 @@
           "b": "A"
         }
       ],
-      "description": "RNGContext",
+      "description": "The linear RNG context type",
       "bound": {
         "b": "Explicit",
         "bound": "A"
@@ -23,10 +23,10 @@
   },
   "values": {},
   "operations": {
-    "DeleteContext": {
+    "DeleteRNGContext": {
       "extension": "tket2.qsystem.random",
-      "name": "DeleteContext",
-      "description": "Discard RNG context.",
+      "name": "DeleteRNGContext",
+      "description": "Discard the given RNG context.",
       "signature": {
         "params": [],
         "body": {
@@ -61,10 +61,10 @@
       },
       "binary": false
     },
-    "NewContext": {
+    "NewRNGContext": {
       "extension": "tket2.qsystem.random",
-      "name": "NewContext",
-      "description": "Get a new RNG context with a seed.",
+      "name": "NewRNGContext",
+      "description": "Seed the RNG and return a new RNG context. Required before using other RNG ops.",
       "signature": {
         "params": [],
         "body": {
@@ -124,7 +124,7 @@
     "RandomFloat": {
       "extension": "tket2.qsystem.random",
       "name": "RandomFloat",
-      "description": "Generate a random float.",
+      "description": "Generate a random floating point value in the range [0,1).",
       "signature": {
         "params": [],
         "body": {
@@ -193,7 +193,7 @@
     "RandomInt": {
       "extension": "tket2.qsystem.random",
       "name": "RandomInt",
-      "description": "Generate a random integer.",
+      "description": "Generates a pseudorandom 32-bit unsigned integer.",
       "signature": {
         "params": [],
         "body": {
@@ -267,7 +267,7 @@
     "RandomIntBounded": {
       "extension": "tket2.qsystem.random",
       "name": "RandomIntBounded",
-      "description": "Generate a random integer within the range [0, bound).",
+      "description": "Generates a 32-bit unsigned integer less than `bound`.",
       "signature": {
         "params": [],
         "body": {

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -1,0 +1,229 @@
+{
+  "version": "0.1.0",
+  "name": "tket2.qsystem.random",
+  "runtime_reqs": [
+    "prelude"
+  ],
+  "types": {
+    "context": {
+      "extension": "tket2.qsystem.random",
+      "name": "context",
+      "params": [],
+      "description": "RNGContext",
+      "bound": {
+        "b": "Explicit",
+        "bound": "A"
+      }
+    }
+  },
+  "values": {},
+  "operations": {
+    "GetContext": {
+      "extension": "tket2.qsystem.random",
+      "name": "GetContext",
+      "description": "Get the RNG context.",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [],
+          "output": [
+            {
+              "t": "Sum",
+              "s": "General",
+              "rows": [
+                [],
+                [
+                  {
+                    "t": "Opaque",
+                    "extension": "tket2.qsystem.random",
+                    "id": "module",
+                    "args": [
+                      {
+                        "tya": "Type",
+                        "ty": {
+                          "t": "Opaque",
+                          "extension": "arithmetic.int.types",
+                          "id": "int",
+                          "args": [
+                            {
+                              "tya": "BoundedNat",
+                              "n": 7
+                            }
+                          ],
+                          "bound": "C"
+                        }
+                      }
+                    ],
+                    "bound": "C"
+                  }
+                ]
+              ]
+            }
+          ],
+          "runtime_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "RandomFloat": {
+      "extension": "tket2.qsystem.random",
+      "name": "RandomFloat",
+      "description": "Generate a random float.",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "module",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "Opaque",
+                    "extension": "arithmetic.int.types",
+                    "id": "int",
+                    "args": [
+                      {
+                        "tya": "BoundedNat",
+                        "n": 7
+                      }
+                    ],
+                    "bound": "C"
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.float.types",
+              "id": "float64",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "runtime_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "RandomInt": {
+      "extension": "tket2.qsystem.random",
+      "name": "RandomInt",
+      "description": "Generate a random integer.",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "module",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "Opaque",
+                    "extension": "arithmetic.int.types",
+                    "id": "int",
+                    "args": [
+                      {
+                        "tya": "BoundedNat",
+                        "n": 7
+                      }
+                    ],
+                    "bound": "C"
+                  }
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "BoundedNat",
+                  "n": 6
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "runtime_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "RandomIntInRange": {
+      "extension": "tket2.qsystem.random",
+      "name": "RandomIntInRange",
+      "description": "Generate a random integer in the range [0, bound).",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "module",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "Opaque",
+                    "extension": "arithmetic.int.types",
+                    "id": "int",
+                    "args": [
+                      {
+                        "tya": "BoundedNat",
+                        "n": 7
+                      }
+                    ],
+                    "bound": "C"
+                  }
+                }
+              ],
+              "bound": "C"
+            },
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "BoundedNat",
+                  "n": 6
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "BoundedNat",
+                  "n": 6
+                }
+              ],
+              "bound": "C"
+            }
+          ],
+          "runtime_reqs": []
+        }
+      },
+      "binary": false
+    }
+  }
+}

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -193,7 +193,7 @@
     "RandomInt": {
       "extension": "tket2.qsystem.random",
       "name": "RandomInt",
-      "description": "Generates a random 32-bit unsigned integer.",
+      "description": "Generate a random 32-bit unsigned integer.",
       "signature": {
         "params": [],
         "body": {
@@ -267,7 +267,7 @@
     "RandomIntBounded": {
       "extension": "tket2.qsystem.random",
       "name": "RandomIntBounded",
-      "description": "Generates a 32-bit unsigned integer less than `bound`.",
+      "description": "Generate a random 32-bit unsigned integer less than `bound`.",
       "signature": {
         "params": [],
         "body": {

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -8,7 +8,12 @@
     "context": {
       "extension": "tket2.qsystem.random",
       "name": "context",
-      "params": [],
+      "params": [
+        {
+          "tp": "Type",
+          "b": "A"
+        }
+      ],
       "description": "RNGContext",
       "bound": {
         "b": "Explicit",
@@ -18,14 +23,65 @@
   },
   "values": {},
   "operations": {
-    "GetContext": {
+    "DeleteContext": {
       "extension": "tket2.qsystem.random",
-      "name": "GetContext",
-      "description": "Get the RNG context.",
+      "name": "DeleteContext",
+      "description": "Discard RNG context.",
       "signature": {
         "params": [],
         "body": {
-          "input": [],
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "context",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "Opaque",
+                    "extension": "arithmetic.int.types",
+                    "id": "int",
+                    "args": [
+                      {
+                        "tya": "BoundedNat",
+                        "n": 6
+                      }
+                    ],
+                    "bound": "C"
+                  }
+                }
+              ],
+              "bound": "A"
+            }
+          ],
+          "output": [],
+          "runtime_reqs": []
+        }
+      },
+      "binary": false
+    },
+    "NewContext": {
+      "extension": "tket2.qsystem.random",
+      "name": "NewContext",
+      "description": "Get a new RNG context with a seed.",
+      "signature": {
+        "params": [],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "arithmetic.int.types",
+              "id": "int",
+              "args": [
+                {
+                  "tya": "BoundedNat",
+                  "n": 6
+                }
+              ],
+              "bound": "C"
+            }
+          ],
           "output": [
             {
               "t": "Sum",
@@ -36,7 +92,7 @@
                   {
                     "t": "Opaque",
                     "extension": "tket2.qsystem.random",
-                    "id": "module",
+                    "id": "context",
                     "args": [
                       {
                         "tya": "Type",
@@ -47,14 +103,14 @@
                           "args": [
                             {
                               "tya": "BoundedNat",
-                              "n": 7
+                              "n": 6
                             }
                           ],
                           "bound": "C"
                         }
                       }
                     ],
-                    "bound": "C"
+                    "bound": "A"
                   }
                 ]
               ]
@@ -76,7 +132,7 @@
             {
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
-              "id": "module",
+              "id": "context",
               "args": [
                 {
                   "tya": "Type",
@@ -87,17 +143,40 @@
                     "args": [
                       {
                         "tya": "BoundedNat",
-                        "n": 7
+                        "n": 6
                       }
                     ],
                     "bound": "C"
                   }
                 }
               ],
-              "bound": "C"
+              "bound": "A"
             }
           ],
           "output": [
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "context",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "Opaque",
+                    "extension": "arithmetic.int.types",
+                    "id": "int",
+                    "args": [
+                      {
+                        "tya": "BoundedNat",
+                        "n": 6
+                      }
+                    ],
+                    "bound": "C"
+                  }
+                }
+              ],
+              "bound": "A"
+            },
             {
               "t": "Opaque",
               "extension": "arithmetic.float.types",
@@ -122,7 +201,7 @@
             {
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
-              "id": "module",
+              "id": "context",
               "args": [
                 {
                   "tya": "Type",
@@ -133,17 +212,40 @@
                     "args": [
                       {
                         "tya": "BoundedNat",
-                        "n": 7
+                        "n": 6
                       }
                     ],
                     "bound": "C"
                   }
                 }
               ],
-              "bound": "C"
+              "bound": "A"
             }
           ],
           "output": [
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "context",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "Opaque",
+                    "extension": "arithmetic.int.types",
+                    "id": "int",
+                    "args": [
+                      {
+                        "tya": "BoundedNat",
+                        "n": 6
+                      }
+                    ],
+                    "bound": "C"
+                  }
+                }
+              ],
+              "bound": "A"
+            },
             {
               "t": "Opaque",
               "extension": "arithmetic.int.types",
@@ -151,7 +253,7 @@
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 6
+                  "n": 5
                 }
               ],
               "bound": "C"
@@ -162,10 +264,10 @@
       },
       "binary": false
     },
-    "RandomIntInRange": {
+    "RandomIntBounded": {
       "extension": "tket2.qsystem.random",
-      "name": "RandomIntInRange",
-      "description": "Generate a random integer in the range [0, bound).",
+      "name": "RandomIntBounded",
+      "description": "Generate a random integer within the range [0, bound).",
       "signature": {
         "params": [],
         "body": {
@@ -173,7 +275,7 @@
             {
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
-              "id": "module",
+              "id": "context",
               "args": [
                 {
                   "tya": "Type",
@@ -184,14 +286,14 @@
                     "args": [
                       {
                         "tya": "BoundedNat",
-                        "n": 7
+                        "n": 6
                       }
                     ],
                     "bound": "C"
                   }
                 }
               ],
-              "bound": "C"
+              "bound": "A"
             },
             {
               "t": "Opaque",
@@ -200,7 +302,7 @@
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 6
+                  "n": 5
                 }
               ],
               "bound": "C"
@@ -209,12 +311,35 @@
           "output": [
             {
               "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "context",
+              "args": [
+                {
+                  "tya": "Type",
+                  "ty": {
+                    "t": "Opaque",
+                    "extension": "arithmetic.int.types",
+                    "id": "int",
+                    "args": [
+                      {
+                        "tya": "BoundedNat",
+                        "n": 6
+                      }
+                    ],
+                    "bound": "C"
+                  }
+                }
+              ],
+              "bound": "A"
+            },
+            {
+              "t": "Opaque",
               "extension": "arithmetic.int.types",
               "id": "int",
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 6
+                  "n": 5
                 }
               ],
               "bound": "C"

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -64,7 +64,7 @@
     "NewRNGContext": {
       "extension": "tket2.qsystem.random",
       "name": "NewRNGContext",
-      "description": "Seed the RNG and return a new RNG context. Required before using other RNG ops.",
+      "description": "Seed the RNG and return a new RNG context. Required before using other RNG ops, can be called only once.",
       "signature": {
         "params": [],
         "body": {
@@ -193,7 +193,7 @@
     "RandomInt": {
       "extension": "tket2.qsystem.random",
       "name": "RandomInt",
-      "description": "Generates a pseudorandom 32-bit unsigned integer.",
+      "description": "Generates a random 32-bit unsigned integer.",
       "signature": {
         "params": [],
         "body": {

--- a/tket2-hseries/src/bin/tket2-hseries.rs
+++ b/tket2-hseries/src/bin/tket2-hseries.rs
@@ -12,9 +12,10 @@ fn main() {
                 tket2::extension::rotation::ROTATION_EXTENSION.to_owned(),
                 tket2_hseries::extension::qsystem::EXTENSION.to_owned(),
                 tket2_hseries::extension::futures::EXTENSION.to_owned(),
+                tket2_hseries::extension::random::EXTENSION.to_owned(),
                 tket2_hseries::extension::result::EXTENSION.to_owned(),
-                tket2_hseries::extension::wasm::EXTENSION.to_owned(),
                 tket2_hseries::extension::utils::EXTENSION.to_owned(),
+                tket2_hseries::extension::wasm::EXTENSION.to_owned(),
             ]);
 
             args.run_dump(&reg);

--- a/tket2-hseries/src/extension.rs
+++ b/tket2-hseries/src/extension.rs
@@ -1,6 +1,7 @@
 //! This module defines the Hugr extensions used by tket2-hseries.
 pub mod futures;
 pub mod qsystem;
+pub mod random;
 pub mod result;
 pub mod utils;
 pub mod wasm;

--- a/tket2-hseries/src/extension/random.rs
+++ b/tket2-hseries/src/extension/random.rs
@@ -103,15 +103,15 @@ impl RandomType {
 )]
 /// The operations provided by the random extension.
 pub enum RandomOp {
-    /// fn random_int(RNGContext) -> (RNGContext, u32)
+    /// `fn random_int(RNGContext) -> (RNGContext, u32)`
     RandomInt,
-    /// fn random_float(RNGContext) -> (RNGContext, f32)
+    /// `fn random_float(RNGContext) -> (RNGContext, f32)`
     RandomFloat,
-    /// fn random_int_bounded(RNGContext, bound: u32) -> (RNGContext, u32)
+    /// `fn random_int_bounded(RNGContext, bound: u32) -> (RNGContext, u32)`
     RandomIntBounded,
-    /// fn new_rng_context(seed: u64) -> Option<RNGContext> // return None on second call
+    /// `fn new_rng_context(seed: u64) -> Option<RNGContext>` // return None on second call
     NewContext,
-    /// fn delete_rng_context(RNGContext) -> ()
+    /// `fn delete_rng_context(RNGContext) -> ()`
     DeleteContext,
 }
 

--- a/tket2-hseries/src/extension/random.rs
+++ b/tket2-hseries/src/extension/random.rs
@@ -158,11 +158,11 @@ impl MakeOpDef for RandomOp {
 
     fn description(&self) -> String {
         match self {
-            RandomOp::RandomInt => "Generates a pseudorandom 32-bit unsigned integer.",
+            RandomOp::RandomInt => "Generates a random 32-bit unsigned integer.",
             RandomOp::RandomFloat => "Generate a random floating point value in the range [0,1).",
             RandomOp::RandomIntBounded => "Generates a 32-bit unsigned integer less than `bound`.",
             RandomOp::NewRNGContext => {
-                "Seed the RNG and return a new RNG context. Required before using other RNG ops."
+                "Seed the RNG and return a new RNG context. Required before using other RNG ops, can be called only once."
             }
             RandomOp::DeleteRNGContext => "Discard the given RNG context.",
         }

--- a/tket2-hseries/src/extension/random.rs
+++ b/tket2-hseries/src/extension/random.rs
@@ -1,0 +1,271 @@
+//! This module defines the "tket2.qsystem.random" extension that includes
+//! random number generation (RNG) functions available for Quantinuum systems.
+
+use std::sync::{Arc, Weak};
+
+use derive_more::derive::Display;
+use hugr::{
+    builder::{BuildError, Dataflow},
+    extension::{
+        prelude::{option_type, UnwrapBuilder, PRELUDE_ID},
+        simple_op::{try_from_name, MakeOpDef, MakeRegisteredOp},
+        ExtensionBuildError, ExtensionId, ExtensionRegistry, ExtensionSet, OpDef, SignatureFunc,
+        TypeDefBound, Version, PRELUDE,
+    },
+    std_extensions::arithmetic::{float_types::float64_type, int_types::int_type},
+    types::{type_param::TypeParam, CustomType, Signature, Type, TypeBound},
+    Extension, Wire,
+};
+use lazy_static::lazy_static;
+use smol_str::SmolStr;
+use strum::{EnumIter, EnumString, IntoStaticStr};
+
+/// The extension ID for the RNG extension.
+pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("tket2.qsystem.random");
+/// The version of the "tket2.qsystem.random" extension.
+pub const EXTENSION_VERSION: Version = Version::new(0, 1, 0);
+
+lazy_static! {
+    /// The "tket2.qsystem.random" extension.
+    pub static ref EXTENSION: Arc<Extension> = {
+         Extension::new_arc(EXTENSION_ID, EXTENSION_VERSION, |ext, ext_ref| {
+            ext.add_requirements(ExtensionSet::from_iter([PRELUDE_ID]));
+            add_random_type_defs(ext, ext_ref).unwrap();
+            RandomOp::load_all_ops( ext, ext_ref).unwrap();
+        })
+    };
+
+    /// Extension registry including the "tket2.qsystem.random" extension and
+    /// dependencies.
+    pub static ref REGISTRY: ExtensionRegistry = ExtensionRegistry::new([
+        EXTENSION.to_owned(),
+        PRELUDE.to_owned(),
+    ]);
+
+    /// The name of the `tket2.qsystem.random.context` type.
+    pub static ref CONTEXT_TYPE_NAME: SmolStr = SmolStr::new_inline("context");
+
+    /// The type parameter for the seed of the RNG.
+    pub static ref SEED: TypeParam =
+    TypeParam::Type { b: TypeBound::Any };
+}
+
+fn add_random_type_defs(
+    extension: &mut Extension,
+    extension_ref: &Weak<Extension>,
+) -> Result<(), ExtensionBuildError> {
+    extension.add_type(
+        CONTEXT_TYPE_NAME.to_owned(),
+        vec![SEED.to_owned()],
+        "RNGContext".into(),
+        TypeDefBound::any(),
+        extension_ref,
+    )?;
+    Ok(())
+}
+
+/// An enum for RNG extension types.
+pub enum RandomType {
+    /// The linear RNG context type.
+    RNGContext,
+}
+
+impl RandomType {
+    fn get_type(&self, extension_ref: &Weak<Extension>) -> Type {
+        match self {
+            Self::RNGContext { .. } => CustomType::new(
+                CONTEXT_TYPE_NAME.to_owned(),
+                vec![int_type(6).into()],
+                EXTENSION_ID,
+                TypeBound::Any,
+                extension_ref,
+            ),
+        }
+        .into()
+    }
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    EnumIter,
+    IntoStaticStr,
+    EnumString,
+    Display,
+)]
+/// The operations provided by the random extension.
+pub enum RandomOp {
+    /// fn random_int(RNGContext) -> (RNGContext, u32)
+    RandomInt,
+    /// fn random_float(RNGContext) -> (RNGContext, f32)
+    RandomFloat,
+    /// fn random_int_bounded(RNGContext, bound: u32) -> (RNGContext, u32)
+    RandomIntBounded,
+    /// fn new_rng_context(seed: u64) -> Option<RNGContext> // return None on second call
+    NewContext,
+    /// fn delete_rng_context(RNGContext) -> ()
+    DeleteContext,
+}
+
+impl MakeOpDef for RandomOp {
+    fn init_signature(&self, extension_ref: &std::sync::Weak<Extension>) -> SignatureFunc {
+        match self {
+            RandomOp::RandomInt => Signature::new(
+                vec![RandomType::RNGContext.get_type(extension_ref)],
+                vec![RandomType::RNGContext.get_type(extension_ref), int_type(5)],
+            ),
+            RandomOp::RandomFloat => Signature::new(
+                vec![RandomType::RNGContext.get_type(extension_ref)],
+                vec![
+                    RandomType::RNGContext.get_type(extension_ref),
+                    float64_type(),
+                ],
+            ),
+            RandomOp::RandomIntBounded => Signature::new(
+                vec![RandomType::RNGContext.get_type(extension_ref), int_type(5)],
+                vec![RandomType::RNGContext.get_type(extension_ref), int_type(5)],
+            ),
+            RandomOp::NewContext => Signature::new(
+                vec![int_type(6)],
+                Type::from(option_type(RandomType::RNGContext.get_type(extension_ref))),
+            ),
+            RandomOp::DeleteContext => {
+                Signature::new(vec![RandomType::RNGContext.get_type(extension_ref)], vec![])
+            }
+        }
+        .into()
+    }
+
+    fn from_def(op_def: &OpDef) -> Result<Self, hugr::extension::simple_op::OpLoadError> {
+        try_from_name(op_def.name(), op_def.extension_id())
+    }
+
+    fn extension(&self) -> ExtensionId {
+        EXTENSION_ID
+    }
+
+    fn extension_ref(&self) -> std::sync::Weak<Extension> {
+        Arc::downgrade(&EXTENSION)
+    }
+
+    fn description(&self) -> String {
+        match self {
+            RandomOp::RandomInt => "Generate a random integer.",
+            RandomOp::RandomFloat => "Generate a random float.",
+            RandomOp::RandomIntBounded => "Generate a random integer within the range [0, bound).",
+            RandomOp::NewContext => "Get a new RNG context with a seed.",
+            RandomOp::DeleteContext => "Discard RNG context.",
+        }
+        .to_string()
+    }
+}
+
+impl MakeRegisteredOp for RandomOp {
+    fn extension_id(&self) -> ExtensionId {
+        EXTENSION_ID
+    }
+
+    fn extension_ref(&self) -> Weak<Extension> {
+        Arc::downgrade(&EXTENSION)
+    }
+}
+
+/// An extension trait for [Dataflow] providing methods to add
+/// "tket2.qsystem.random" operations.
+pub trait RandomOpBuilder: Dataflow + UnwrapBuilder {
+    /// Add a "tket2.qsystem.random.random_int" op.
+    fn add_random_int(&mut self, ctx: Wire) -> Result<[Wire; 2], BuildError> {
+        Ok(self
+            .add_dataflow_op(RandomOp::RandomInt, [ctx])?
+            .outputs_arr())
+    }
+
+    /// Add a "tket2.qsystem.random.random_float" op.
+    fn add_random_float(&mut self, ctx: Wire) -> Result<[Wire; 2], BuildError> {
+        Ok(self
+            .add_dataflow_op(RandomOp::RandomFloat, [ctx])?
+            .outputs_arr())
+    }
+
+    /// Add a "tket2.qsystem.random.random_int_bounded" op.
+    fn add_random_int_bounded(&mut self, ctx: Wire, bound: Wire) -> Result<[Wire; 2], BuildError> {
+        Ok(self
+            .add_dataflow_op(RandomOp::RandomIntBounded, [ctx, bound])?
+            .outputs_arr())
+    }
+
+    /// Add a "tket2.qsystem.random.new_rng_context" op.
+    fn add_new_rng_context(&mut self, seed: Wire) -> Result<Wire, BuildError> {
+        Ok(self
+            .add_dataflow_op(RandomOp::NewContext, [seed])?
+            .out_wire(0))
+    }
+
+    /// Add a "tket2.qsystem.random.delete_rng_context" op.
+    fn add_delete_rng_context(&mut self, ctx: Wire) -> Result<(), BuildError> {
+        self.add_dataflow_op(RandomOp::DeleteContext, [ctx])?;
+        Ok(())
+    }
+}
+
+impl<D: Dataflow> RandomOpBuilder for D {}
+
+#[cfg(test)]
+mod test {
+    use hugr::ops::{NamedOp, Value};
+    use hugr::std_extensions::arithmetic::int_types::ConstInt;
+
+    use hugr::builder::{DataflowHugr, FunctionBuilder};
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    #[test]
+    fn create_extension() {
+        assert_eq!(EXTENSION.name(), &EXTENSION_ID);
+
+        for o in RandomOp::iter() {
+            assert_eq!(
+                RandomOp::from_def(EXTENSION.get_op(&o.name()).unwrap()),
+                Ok(o)
+            );
+        }
+    }
+
+    #[test]
+    fn test_random_op_builder() {
+        let hugr = {
+            let mut func_builder = FunctionBuilder::new(
+                "random_op_builder",
+                Signature::new(vec![], vec![int_type(5)]),
+            )
+            .unwrap();
+
+            let seed =
+                func_builder.add_load_const(Value::from(ConstInt::new_u(6, 123456).unwrap()));
+            let maybe_ctx = func_builder.add_new_rng_context(seed).unwrap();
+            let [ctx] = func_builder
+                .build_unwrap_sum(
+                    1,
+                    option_type(RandomType::RNGContext.get_type(&Arc::downgrade(&EXTENSION))),
+                    maybe_ctx,
+                )
+                .unwrap();
+            let bound = func_builder.add_load_const(Value::from(ConstInt::new_u(5, 100).unwrap()));
+            let [ctx, _] = func_builder.add_random_int_bounded(ctx, bound).unwrap();
+            let [ctx, _] = func_builder.add_random_float(ctx).unwrap();
+            let [ctx, rnd] = func_builder.add_random_int(ctx).unwrap();
+            func_builder.add_delete_rng_context(ctx).unwrap();
+            func_builder.finish_hugr_with_outputs([rnd]).unwrap()
+        };
+        hugr.validate().unwrap()
+    }
+}

--- a/tket2-hseries/src/extension/random.rs
+++ b/tket2-hseries/src/extension/random.rs
@@ -158,9 +158,9 @@ impl MakeOpDef for RandomOp {
 
     fn description(&self) -> String {
         match self {
-            RandomOp::RandomInt => "Generates a random 32-bit unsigned integer.",
+            RandomOp::RandomInt => "Generate a random 32-bit unsigned integer.",
             RandomOp::RandomFloat => "Generate a random floating point value in the range [0,1).",
-            RandomOp::RandomIntBounded => "Generates a 32-bit unsigned integer less than `bound`.",
+            RandomOp::RandomIntBounded => "Generate a random 32-bit unsigned integer less than `bound`.",
             RandomOp::NewRNGContext => {
                 "Seed the RNG and return a new RNG context. Required before using other RNG ops, can be called only once."
             }

--- a/tket2-hseries/src/extension/utils.rs
+++ b/tket2-hseries/src/extension/utils.rs
@@ -61,7 +61,7 @@ lazy_static! {
 )]
 /// The operations provided by the utils extension.
 pub enum UtilsOp {
-    /// fn get_current_shot() -> usize
+    /// `fn get_current_shot() -> usize`
     GetCurrentShot,
 }
 

--- a/tket2-hseries/src/extension/utils.rs
+++ b/tket2-hseries/src/extension/utils.rs
@@ -1,4 +1,5 @@
-//! This module contains utility functions for Quantinuum systems.
+//! This module defines the "tket2.qsystem.utils" extension that includes the
+//! utility functions available for Quantinuum systems.
 
 use std::sync::{Arc, Weak};
 

--- a/tket2-hseries/src/extension/utils.rs
+++ b/tket2-hseries/src/extension/utils.rs
@@ -1,4 +1,4 @@
-//! This module defines the "tket2.qsystem.utils" extension that includes the
+//! This module defines the "tket2.qsystem.utils" extension, which includes the
 //! utility functions available for Quantinuum systems.
 
 use std::sync::{Arc, Weak};


### PR DESCRIPTION
Closes: #748

Apart from the signatures in the reporting issue, I had to include an additional function to discard the linear context.
```rust
    /// fn delete_rng_context(RNGContext) -> ()
    DeleteContext,
```

Appreciate other ideas to discard the context.