### PR TITLE
chore(tket2-exts): Force non-breaking python release

### DIFF
--- a/tket2-exts/src/tket2_exts/__init__.py
+++ b/tket2-exts/src/tket2_exts/__init__.py
@@ -6,7 +6,7 @@ import functools
 from hugr.ext import Extension
 
 
-# This is updated by our release-please workflow, triggered by this
+# This is updated by our release-please workflow, triggered by this.
 # annotation: x-release-please-version
 __version__ = "0.5.0"
 


### PR DESCRIPTION
#789 added a breaking change to the rust crate, but the breaking flag also affects the python side since `tket2-exts` got modified.

This empty change tells `release-please` to ignore that and do a non-breaking version bump on the next release PR.

The magic is in having a commit on the tree containing this comment:

Release-As: 0.5.1