### PR TITLE
fix(tket2-hseries)!: rm unneeded ext, make `UtilsOp` enum `non_exhaustive`

### DIFF
--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem/utils.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem/utils.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "name": "tket2.qsystem.utils",
   "runtime_reqs": [
     "prelude"
@@ -27,58 +27,6 @@
                 }
               ],
               "bound": "C"
-            }
-          ],
-          "runtime_reqs": []
-        }
-      },
-      "binary": false
-    },
-    "OrderInZones": {
-      "extension": "tket2.qsystem.utils",
-      "name": "OrderInZones",
-      "description": "Order qubits in gating zones. The qubits are assigned in pairs, the first element of the pair goes to the left of the zone and the second goes to the right. Pairs are assigned to zones from left to right: `UG1,...,UG4`, and then `DG1,...,DG4`.",
-      "signature": {
-        "params": [],
-        "body": {
-          "input": [
-            {
-              "t": "Opaque",
-              "extension": "collections.array",
-              "id": "array",
-              "args": [
-                {
-                  "tya": "BoundedNat",
-                  "n": 16
-                },
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Q"
-                  }
-                }
-              ],
-              "bound": "A"
-            }
-          ],
-          "output": [
-            {
-              "t": "Opaque",
-              "extension": "collections.array",
-              "id": "array",
-              "args": [
-                {
-                  "tya": "BoundedNat",
-                  "n": 16
-                },
-                {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Q"
-                  }
-                }
-              ],
-              "bound": "A"
             }
           ],
           "runtime_reqs": []

--- a/tket2-py/src/circuit/tk2circuit.rs
+++ b/tket2-py/src/circuit/tk2circuit.rs
@@ -146,15 +146,9 @@ impl Tk2Circuit {
     pub fn to_tket1_json(&self) -> PyResult<String> {
         // Try to simplify tuple pack-unpack pairs, and other operations not supported by pytket.
         let circ = lower_to_pytket(&self.circ).convert_pyerrs()?;
-        Ok(
-            serde_json::to_string(&SerialCircuit::encode(&circ).convert_pyerrs()?).map_err(
-                |e| {
-                    PyErr::new::<PyValueError, _>(format!(
-                        "Could not encode pytket circuit to str: {e}"
-                    ))
-                },
-            )?,
-        )
+        serde_json::to_string(&SerialCircuit::encode(&circ).convert_pyerrs()?).map_err(|e| {
+            PyErr::new::<PyValueError, _>(format!("Could not encode pytket circuit to str: {e}"))
+        })
     }
 
     /// Decode a tket1 json string to a circuit.
@@ -170,13 +164,9 @@ impl Tk2Circuit {
     pub fn to_tket1_json_bytes(&self) -> PyResult<Vec<u8>> {
         // Try to simplify tuple pack-unpack pairs, and other operations not supported by pytket.
         let circ = lower_to_pytket(&self.circ).convert_pyerrs()?;
-        Ok(
-            serde_json::to_vec(&SerialCircuit::encode(&circ).convert_pyerrs()?).map_err(|e| {
-                PyErr::new::<PyValueError, _>(format!(
-                    "Could not encode pytket circuit to bytes: {e}"
-                ))
-            })?,
-        )
+        serde_json::to_vec(&SerialCircuit::encode(&circ).convert_pyerrs()?).map_err(|e| {
+            PyErr::new::<PyValueError, _>(format!("Could not encode pytket circuit to bytes: {e}"))
+        })
     }
 
     /// Decode a tket1 json utf8 bytes to a circuit.


### PR DESCRIPTION
Revert #792 

BREAKING CHANGE: Make `UtilsOp` enum `non_exhaustive` so that future additions are not considered API-breaking.