### PR TITLE
fix!: remove type argument from `RNGContext` type, swap returns

### DIFF
--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -145,7 +145,7 @@
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 6
+                  "n": 5
                 }
               ],
               "bound": "C"
@@ -185,7 +185,7 @@
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 6
+                  "n": 5
                 }
               ],
               "bound": "C"
@@ -199,7 +199,7 @@
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 6
+                  "n": 5
                 }
               ],
               "bound": "C"

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -103,17 +103,17 @@
           "output": [
             {
               "t": "Opaque",
-              "extension": "tket2.qsystem.random",
-              "id": "context",
-              "args": [],
-              "bound": "A"
-            },
-            {
-              "t": "Opaque",
               "extension": "arithmetic.float.types",
               "id": "float64",
               "args": [],
               "bound": "C"
+            },
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "context",
+              "args": [],
+              "bound": "A"
             }
           ],
           "runtime_reqs": []
@@ -140,13 +140,6 @@
           "output": [
             {
               "t": "Opaque",
-              "extension": "tket2.qsystem.random",
-              "id": "context",
-              "args": [],
-              "bound": "A"
-            },
-            {
-              "t": "Opaque",
               "extension": "arithmetic.int.types",
               "id": "int",
               "args": [
@@ -156,6 +149,13 @@
                 }
               ],
               "bound": "C"
+            },
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "context",
+              "args": [],
+              "bound": "A"
             }
           ],
           "runtime_reqs": []
@@ -194,13 +194,6 @@
           "output": [
             {
               "t": "Opaque",
-              "extension": "tket2.qsystem.random",
-              "id": "context",
-              "args": [],
-              "bound": "A"
-            },
-            {
-              "t": "Opaque",
               "extension": "arithmetic.int.types",
               "id": "int",
               "args": [
@@ -210,6 +203,13 @@
                 }
               ],
               "bound": "C"
+            },
+            {
+              "t": "Opaque",
+              "extension": "tket2.qsystem.random",
+              "id": "context",
+              "args": [],
+              "bound": "A"
             }
           ],
           "runtime_reqs": []

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -8,12 +8,7 @@
     "context": {
       "extension": "tket2.qsystem.random",
       "name": "context",
-      "params": [
-        {
-          "tp": "Type",
-          "b": "A"
-        }
-      ],
+      "params": [],
       "description": "The linear RNG context type",
       "bound": {
         "b": "Explicit",
@@ -35,23 +30,7 @@
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
               "id": "context",
-              "args": [
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Opaque",
-                    "extension": "arithmetic.int.types",
-                    "id": "int",
-                    "args": [
-                      {
-                        "tya": "BoundedNat",
-                        "n": 6
-                      }
-                    ],
-                    "bound": "C"
-                  }
-                }
-              ],
+              "args": [],
               "bound": "A"
             }
           ],
@@ -93,23 +72,7 @@
                     "t": "Opaque",
                     "extension": "tket2.qsystem.random",
                     "id": "context",
-                    "args": [
-                      {
-                        "tya": "Type",
-                        "ty": {
-                          "t": "Opaque",
-                          "extension": "arithmetic.int.types",
-                          "id": "int",
-                          "args": [
-                            {
-                              "tya": "BoundedNat",
-                              "n": 6
-                            }
-                          ],
-                          "bound": "C"
-                        }
-                      }
-                    ],
+                    "args": [],
                     "bound": "A"
                   }
                 ]
@@ -133,23 +96,7 @@
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
               "id": "context",
-              "args": [
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Opaque",
-                    "extension": "arithmetic.int.types",
-                    "id": "int",
-                    "args": [
-                      {
-                        "tya": "BoundedNat",
-                        "n": 6
-                      }
-                    ],
-                    "bound": "C"
-                  }
-                }
-              ],
+              "args": [],
               "bound": "A"
             }
           ],
@@ -158,23 +105,7 @@
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
               "id": "context",
