### PR TITLE
fix: include RNG extension in tket2-py, bump tket2-exts constraint

### DIFF
--- a/tket2-py/pyproject.toml
+++ b/tket2-py/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     'pytket >= 1.34, < 2',
     'hugr >= 0.10.0, < 0.11',
     'tket2_eccs >= 0.3.0, < 0.4',
-    'tket2_exts >= 0.3.0, < 0.4',
+    'tket2_exts >= 0.4.0, < 0.5',
 ]
 
 [tool.uv.sources]

--- a/tket2-py/tket2/extensions/__init__.py
+++ b/tket2-py/tket2/extensions/__init__.py
@@ -1,4 +1,20 @@
-from tket2_exts import rotation, futures, qsystem, qsystem_utils, quantum, result
+from tket2_exts import (
+    rotation,
+    futures,
+    qsystem,
+    qsystem_random,
+    qsystem_utils,
+    quantum,
+    result,
+)
 
 
-__all__ = ["rotation", "futures", "qsystem", "qsystem_utils", "quantum", "result"]
+__all__ = [
+    "rotation",
+    "futures",
+    "qsystem",
+    "qsystem_random",
+    "qsystem_utils",
+    "quantum",
+    "result",
+]


### PR DESCRIPTION
I forgot to edit `tket2-py/tket2/extensions/__init__.py` in #779 

Need to bump version constraint for tket2-exts to be able to use it in guppy at https://github.com/CQCL/guppylang/pull/806