-              "args": [
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Opaque",
-                    "extension": "arithmetic.int.types",
-                    "id": "int",
-                    "args": [
-                      {
-                        "tya": "BoundedNat",
-                        "n": 6
-                      }
-                    ],
-                    "bound": "C"
-                  }
-                }
-              ],
+              "args": [],
               "bound": "A"
             },
             {
@@ -202,23 +133,7 @@
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
               "id": "context",
-              "args": [
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Opaque",
-                    "extension": "arithmetic.int.types",
-                    "id": "int",
-                    "args": [
-                      {
-                        "tya": "BoundedNat",
-                        "n": 6
-                      }
-                    ],
-                    "bound": "C"
-                  }
-                }
-              ],
+              "args": [],
               "bound": "A"
             }
           ],
@@ -227,23 +142,7 @@
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
               "id": "context",
-              "args": [
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Opaque",
-                    "extension": "arithmetic.int.types",
-                    "id": "int",
-                    "args": [
-                      {
-                        "tya": "BoundedNat",
-                        "n": 6
-                      }
-                    ],
-                    "bound": "C"
-                  }
-                }
-              ],
+              "args": [],
               "bound": "A"
             },
             {
@@ -276,23 +175,7 @@
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
               "id": "context",
-              "args": [
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Opaque",
-                    "extension": "arithmetic.int.types",
-                    "id": "int",
-                    "args": [
-                      {
-                        "tya": "BoundedNat",
-                        "n": 6
-                      }
-                    ],
-                    "bound": "C"
-                  }
-                }
-              ],
+              "args": [],
               "bound": "A"
             },
             {
@@ -313,23 +196,7 @@
               "t": "Opaque",
               "extension": "tket2.qsystem.random",
               "id": "context",
-              "args": [
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Opaque",
-                    "extension": "arithmetic.int.types",
-                    "id": "int",
-                    "args": [
-                      {
-                        "tya": "BoundedNat",
-                        "n": 6
-                      }
-                    ],
-                    "bound": "C"
-                  }
-                }
-              ],
+              "args": [],
               "bound": "A"
             },
             {

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/random.json
@@ -145,7 +145,7 @@
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 5
+                  "n": 6
                 }
               ],
               "bound": "C"
@@ -185,7 +185,7 @@
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 5
+                  "n": 6
                 }
               ],
               "bound": "C"
@@ -199,7 +199,7 @@
               "args": [
                 {
                   "tya": "BoundedNat",
-                  "n": 5
+                  "n": 6
                 }
               ],
               "bound": "C"

--- a/tket2-hseries/src/extension/random.rs
+++ b/tket2-hseries/src/extension/random.rs
@@ -13,7 +13,7 @@ use hugr::{
         TypeDefBound, Version, PRELUDE,
     },
     std_extensions::arithmetic::{float_types::float64_type, int_types::int_type},
-    types::{type_param::TypeParam, CustomType, Signature, Type, TypeBound},
+    types::{CustomType, Signature, Type, TypeBound},
     Extension, Wire,
 };
 use lazy_static::lazy_static;
@@ -44,10 +44,6 @@ lazy_static! {
 
     /// The name of the `tket2.qsystem.random.context` type.
     pub static ref CONTEXT_TYPE_NAME: SmolStr = SmolStr::new_inline("context");
-
-    /// The type parameter for the seed of the RNG.
-    pub static ref SEED: TypeParam =
-    TypeParam::Type { b: TypeBound::Any };
 }
 
 fn add_random_type_defs(
@@ -56,7 +52,7 @@ fn add_random_type_defs(
 ) -> Result<(), ExtensionBuildError> {
     extension.add_type(
         CONTEXT_TYPE_NAME.to_owned(),
-        vec![SEED.to_owned()],
+        vec![],
         "The linear RNG context type".into(),
         TypeDefBound::any(),
         extension_ref,
@@ -75,7 +71,7 @@ impl RandomType {
         match self {
             Self::RNGContext { .. } => CustomType::new(
                 CONTEXT_TYPE_NAME.to_owned(),
-                vec![int_type(6).into()],
+                vec![],
                 EXTENSION_ID,
                 TypeBound::Any,
                 extension_ref,

--- a/tket2-hseries/src/extension/random.rs
+++ b/tket2-hseries/src/extension/random.rs
@@ -99,11 +99,11 @@ impl RandomType {
 )]
 /// The operations provided by the random extension.
 pub enum RandomOp {
-    /// `fn random_int(RNGContext) -> (RNGContext, u32)`
+    /// `fn random_int(RNGContext) -> (u32, RNGContext)`
     RandomInt,
-    /// `fn random_float(RNGContext) -> (RNGContext, f32)`
+    /// `fn random_float(RNGContext) -> (f32, RNGContext)`
     RandomFloat,
-    /// `fn random_int_bounded(RNGContext, bound: u32) -> (RNGContext, u32)`
+    /// `fn random_int_bounded(RNGContext, bound: u32) -> (u32, RNGContext)`
     RandomIntBounded,
     /// `fn new_rng_context(seed: u64) -> Option<RNGContext>` // return None on second call
     NewRNGContext,
@@ -116,18 +116,18 @@ impl MakeOpDef for RandomOp {
         match self {
             RandomOp::RandomInt => Signature::new(
                 vec![RandomType::RNGContext.get_type(extension_ref)],
-                vec![RandomType::RNGContext.get_type(extension_ref), int_type(5)],
+                vec![int_type(5), RandomType::RNGContext.get_type(extension_ref)],
             ),
             RandomOp::RandomFloat => Signature::new(
                 vec![RandomType::RNGContext.get_type(extension_ref)],
                 vec![
-                    RandomType::RNGContext.get_type(extension_ref),
                     float64_type(),
+                    RandomType::RNGContext.get_type(extension_ref),
                 ],
             ),
             RandomOp::RandomIntBounded => Signature::new(
                 vec![RandomType::RNGContext.get_type(extension_ref), int_type(5)],
-                vec![RandomType::RNGContext.get_type(extension_ref), int_type(5)],
+                vec![int_type(5), RandomType::RNGContext.get_type(extension_ref)],
             ),
             RandomOp::NewRNGContext => Signature::new(
                 vec![int_type(6)],
@@ -258,9 +258,9 @@ mod test {
                 )
                 .unwrap();
             let bound = func_builder.add_load_const(Value::from(ConstInt::new_u(5, 100).unwrap()));
-            let [ctx, _] = func_builder.add_random_int_bounded(ctx, bound).unwrap();
-            let [ctx, _] = func_builder.add_random_float(ctx).unwrap();
-            let [ctx, rnd] = func_builder.add_random_int(ctx).unwrap();
+            let [_, ctx] = func_builder.add_random_int_bounded(ctx, bound).unwrap();
+            let [_, ctx] = func_builder.add_random_float(ctx).unwrap();
+            let [rnd, ctx] = func_builder.add_random_int(ctx).unwrap();
             func_builder.add_delete_rng_context(ctx).unwrap();
             func_builder.finish_hugr_with_outputs([rnd]).unwrap()
         };

--- a/tket2-hseries/src/extension/random.rs
+++ b/tket2-hseries/src/extension/random.rs
@@ -116,7 +116,8 @@ impl MakeOpDef for RandomOp {
         match self {
             RandomOp::RandomInt => Signature::new(
                 vec![RandomType::RNGContext.get_type(extension_ref)],
-                vec![int_type(5), RandomType::RNGContext.get_type(extension_ref)],
+                // NOTE: The output type is u32, not u64, but guppy only has 64-bit ints.
+                vec![int_type(6), RandomType::RNGContext.get_type(extension_ref)],
             ),
             RandomOp::RandomFloat => Signature::new(
                 vec![RandomType::RNGContext.get_type(extension_ref)],
@@ -126,8 +127,10 @@ impl MakeOpDef for RandomOp {
                 ],
             ),
             RandomOp::RandomIntBounded => Signature::new(
-                vec![RandomType::RNGContext.get_type(extension_ref), int_type(5)],
-                vec![int_type(5), RandomType::RNGContext.get_type(extension_ref)],
+                // NOTE: The type for `bound` is u32, not u64, but guppy only has 64-bit ints.
+                vec![RandomType::RNGContext.get_type(extension_ref), int_type(6)],
+                // NOTE: Same output type as `RandomInt` above.
+                vec![int_type(6), RandomType::RNGContext.get_type(extension_ref)],
             ),
             RandomOp::NewRNGContext => Signature::new(
                 vec![int_type(6)],
@@ -243,7 +246,7 @@ mod test {
         let hugr = {
             let mut func_builder = FunctionBuilder::new(
                 "random_op_builder",
-                Signature::new(vec![], vec![int_type(5)]),
+                Signature::new(vec![], vec![int_type(6)]),
             )
             .unwrap();
 
@@ -257,7 +260,7 @@ mod test {
                     maybe_ctx,
                 )
                 .unwrap();
-            let bound = func_builder.add_load_const(Value::from(ConstInt::new_u(5, 100).unwrap()));
+            let bound = func_builder.add_load_const(Value::from(ConstInt::new_u(6, 100).unwrap()));
             let [_, ctx] = func_builder.add_random_int_bounded(ctx, bound).unwrap();
             let [_, ctx] = func_builder.add_random_float(ctx).unwrap();
             let [rnd, ctx] = func_builder.add_random_int(ctx).unwrap();

--- a/tket2-hseries/src/extension/random.rs
+++ b/tket2-hseries/src/extension/random.rs
@@ -116,8 +116,7 @@ impl MakeOpDef for RandomOp {
         match self {
             RandomOp::RandomInt => Signature::new(
                 vec![RandomType::RNGContext.get_type(extension_ref)],
-                // NOTE: The output type is u32, not u64, but guppy only has 64-bit ints.
-                vec![int_type(6), RandomType::RNGContext.get_type(extension_ref)],
+                vec![int_type(5), RandomType::RNGContext.get_type(extension_ref)],
             ),
             RandomOp::RandomFloat => Signature::new(
                 vec![RandomType::RNGContext.get_type(extension_ref)],
@@ -127,10 +126,8 @@ impl MakeOpDef for RandomOp {
                 ],
             ),
             RandomOp::RandomIntBounded => Signature::new(
-                // NOTE: The type for `bound` is u32, not u64, but guppy only has 64-bit ints.
-                vec![RandomType::RNGContext.get_type(extension_ref), int_type(6)],
-                // NOTE: Same output type as `RandomInt` above.
-                vec![int_type(6), RandomType::RNGContext.get_type(extension_ref)],
+                vec![RandomType::RNGContext.get_type(extension_ref), int_type(5)],
+                vec![int_type(5), RandomType::RNGContext.get_type(extension_ref)],
             ),
             RandomOp::NewRNGContext => Signature::new(
                 vec![int_type(6)],
@@ -246,7 +243,7 @@ mod test {
         let hugr = {
             let mut func_builder = FunctionBuilder::new(
                 "random_op_builder",
-                Signature::new(vec![], vec![int_type(6)]),
+                Signature::new(vec![], vec![int_type(5)]),
             )
             .unwrap();
 
@@ -260,7 +257,7 @@ mod test {
                     maybe_ctx,
                 )
                 .unwrap();
-            let bound = func_builder.add_load_const(Value::from(ConstInt::new_u(6, 100).unwrap()));
+            let bound = func_builder.add_load_const(Value::from(ConstInt::new_u(5, 100).unwrap()));
             let [_, ctx] = func_builder.add_random_int_bounded(ctx, bound).unwrap();
             let [_, ctx] = func_builder.add_random_float(ctx).unwrap();
             let [rnd, ctx] = func_builder.add_random_int(ctx).unwrap();


### PR DESCRIPTION
See https://github.com/CQCL/guppylang/pull/822

BREAKING CHANGE: To be compatible with Guppy's convention of implicitly returning `self` as the second value of the tuple, the following signatures are updated:
```diff
-    /// `fn random_int(RNGContext) -> (RNGContext, u32)`
+   /// `fn random_int(RNGContext) -> (u32, RNGContext)`

-   /// `fn random_float(RNGContext) -> (RNGContext, f32)`
+   /// `fn random_float(RNGContext) -> (f32, RNGContext)`

-   /// `fn random_int_bounded(RNGContext, bound: u32) -> (RNGContext, u32)`
+   /// `fn random_int_bounded(RNGContext, bound: u32) -> (u32, RNGContext)`
```