### PR TITLE
chore!: bump to hugr-rs 0.15 and hugr-py 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -911,8 +911,9 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.14.4"
-source = "git+https://github.com/CQCL/hugr?rev=4e6b6d8#4e6b6d8df576f43bd5ced51b2eb4f1ed4d5c3b82"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24412f943ef2bc0644f8dc973e1da1bcdfe61fa4805829b576315d6285a9b293"
 dependencies = [
  "hugr-core",
  "hugr-passes",
@@ -920,8 +921,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.14.4"
-source = "git+https://github.com/CQCL/hugr?rev=4e6b6d8#4e6b6d8df576f43bd5ced51b2eb4f1ed4d5c3b82"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89381bfa1cd7128f0a377d214a7a3c08197cc1abe3dada4286176864565b36a7"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -933,8 +935,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.14.4"
-source = "git+https://github.com/CQCL/hugr?rev=4e6b6d8#4e6b6d8df576f43bd5ced51b2eb4f1ed4d5c3b82"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e81979bfda3765878e0812eded1f4ad68f72b9c830deba59f101fccff619e524"
 dependencies = [
  "cgmath",
  "delegate 0.13.2",
@@ -954,6 +957,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
+ "static_assertions",
  "strum",
  "thiserror 2.0.12",
  "typetag",
@@ -961,8 +965,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-passes"
-version = "0.14.4"
-source = "git+https://github.com/CQCL/hugr?rev=4e6b6d8#4e6b6d8df576f43bd5ced51b2eb4f1ed4d5c3b82"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcc81a7cdcf5edf63a7ef8219ba3cad556d7847d35cf7b35d8e11743c4289b7"
 dependencies = [
  "ascent",
  "hugr-core",
@@ -1005,9 +1010,9 @@ checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1789,6 +1794,12 @@ dependencies = [
  "borsh",
  "serde",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "ascent"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542b90d362e62ae00b8a9f1c8887919fe5cb4a07c64423b9ab72ab78f4b27f41"
+checksum = "f1f021eb502b2d503783f992e99c7a099910c95c548008c51f6380259836260c"
 dependencies = [
  "ascent_base",
  "ascent_macro",
@@ -125,33 +125,33 @@ dependencies = [
  "once_cell",
  "paste",
  "rayon",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
 name = "ascent_base"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606412229e80de366935b461eaef5016a9725064151e52ea35f200e7541c2912"
+checksum = "df836580627d8774d2a573bbfb5612c013004afcde89675b6a054825618de8dc"
 dependencies = [
  "paste",
 ]
 
 [[package]]
 name = "ascent_macro"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67685ce7f6568cfd9671322ed3d7c7322ff8ec6a81e07d5323f997e118885972"
+checksum = "c7d782b676e47b3657e5ae8ad3abe74b73a67a2cf73b3df85d1764e004724646"
 dependencies = [
  "ascent_base",
  "derive-syn-parse",
  "duplicate",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lazy_static",
  "petgraph 0.6.5",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -181,9 +181,9 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitvec"
@@ -230,9 +230,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -248,9 +248,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -362,7 +362,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -576,7 +576,7 @@ checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -596,7 +596,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -609,7 +609,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -629,7 +629,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "unicode-xid",
 ]
 
@@ -651,15 +651,15 @@ checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "duplicate"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
+checksum = "97af9b5f014e228b33e77d75ee0e6e87960124f0f4b16337b586a6bec91867b1"
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enum_dispatch"
@@ -670,7 +670,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -681,9 +681,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
 dependencies = [
  "serde",
  "typeid",
@@ -779,7 +779,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -896,9 +896,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "html-escape"
@@ -912,8 +912,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af69a32d52fab819530faafc98957e043a0d02e81069ecd7ffc8397921e692a"
+source = "git+https://github.com/CQCL/hugr?rev=4e6b6d8#4e6b6d8df576f43bd5ced51b2eb4f1ed4d5c3b82"
 dependencies = [
  "hugr-core",
  "hugr-passes",
@@ -922,8 +921,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f946bedb73d49adf6fc58b85289c8324e07f6fda81106797cc8412ee7605cd"
+source = "git+https://github.com/CQCL/hugr?rev=4e6b6d8#4e6b6d8df576f43bd5ced51b2eb4f1ed4d5c3b82"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -936,11 +934,8 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2f4d4633b3b04bd47f5be96a41269fd36fa457c7a2349e0ccd7ed647b23145"
+source = "git+https://github.com/CQCL/hugr?rev=4e6b6d8#4e6b6d8df576f43bd5ced51b2eb4f1ed4d5c3b82"
 dependencies = [
- "bitvec",
- "bumpalo",
  "cgmath",
  "delegate 0.13.2",
  "derive_more 1.0.0",
@@ -951,7 +946,6 @@ dependencies = [
  "indexmap",
  "itertools 0.14.0",
  "lazy_static",
- "num-rational",
  "paste",
  "petgraph 0.7.1",
  "portgraph 0.13.3",
@@ -961,15 +955,14 @@ dependencies = [
  "serde_json",
  "smol_str",
  "strum",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "typetag",
 ]
 
 [[package]]
 name = "hugr-passes"
 version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238242ce58202732212e138bca2745d72588ec88b08a3d2b53b3dceead929dbd"
+source = "git+https://github.com/CQCL/hugr?rev=4e6b6d8#4e6b6d8df576f43bd5ced51b2eb4f1ed4d5c3b82"
 dependencies = [
  "ascent",
  "hugr-core",
@@ -978,7 +971,7 @@ dependencies = [
  "paste",
  "petgraph 0.7.1",
  "portgraph 0.13.3",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1022,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "instant"
@@ -1037,20 +1030,20 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b12ebb6799019b044deaf431eadfe23245b259bba5a2c0796acec3943a3cdb"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.0",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -1072,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1090,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -1127,9 +1120,9 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "lock_api"
@@ -1173,41 +1166,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "serde",
-]
 
 [[package]]
 name = "num-traits"
@@ -1230,15 +1192,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "overload"
@@ -1278,7 +1240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
@@ -1302,7 +1264,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1350,9 +1312,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -1413,7 +1375,7 @@ dependencies = [
  "itertools 0.14.0",
  "petgraph 0.7.1",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1428,7 +1390,7 @@ dependencies = [
  "itertools 0.10.5",
  "petgraph 0.6.5",
  "portgraph 0.8.0",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "smallvec",
 ]
@@ -1441,9 +1403,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "priority-queue"
-version = "2.1.2"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090ded312ed32a928fb49cb91ab4db6523ae3767225e61fbf6ceaaec3664ed26"
+checksum = "f759742601cb7ee8df8780e5f7f9ab7134fb6c5dd2748a61ddd7c960e24db2f8"
 dependencies = [
  "autocfg",
  "equivalent",
@@ -1452,27 +1414,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1488,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1498,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1508,27 +1470,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
  "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1543,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -1578,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -1668,7 +1630,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.98",
+ "syn 2.0.100",
  "unicode-ident",
 ]
 
@@ -1677,6 +1639,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1689,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
 dependencies = [
  "bitflags",
  "errno",
@@ -1702,15 +1670,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1729,9 +1697,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
@@ -1753,7 +1721,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1847,7 +1815,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1863,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1886,9 +1854,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1909,11 +1877,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1924,18 +1892,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1970,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -1985,15 +1953,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2150,7 +2118,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2190,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "typeid"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -2221,7 +2189,7 @@ checksum = "35f5380909ffc31b4de4f4bdf96b877175a016aa2ca98cee39fcfd8c4d53d952"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2232,9 +2200,9 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-xid"
@@ -2244,9 +2212,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8-width"
@@ -2262,9 +2230,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "serde",
 ]
@@ -2322,7 +2290,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -2344,7 +2312,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2588,7 +2556,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,9 +1403,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "priority-queue"
-version = "2.2.2"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f759742601cb7ee8df8780e5f7f9ab7134fb6c5dd2748a61ddd7c960e24db2f8"
+checksum = "090ded312ed32a928fb49cb91ab4db6523ae3767225e61fbf6ceaaec3664ed26"
 dependencies = [
  "autocfg",
  "equivalent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,10 @@ missing_docs = "warn"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-# hugr = { git = "https://github.com/CQCL/hugr", rev = "c642855" }
-# hugr-core = { git = "https://github.com/CQCL/hugr", rev = "c642855" }
-# hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "c642855" }
-# hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "c642855" }
-# hugr-model = { git = "https://github.com/CQCL/hugr", rev = "c642855" }
+hugr = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
+hugr-core = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
+hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
+hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
 # portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,18 +26,18 @@ missing_docs = "warn"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
-hugr-core = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
-hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
-hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
+# hugr = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
+# hugr-core = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
+# hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
+# hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "4e6b6d8" }
 # portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]
 
 # Make sure to run `just recompile-eccs` if the hugr serialisation format changes.
-hugr = "0.14.4"
-hugr-core = "0.14.4"
-hugr-cli = "0.14.4"
+hugr = "0.15.0"
+hugr-core = "0.15.0"
+hugr-cli = "0.15.0"
 portgraph = "0.13.3"
 pyo3 = "0.23.4"
 itertools = "0.14.0"

--- a/tket2-exts/pyproject.toml
+++ b/tket2-exts/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 
-dependencies = ['hugr >= 0.10.0, < 0.11']
+dependencies = ['hugr >= 0.11.0, < 0.12']
 
 [project.urls]
 homepage = "https://github.com/CQCL/tket2/tree/main/tket2-exts"

--- a/tket2-hseries/src/extension/qsystem/lower.rs
+++ b/tket2-hseries/src/extension/qsystem/lower.rs
@@ -213,8 +213,8 @@ fn lower_direct(hugr: &mut impl HugrMut) -> Result<Vec<Node>, LowerTk2Error> {
 ///
 /// # Errors
 /// Returns vector of nodes that are not lowered.
-pub fn check_lowered(hugr: &impl HugrView) -> Result<(), Vec<Node>> {
-    let unlowered: Vec<Node> = hugr
+pub fn check_lowered<H: HugrView>(hugr: &H) -> Result<(), Vec<H::Node>> {
+    let unlowered: Vec<H::Node> = hugr
         .nodes()
         .filter_map(|node| {
             let optype = hugr.get_optype(node);

--- a/tket2-hseries/src/lib.rs
+++ b/tket2-hseries/src/lib.rs
@@ -10,7 +10,7 @@ use hugr::{
         MonomorphizeError, MonomorphizePass, RemoveDeadFuncsError, RemoveDeadFuncsPass,
     },
     hugr::HugrError,
-    Hugr, HugrView,
+    Hugr, HugrView, Node,
 };
 use tket2::Tk2Op;
 
@@ -54,11 +54,11 @@ impl Default for QSystemPass {
 #[derive(Error, Debug, Display, From)]
 #[non_exhaustive]
 /// An error reported from [QSystemPass].
-pub enum QSystemPassError {
+pub enum QSystemPassError<N = Node> {
     /// The [hugr::Hugr] was invalid either before or after a pass ran.
     ValidationError(ValidatePassError),
     /// An error from the component [LazifyMeasurePass].
-    LazyMeasureError(LazifyMeasurePassError),
+    LazyMeasureError(LazifyMeasurePassError<N>),
     /// An error from the component [force_order()] pass.
     ForceOrderError(HugrError),
     /// An error from the component [LowerTket2ToQSystemPass] pass.

--- a/tket2-py/examples/utils/__init__.py
+++ b/tket2-py/examples/utils/__init__.py
@@ -1,6 +1,7 @@
 """Some utility functions for the example notebooks."""
 
 from hugr import Hugr
+from hugr.envelope import EnvelopeConfig
 from tket2.passes import lower_to_pytket
 from tket2.circuit import Tk2Circuit
 from typing import Any
@@ -33,7 +34,7 @@ def guppy_to_circuit(func_def: Any) -> Tk2Circuit:
 
     pkg = module.compile()
 
-    json = pkg.package.to_json()
+    json = pkg.package.to_str(EnvelopeConfig.TEXT)
     circ = Tk2Circuit.from_package_json(json, func_def.name)
 
     return lower_to_pytket(circ)

--- a/tket2-py/pyproject.toml
+++ b/tket2-py/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 dependencies = [
     'pytket >= 2.0, < 3',
-    'hugr >= 0.10.0, < 0.11',
+    'hugr >= 0.11.0, < 0.12',
     'tket2_eccs >= 0.3.0, < 0.4',
     'tket2_exts >= 0.5.0, < 0.6',
 ]

--- a/tket2-py/src/pattern.rs
+++ b/tket2-py/src/pattern.rs
@@ -6,7 +6,7 @@ use crate::circuit::Tk2Circuit;
 use crate::rewrite::PyCircuitRewrite;
 use crate::utils::{create_py_exception, ConvertPyErr};
 
-use hugr::HugrView;
+use hugr::{HugrView, Node};
 use pyo3::prelude::*;
 use tket2::portmatching::{CircuitPattern, PatternMatch, PatternMatcher};
 use tket2::Circuit;
@@ -119,7 +119,7 @@ impl RuleMatcher {
     fn match_to_rewrite(
         &self,
         pmatch: PatternMatch,
-        target: &Circuit<impl HugrView>,
+        target: &Circuit<impl HugrView<Node = Node>>,
     ) -> PyResult<PyCircuitRewrite> {
         let r = self.rights.get(pmatch.pattern_id().0).unwrap().clone();
         let rw = pmatch.to_rewrite(target, r).convert_pyerrs()?;

--- a/tket2-py/tket2/circuit/build.py
+++ b/tket2-py/tket2/circuit/build.py
@@ -8,6 +8,7 @@ from hugr.ops import ComWire, Command
 from hugr.std.float import FLOAT_T
 from hugr.build.function import Module
 from hugr.build.tracked_dfg import TrackedDfg
+from hugr.envelope import EnvelopeConfig
 from tket2.circuit import Tk2Circuit
 
 from dataclasses import dataclass
@@ -76,7 +77,9 @@ class CircBuild(TrackedDfg):
         and validate."""
 
         return Tk2Circuit.from_package_json(
-            self.finish_package(other_extensions=other_extensions).to_json()
+            self.finish_package(other_extensions=other_extensions).to_str(
+                EnvelopeConfig.TEXT
+            )
         )
 
 

--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -12,7 +12,7 @@ use std::iter::Sum;
 
 pub use command::{Command, CommandIterator};
 pub use hash::CircuitHash;
-use hugr::extension::prelude::{LiftDef, NoopDef, TupleOpDef};
+use hugr::extension::prelude::{NoopDef, TupleOpDef};
 use hugr::hugr::views::{DescendantsGraph, ExtractHugr, HierarchyView};
 use itertools::Either::{Left, Right};
 
@@ -71,7 +71,6 @@ lazy_static! {
         set.insert(format!("prelude.{}", NoopDef.name()).into());
         set.insert(format!("prelude.{}", TupleOpDef::MakeTuple.name()).into());
         set.insert(format!("prelude.{}", TupleOpDef::UnpackTuple.name()).into());
-        set.insert(format!("prelude.{}", LiftDef.name()).into());
         set
     };
 }

--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -34,16 +34,16 @@ use self::units::{filter, LinearUnit, Units};
 
 /// A quantum circuit, represented as a function in a HUGR.
 #[derive(Debug, Clone)]
-pub struct Circuit<T = Hugr> {
+pub struct Circuit<T = Hugr, N = Node> {
     /// The HUGR containing the circuit.
     hugr: T,
     /// The parent node of the circuit.
     ///
     /// This is checked at runtime to ensure that the node is a DFG node.
-    parent: Node,
+    parent: N,
 }
 
-impl<T: Default + HugrView> Default for Circuit<T> {
+impl<T: Default + HugrView> Default for Circuit<T, T::Node> {
     fn default() -> Self {
         let hugr = T::default();
         let parent = hugr.root();
@@ -51,7 +51,7 @@ impl<T: Default + HugrView> Default for Circuit<T> {
     }
 }
 
-impl<T: HugrView> PartialEq for Circuit<T> {
+impl<T: HugrView<Node = Node>> PartialEq for Circuit<T> {
     fn eq(&self, other: &Self) -> bool {
         match (self.circuit_hash(), other.circuit_hash()) {
             (Ok(hash1), Ok(hash2)) => hash1 == hash2,
@@ -83,13 +83,13 @@ fn issue_1496_remains() {
     assert_eq!("Noop", NoopDef.name())
 }
 
-impl<T: HugrView> Circuit<T> {
+impl<T: HugrView> Circuit<T, T::Node> {
     /// Create a new circuit from a HUGR and a node.
     ///
     /// # Errors
     ///
     /// Returns an error if the parent node is not a DFG node in the HUGR.
-    pub fn try_new(hugr: T, parent: Node) -> Result<Self, CircuitError> {
+    pub fn try_new(hugr: T, parent: T::Node) -> Result<Self, CircuitError<T::Node>> {
         check_hugr(&hugr, parent)?;
         Ok(Self { hugr, parent })
     }
@@ -101,12 +101,12 @@ impl<T: HugrView> Circuit<T> {
     /// # Panics
     ///
     /// Panics if the parent node is not a DFG node in the HUGR.
-    pub fn new(hugr: T, parent: Node) -> Self {
+    pub fn new(hugr: T, parent: T::Node) -> Self {
         Self::try_new(hugr, parent).unwrap_or_else(|e| panic!("{}", e))
     }
 
     /// Returns the node containing the circuit definition.
-    pub fn parent(&self) -> Node {
+    pub fn parent(&self) -> T::Node {
         self.parent
     }
 
@@ -126,15 +126,6 @@ impl<T: HugrView> Circuit<T> {
     /// by changing the node's type to a non-DFG node or by removing it.
     pub fn hugr_mut(&mut self) -> &mut T {
         &mut self.hugr
-    }
-
-    /// Ensures the circuit contains an owned HUGR.
-    pub fn to_owned(&self) -> Circuit<Hugr> {
-        let hugr = self.hugr.base_hugr().clone();
-        Circuit {
-            hugr,
-            parent: self.parent,
-        }
     }
 
     /// Return the name of the circuit
@@ -167,7 +158,7 @@ impl<T: HugrView> Circuit<T> {
 
     /// Returns the input node to the circuit.
     #[inline]
-    pub fn input_node(&self) -> Node {
+    pub fn input_node(&self) -> T::Node {
         self.hugr
             .get_io(self.parent)
             .expect("Circuit has no input node")[0]
@@ -175,7 +166,7 @@ impl<T: HugrView> Circuit<T> {
 
     /// Returns the output node to the circuit.
     #[inline]
-    pub fn output_node(&self) -> Node {
+    pub fn output_node(&self) -> T::Node {
         self.hugr
             .get_io(self.parent)
             .expect("Circuit has no output node")[1]
@@ -183,7 +174,7 @@ impl<T: HugrView> Circuit<T> {
 
     /// Returns the input and output nodes of the circuit.
     #[inline]
-    pub fn io_nodes(&self) -> [Node; 2] {
+    pub fn io_nodes(&self) -> [T::Node; 2] {
         self.hugr
             .get_io(self.parent)
             .expect("Circuit has no I/O nodes")
@@ -229,7 +220,7 @@ impl<T: HugrView> Circuit<T> {
 
     /// Get the input units of the circuit and their types.
     #[inline]
-    pub fn units(&self) -> Units<OutgoingPort>
+    pub fn units(&self) -> Units<OutgoingPort, T::Node>
     where
         Self: Sized,
     {
@@ -247,7 +238,7 @@ impl<T: HugrView> Circuit<T> {
 
     /// Get the non-linear input units of the circuit and their types.
     #[inline]
-    pub fn nonlinear_units(&self) -> impl Iterator<Item = (Wire, OutgoingPort, Type)> + '_
+    pub fn nonlinear_units(&self) -> impl Iterator<Item = (Wire<T::Node>, OutgoingPort, Type)> + '_
     where
         Self: Sized,
     {
@@ -261,6 +252,52 @@ impl<T: HugrView> Circuit<T> {
         Self: Sized,
     {
         self.units().filter_map(filter::filter_qubit)
+    }
+
+    /// Compute the cost of a group of nodes in a circuit based on a
+    /// per-operation cost function.
+    #[inline]
+    pub fn nodes_cost<F, C>(&self, nodes: impl IntoIterator<Item = T::Node>, op_cost: F) -> C
+    where
+        C: Sum,
+        F: Fn(&OpType) -> C,
+    {
+        nodes
+            .into_iter()
+            .map(|n| op_cost(self.hugr.get_optype(n)))
+            .sum()
+    }
+
+    /// Return the graphviz representation of the underlying graph and hierarchy side by side.
+    ///
+    /// For a simpler representation, use the [`Circuit::mermaid_string`] format instead.
+    pub fn dot_string(&self) -> String {
+        // TODO: This will print the whole HUGR without identifying the circuit container.
+        // Should we add some extra formatting for that?
+        self.hugr.dot_string()
+    }
+
+    /// Return the mermaid representation of the underlying hierarchical graph.
+    ///
+    /// The hierarchy is represented using subgraphs. Edges are labelled with
+    /// their source and target ports.
+    ///
+    /// For a more detailed representation, use the [`Circuit::dot_string`]
+    /// format instead.
+    pub fn mermaid_string(&self) -> String {
+        // TODO: See comment in `dot_string`.
+        self.hugr.mermaid_string()
+    }
+}
+
+impl<T: HugrView<Node = Node>> Circuit<T, Node> {
+    /// Ensures the circuit contains an owned HUGR.
+    pub fn to_owned(&self) -> Circuit<Hugr> {
+        let hugr = self.hugr.base_hugr().clone();
+        Circuit {
+            hugr,
+            parent: self.parent,
+        }
     }
 
     /// Returns all the commands in the circuit, in some topological order.
@@ -293,52 +330,6 @@ impl<T: HugrView> Circuit<T> {
         })
     }
 
-    /// Compute the cost of the circuit based on a per-operation cost function.
-    #[inline]
-    pub fn circuit_cost<F, C>(&self, op_cost: F) -> C
-    where
-        Self: Sized,
-        C: Sum,
-        F: Fn(&OpType) -> C,
-    {
-        self.commands().map(|cmd| op_cost(cmd.optype())).sum()
-    }
-
-    /// Compute the cost of a group of nodes in a circuit based on a
-    /// per-operation cost function.
-    #[inline]
-    pub fn nodes_cost<F, C>(&self, nodes: impl IntoIterator<Item = Node>, op_cost: F) -> C
-    where
-        C: Sum,
-        F: Fn(&OpType) -> C,
-    {
-        nodes
-            .into_iter()
-            .map(|n| op_cost(self.hugr.get_optype(n)))
-            .sum()
-    }
-
-    /// Return the graphviz representation of the underlying graph and hierarchy side by side.
-    ///
-    /// For a simpler representation, use the [`Circuit::mermaid_string`] format instead.
-    pub fn dot_string(&self) -> String {
-        // TODO: This will print the whole HUGR without identifying the circuit container.
-        // Should we add some extra formatting for that?
-        self.hugr.dot_string()
-    }
-
-    /// Return the mermaid representation of the underlying hierarchical graph.
-    ///
-    /// The hierarchy is represented using subgraphs. Edges are labelled with
-    /// their source and target ports.
-    ///
-    /// For a more detailed representation, use the [`Circuit::dot_string`]
-    /// format instead.
-    pub fn mermaid_string(&self) -> String {
-        // TODO: See comment in `dot_string`.
-        self.hugr.mermaid_string()
-    }
-
     /// Extracts the circuit into a new owned HUGR containing the circuit at the root.
     /// Replaces the circuit container operation with an [`OpType::DFG`].
     ///
@@ -359,9 +350,20 @@ impl<T: HugrView> Circuit<T> {
         extract_dfg::rewrite_into_dfg(&mut circ)?;
         Ok(circ)
     }
+
+    /// Compute the cost of the circuit based on a per-operation cost function.
+    #[inline]
+    pub fn circuit_cost<F, C>(&self, op_cost: F) -> C
+    where
+        Self: Sized,
+        C: Sum,
+        F: Fn(&OpType) -> C,
+    {
+        self.commands().map(|cmd| op_cost(cmd.optype())).sum()
+    }
 }
 
-impl<T: HugrView> From<T> for Circuit<T> {
+impl<T: HugrView> From<T> for Circuit<T, T::Node> {
     fn from(hugr: T) -> Self {
         let parent = hugr.root();
         Self::new(hugr, parent)
@@ -370,7 +372,7 @@ impl<T: HugrView> From<T> for Circuit<T> {
 
 /// Checks if the passed hugr is a valid circuit,
 /// and return [`CircuitError`] if not.
-fn check_hugr(hugr: &impl HugrView, parent: Node) -> Result<(), CircuitError> {
+fn check_hugr<H: HugrView>(hugr: &H, parent: H::Node) -> Result<(), CircuitError<H::Node>> {
     if !hugr.contains_node(parent) {
         return Err(CircuitError::MissingParentNode { parent });
     }
@@ -469,12 +471,12 @@ pub(crate) fn remove_empty_wire(
 /// Errors that can occur when mutating a circuit.
 #[derive(Display, Debug, Clone, Error, PartialEq)]
 #[non_exhaustive]
-pub enum CircuitError {
+pub enum CircuitError<N = Node> {
     /// The parent node for the circuit does not exist in the HUGR.
     #[display("{parent} cannot define a circuit as it is not present in the HUGR.")]
     MissingParentNode {
         /// The node that was used as the parent.
-        parent: Node,
+        parent: N,
     },
     /// Circuit parents must have a concrete signature.
     #[display(
@@ -484,7 +486,7 @@ pub enum CircuitError {
     )]
     ParametricSignature {
         /// The node that was used as the parent.
-        parent: Node,
+        parent: N,
         /// The parent optype.
         optype: OpType,
         /// The parent signature.
@@ -497,7 +499,7 @@ pub enum CircuitError {
     )]
     InvalidParentOp {
         /// The node that was used as the parent.
-        parent: Node,
+        parent: N,
         /// The parent optype.
         optype: OpType,
     },

--- a/tket2/src/circuit/command.rs
+++ b/tket2/src/circuit/command.rs
@@ -33,7 +33,7 @@ pub struct Command<'circ, T> {
     output_linear_units: Vec<LinearUnit>,
 }
 
-impl<'circ, T: HugrView> Command<'circ, T> {
+impl<'circ, T: HugrView<Node = Node>> Command<'circ, T> {
     /// Returns the node corresponding to this command.
     #[inline]
     pub fn node(&self) -> Node {
@@ -88,7 +88,7 @@ impl<'circ, T: HugrView> Command<'circ, T> {
 
     /// Returns the output units of this command. See [`Command::units`].
     #[inline]
-    pub fn outputs(&self) -> Units<OutgoingPort, &'_ Self> {
+    pub fn outputs(&self) -> Units<OutgoingPort, Node, &'_ Self> {
         Units::new_outgoing(self.circ, self.node, self)
     }
 
@@ -109,7 +109,7 @@ impl<'circ, T: HugrView> Command<'circ, T> {
 
     /// Returns the output units of this command.
     #[inline]
-    pub fn inputs(&self) -> Units<IncomingPort, &'_ Self> {
+    pub fn inputs(&self) -> Units<IncomingPort, Node, &'_ Self> {
         Units::new_incoming(self.circ, self.node, self)
     }
 
@@ -163,7 +163,7 @@ impl<'circ, T: HugrView> Command<'circ, T> {
     }
 }
 
-impl<T: HugrView> UnitLabeller for &Command<'_, T> {
+impl<T: HugrView<Node = Node>> UnitLabeller<Node> for &Command<'_, T> {
     #[inline]
     fn assign_linear(&self, _: Node, port: Port, _linear_count: usize) -> LinearUnit {
         let units = match port.direction() {
@@ -190,7 +190,7 @@ impl<T: HugrView> UnitLabeller for &Command<'_, T> {
     }
 }
 
-impl<T: HugrView> std::fmt::Debug for Command<'_, T> {
+impl<T: HugrView<Node = Node>> std::fmt::Debug for Command<'_, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Command")
             .field("circuit name", &self.circ.name())
@@ -234,6 +234,8 @@ impl<T: HugrView> std::hash::Hash for Command<'_, T> {
 type NodeWalker = pv::Topo<Node, HashSet<Node>>;
 
 /// An iterator over the commands of a circuit.
+// TODO: this can only be made generic over node type once `SiblingGraph` is
+// generic over node type. See https://github.com/CQCL/hugr/issues/1926
 #[derive(Clone)]
 pub struct CommandIterator<'circ, T> {
     /// The circuit.
@@ -266,7 +268,7 @@ pub struct CommandIterator<'circ, T> {
     delayed_node: Option<Node>,
 }
 
-impl<'circ, T: HugrView> CommandIterator<'circ, T> {
+impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// Create a new iterator over the commands of a circuit.
     pub(super) fn new(circ: &'circ Circuit<T>) -> Self {
         // Initialize the map assigning linear units to the input's linear
@@ -434,7 +436,7 @@ impl<'circ, T: HugrView> CommandIterator<'circ, T> {
     }
 }
 
-impl<'circ, T: HugrView> Iterator for CommandIterator<'circ, T> {
+impl<'circ, T: HugrView<Node = Node>> Iterator for CommandIterator<'circ, T> {
     type Item = Command<'circ, T>;
 
     #[inline]
@@ -460,9 +462,9 @@ impl<'circ, T: HugrView> Iterator for CommandIterator<'circ, T> {
     }
 }
 
-impl<T: HugrView> FusedIterator for CommandIterator<'_, T> {}
+impl<T: HugrView<Node = Node>> FusedIterator for CommandIterator<'_, T> {}
 
-impl<T: HugrView> std::fmt::Debug for CommandIterator<'_, T> {
+impl<T: HugrView<Node = Node>> std::fmt::Debug for CommandIterator<'_, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CommandIterator")
             .field("circuit name", &self.circ.name())

--- a/tket2/src/circuit/hash.rs
+++ b/tket2/src/circuit/hash.rs
@@ -26,7 +26,7 @@ pub trait CircuitHash {
     fn circuit_hash(&self) -> Result<u64, HashError>;
 }
 
-impl<T: HugrView> CircuitHash for Circuit<T> {
+impl<T: HugrView<Node = Node>> CircuitHash for Circuit<T> {
     fn circuit_hash(&self) -> Result<u64, HashError> {
         let hugr = self.hugr();
         let container: SiblingGraph = SiblingGraph::try_new(hugr, self.parent()).unwrap();
@@ -36,7 +36,7 @@ impl<T: HugrView> CircuitHash for Circuit<T> {
 
 impl<T> CircuitHash for T
 where
-    T: HugrView,
+    T: HugrView<Node = Node>,
 {
     fn circuit_hash(&self) -> Result<u64, HashError> {
         let Some([_, output_node]) = self.get_io(self.root()) else {
@@ -116,7 +116,11 @@ fn hashable_op(op: &OpType) -> impl Hash {
 /// # Panics
 /// - If the command is a container node, or if it is a parametric CustomOp.
 /// - If the hash of any of its predecessors has not been set.
-fn hash_node(circ: &impl HugrView, node: Node, state: &mut HashState) -> Result<u64, HashError> {
+fn hash_node(
+    circ: &impl HugrView<Node = Node>,
+    node: Node,
+    state: &mut HashState,
+) -> Result<u64, HashError> {
     let op = circ.get_optype(node);
     let mut hasher = FxHasher64::default();
 

--- a/tket2/src/circuit/units/filter.rs
+++ b/tket2/src/circuit/units/filter.rs
@@ -13,7 +13,7 @@ use hugr::Wire;
 use super::LinearUnit;
 
 /// A unit filter that return only linear units.
-pub fn filter_linear<P>(item: (CircuitUnit, P, Type)) -> Option<(LinearUnit, P, Type)> {
+pub fn filter_linear<N, P>(item: (CircuitUnit<N>, P, Type)) -> Option<(LinearUnit, P, Type)> {
     match item {
         (CircuitUnit::Linear(unit), port, typ) => Some((LinearUnit::new(unit), port, typ)),
         _ => None,
@@ -21,7 +21,7 @@ pub fn filter_linear<P>(item: (CircuitUnit, P, Type)) -> Option<(LinearUnit, P, 
 }
 
 /// A unit filter that return only qubits, a subset of [`filter_linear`].
-pub fn filter_qubit<P>(item: (CircuitUnit, P, Type)) -> Option<(LinearUnit, P, Type)> {
+pub fn filter_qubit<N, P>(item: (CircuitUnit<N>, P, Type)) -> Option<(LinearUnit, P, Type)> {
     match item {
         (CircuitUnit::Linear(unit), port, typ) if typ == prelude::qb_t() => {
             Some((LinearUnit::new(unit), port, typ))
@@ -31,7 +31,7 @@ pub fn filter_qubit<P>(item: (CircuitUnit, P, Type)) -> Option<(LinearUnit, P, T
 }
 
 /// A unit filter that return only non-linear units.
-pub fn filter_non_linear<P>(item: (CircuitUnit, P, Type)) -> Option<(Wire, P, Type)> {
+pub fn filter_non_linear<N, P>(item: (CircuitUnit<N>, P, Type)) -> Option<(Wire<N>, P, Type)> {
     match item {
         (CircuitUnit::Wire(wire), port, typ) => Some((wire, port, typ)),
         _ => None,

--- a/tket2/src/optimiser/badger.rs
+++ b/tket2/src/optimiser/badger.rs
@@ -22,7 +22,7 @@ use crossbeam_channel::select;
 pub use eq_circ_class::{load_eccs_json_file, EqCircClass};
 use fxhash::FxHashSet;
 use hugr::hugr::HugrError;
-use hugr::HugrView;
+use hugr::{HugrView, Node};
 pub use log::BadgerLogger;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
@@ -122,7 +122,7 @@ impl<R, S> BadgerOptimiser<R, S> {
         Self { rewriter, strategy }
     }
 
-    fn cost(&self, circ: &Circuit<impl HugrView>) -> S::Cost
+    fn cost(&self, circ: &Circuit<impl HugrView<Node = Node>>) -> S::Cost
     where
         S: RewriteStrategy,
     {
@@ -139,7 +139,11 @@ where
     /// Run the Badger optimiser on a circuit.
     ///
     /// A timeout (in seconds) can be provided.
-    pub fn optimise(&self, circ: &Circuit<impl HugrView>, options: BadgerOptions) -> Circuit {
+    pub fn optimise(
+        &self,
+        circ: &Circuit<impl HugrView<Node = Node>>,
+        options: BadgerOptions,
+    ) -> Circuit {
         self.optimise_with_log(circ, Default::default(), options)
     }
 
@@ -148,7 +152,7 @@ where
     /// A timeout (in seconds) can be provided.
     pub fn optimise_with_log(
         &self,
-        circ: &Circuit<impl HugrView>,
+        circ: &Circuit<impl HugrView<Node = Node>>,
         log_config: BadgerLogger,
         options: BadgerOptions,
     ) -> Circuit {
@@ -169,7 +173,7 @@ where
     #[tracing::instrument(target = "badger::metrics", skip(self, circ, logger))]
     fn badger(
         &self,
-        circ: &Circuit<impl HugrView>,
+        circ: &Circuit<impl HugrView<Node = Node>>,
         mut logger: BadgerLogger,
         opt: BadgerOptions,
     ) -> Circuit {
@@ -278,7 +282,7 @@ where
     #[tracing::instrument(target = "badger::metrics", skip(self, circ, logger))]
     fn badger_multithreaded(
         &self,
-        circ: &Circuit<impl HugrView>,
+        circ: &Circuit<impl HugrView<Node = Node>>,
         mut logger: BadgerLogger,
         opt: BadgerOptions,
     ) -> Circuit {
@@ -422,7 +426,7 @@ where
     #[tracing::instrument(target = "badger::metrics", skip(self, circ, logger))]
     fn badger_split_multithreaded(
         &self,
-        circ: &Circuit<impl HugrView>,
+        circ: &Circuit<impl HugrView<Node = Node>>,
         mut logger: BadgerLogger,
         opt: BadgerOptions,
     ) -> Result<Circuit, HugrError> {

--- a/tket2/src/passes/commutation.rs
+++ b/tket2/src/passes/commutation.rs
@@ -26,7 +26,7 @@ struct ComCommand {
     inputs: Vec<CircuitUnit>,
 }
 
-impl<'c, T: HugrView> From<Command<'c, T>> for ComCommand {
+impl<'c, T: HugrView<Node = Node>> From<Command<'c, T>> for ComCommand {
     fn from(com: Command<'c, T>) -> Self {
         ComCommand {
             node: com.node(),
@@ -66,7 +66,7 @@ fn add_to_slice(slice: &mut Slice, com: Rc<ComCommand>) {
     }
 }
 
-fn load_slices(circ: &Circuit<impl HugrView>) -> SliceVec {
+fn load_slices(circ: &Circuit<impl HugrView<Node = Node>>) -> SliceVec {
     let mut slices = vec![];
 
     let n_qbs = circ.qubit_count();
@@ -98,7 +98,7 @@ fn load_slices(circ: &Circuit<impl HugrView>) -> SliceVec {
 }
 
 /// check if node is one we want to put in to a slice.
-fn is_slice_op(h: &impl HugrView, node: Node) -> bool {
+fn is_slice_op<H: HugrView>(h: &H, node: H::Node) -> bool {
     h.get_optype(node).cast::<Tk2Op>().is_some()
 }
 

--- a/tket2/src/passes/pytket.rs
+++ b/tket2/src/passes/pytket.rs
@@ -5,6 +5,7 @@
 
 use derive_more::{Display, Error, From};
 use hugr::hugr::views::ExtractHugr;
+use hugr::Node;
 use itertools::Itertools;
 
 use crate::serialize::pytket::OpConvertError;
@@ -13,7 +14,9 @@ use crate::Circuit;
 use super::find_tuple_unpack_rewrites;
 
 /// Try to lower a circuit to a form that can be encoded as a pytket legacy circuit.
-pub fn lower_to_pytket<T: ExtractHugr>(circ: &Circuit<T>) -> Result<Circuit, PytketLoweringError> {
+pub fn lower_to_pytket<T: ExtractHugr<Node = Node>>(
+    circ: &Circuit<T>,
+) -> Result<Circuit, PytketLoweringError> {
     let mut circ = circ
         .extract_dfg()
         .map_err(|_| PytketLoweringError::NonLocalOperations)?;

--- a/tket2/src/passes/tuple_unpack.rs
+++ b/tket2/src/passes/tuple_unpack.rs
@@ -16,7 +16,7 @@ use crate::Circuit;
 /// Find tuple pack operations followed by tuple unpack operations
 /// and generate rewrites to remove them.
 pub fn find_tuple_unpack_rewrites(
-    circ: &Circuit<impl HugrView>,
+    circ: &Circuit<impl HugrView<Node = Node>>,
 ) -> impl Iterator<Item = CircuitRewrite> + '_ {
     circ.commands().filter_map(|cmd| make_rewrite(circ, cmd))
 }
@@ -35,7 +35,10 @@ fn is_unpack_tuple(optype: &OpType) -> bool {
     optype.name() == format!("prelude.{}", TupleOpDef::UnpackTuple.name())
 }
 
-fn make_rewrite<T: HugrView>(circ: &Circuit<T>, cmd: Command<T>) -> Option<CircuitRewrite> {
+fn make_rewrite<T: HugrView<Node = Node>>(
+    circ: &Circuit<T>,
+    cmd: Command<T>,
+) -> Option<CircuitRewrite> {
     let cmd_optype = cmd.optype();
     let tuple_node = cmd.node();
     if !is_make_tuple(cmd_optype) {
@@ -86,7 +89,7 @@ fn make_rewrite<T: HugrView>(circ: &Circuit<T>, cmd: Command<T>) -> Option<Circu
 
 /// Returns a rewrite to remove a tuple pack operation that's followed by unpack operations,
 /// and `other_tuple_links` other operations.
-fn remove_pack_unpack<T: HugrView>(
+fn remove_pack_unpack<T: HugrView<Node = Node>>(
     circ: &Circuit<T>,
     tuple_types: &[Type],
     pack_node: Node,

--- a/tket2/src/portmatching/matcher.rs
+++ b/tket2/src/portmatching/matcher.rs
@@ -138,7 +138,7 @@ impl PatternMatch {
     pub fn try_from_root_match_with_checker(
         root: Node,
         pattern: PatternID,
-        circ: &Circuit<impl HugrView>,
+        circ: &Circuit<impl HugrView<Node = Node>>,
         matcher: &PatternMatcher,
         checker: &impl ConvexChecker,
     ) -> Result<Self, InvalidPatternMatch> {
@@ -198,7 +198,7 @@ impl PatternMatch {
     pub fn try_from_io_with_checker(
         root: Node,
         pattern: PatternID,
-        circ: &Circuit<impl HugrView>,
+        circ: &Circuit<impl HugrView<Node = Node>>,
         inputs: Vec<Vec<(Node, IncomingPort)>>,
         outputs: Vec<(Node, OutgoingPort)>,
         checker: &impl ConvexChecker,
@@ -215,7 +215,7 @@ impl PatternMatch {
     /// Construct a rewrite to replace `self` with `repl`.
     pub fn to_rewrite(
         &self,
-        source: &Circuit<impl HugrView>,
+        source: &Circuit<impl HugrView<Node = Node>>,
         target: Circuit,
     ) -> Result<CircuitRewrite, InvalidReplacement> {
         CircuitRewrite::try_new(&self.position, source, target)
@@ -273,7 +273,7 @@ impl PatternMatcher {
     /// Find all convex pattern matches in a circuit.
     pub fn find_matches_iter<'a, 'c: 'a>(
         &'a self,
-        circuit: &'c Circuit<impl HugrView>,
+        circuit: &'c Circuit<impl HugrView<Node = Node>>,
     ) -> impl Iterator<Item = PatternMatch> + 'a {
         let checker = TopoConvexChecker::new(circuit.hugr());
         circuit
@@ -282,14 +282,14 @@ impl PatternMatcher {
     }
 
     /// Find all convex pattern matches in a circuit.and collect in to a vector
-    pub fn find_matches(&self, circuit: &Circuit<impl HugrView>) -> Vec<PatternMatch> {
+    pub fn find_matches(&self, circuit: &Circuit<impl HugrView<Node = Node>>) -> Vec<PatternMatch> {
         self.find_matches_iter(circuit).collect()
     }
 
     /// Find all convex pattern matches in a circuit rooted at a given node.
     fn find_rooted_matches(
         &self,
-        circ: &Circuit<impl HugrView>,
+        circ: &Circuit<impl HugrView<Node = Node>>,
         root: Node,
         checker: &impl ConvexChecker,
     ) -> Vec<PatternMatch> {
@@ -438,7 +438,7 @@ fn compatible_offsets(e1: &PEdge, e2: &PEdge) -> bool {
 
 /// Returns a predicate checking that an edge at `src` satisfies `prop` in `circ`.
 pub(super) fn validate_circuit_edge(
-    circ: &Circuit<impl HugrView>,
+    circ: &Circuit<impl HugrView<Node = Node>>,
 ) -> impl for<'a> Fn(NodeID, &'a PEdge) -> Option<NodeID> + '_ {
     move |src, &prop| {
         let NodeID::HugrNode(src) = src else {
@@ -464,7 +464,7 @@ pub(super) fn validate_circuit_edge(
 
 /// Returns a predicate checking that `node` satisfies `prop` in `circ`.
 pub(crate) fn validate_circuit_node(
-    circ: &Circuit<impl HugrView>,
+    circ: &Circuit<impl HugrView<Node = Node>>,
 ) -> impl for<'a> Fn(NodeID, &PNode) -> bool + '_ {
     move |node, prop| {
         let NodeID::HugrNode(node) = node else {

--- a/tket2/src/portmatching/pattern.rs
+++ b/tket2/src/portmatching/pattern.rs
@@ -103,7 +103,7 @@ impl CircuitPattern {
     pub fn get_match_map(
         &self,
         root: Node,
-        circ: &Circuit<impl HugrView>,
+        circ: &Circuit<impl HugrView<Node = Node>>,
     ) -> Option<HashMap<Node, Node>> {
         let single_matcher = SinglePatternMatcher::from_pattern(self.pattern.clone());
         single_matcher

--- a/tket2/src/rewrite/ecc_rewriter.rs
+++ b/tket2/src/rewrite/ecc_rewriter.rs
@@ -14,7 +14,7 @@
 
 use derive_more::{Display, Error, From, Into};
 use hugr::extension::resolution::ExtensionResolutionError;
-use hugr::{Hugr, HugrView, PortIndex};
+use hugr::{Hugr, HugrView, Node, PortIndex};
 use itertools::Itertools;
 use portmatching::PatternID;
 use std::{
@@ -185,7 +185,7 @@ impl ECCRewriter {
 }
 
 impl Rewriter for ECCRewriter {
-    fn get_rewrites(&self, circ: &Circuit<impl HugrView>) -> Vec<CircuitRewrite> {
+    fn get_rewrites(&self, circ: &Circuit<impl HugrView<Node = Node>>) -> Vec<CircuitRewrite> {
         let matches = self.matcher.find_matches(circ);
         matches
             .into_iter()
@@ -266,7 +266,7 @@ fn get_patterns(rep_sets: &[EqCircClass]) -> Vec<Option<(CircuitPattern, Vec<usi
 }
 
 /// The port offsets of wires that are empty.
-fn empty_wires(circ: &Circuit<impl HugrView>) -> Vec<usize> {
+fn empty_wires(circ: &Circuit<impl HugrView<Node = Node>>) -> Vec<usize> {
     let hugr = circ.hugr();
     let input = circ.input_node();
     let input_sig = hugr.signature(input).unwrap();

--- a/tket2/src/rewrite/strategy.rs
+++ b/tket2/src/rewrite/strategy.rs
@@ -25,7 +25,7 @@ use std::{collections::HashSet, fmt::Debug};
 
 use derive_more::From;
 use hugr::ops::OpType;
-use hugr::HugrView;
+use hugr::{HugrView, Node};
 use itertools::Itertools;
 
 use crate::circuit::cost::{is_cx, is_quantum, CircuitCost, CostDelta, LexicographicCost};
@@ -59,7 +59,7 @@ pub trait RewriteStrategy {
 
     /// The cost of a circuit using this strategy's cost function.
     #[inline]
-    fn circuit_cost(&self, circ: &Circuit<impl HugrView>) -> Self::Cost {
+    fn circuit_cost(&self, circ: &Circuit<impl HugrView<Node = Node>>) -> Self::Cost {
         circ.circuit_cost(|op| self.op_cost(op))
     }
 
@@ -86,7 +86,9 @@ pub struct RewriteResult<C: CircuitCost> {
     pub cost_delta: C::CostDelta,
 }
 
-impl<C: CircuitCost, T: HugrView> From<(Circuit<T>, C::CostDelta)> for RewriteResult<C> {
+impl<C: CircuitCost, T: HugrView<Node = Node>> From<(Circuit<T>, C::CostDelta)>
+    for RewriteResult<C>
+{
     #[inline]
     fn from((circ, cost_delta): (Circuit<T>, C::CostDelta)) -> Self {
         Self {
@@ -143,7 +145,7 @@ impl RewriteStrategy for GreedyRewriteStrategy {
         iter::once((circ, cost_delta).into())
     }
 
-    fn circuit_cost(&self, circ: &Circuit<impl HugrView>) -> Self::Cost {
+    fn circuit_cost(&self, circ: &Circuit<impl HugrView<Node = Node>>) -> Self::Cost {
         circ.num_operations()
     }
 

--- a/tket2/src/serialize.rs
+++ b/tket2/src/serialize.rs
@@ -99,7 +99,7 @@ impl Circuit<Hugr> {
     /// Otherwise, the json must encode a module-rooted HUGR containing the
     /// named function.
     pub fn load_function_reader(
-        json: impl std::io::BufRead,
+        json: impl io::BufRead,
         function_name: impl AsRef<str>,
     ) -> Result<Self, CircuitLoadError> {
         let pkg = Package::load(json, Some(&REGISTRY))?;

--- a/uv.lock
+++ b/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "hugr"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "graphviz" },
@@ -168,9 +168,9 @@ dependencies = [
     { name = "pydantic-extra-types" },
     { name = "semver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/ef/9cd410ff0e3a92c5e88da2ef3c0e051dd971f4f6c5577873c7901ed31dd5/hugr-0.10.0.tar.gz", hash = "sha256:11e5a80ebd4e31cad0cb04d408cdd93a094e6fb817dd81481eedac5a58f86ff7", size = 129441 }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/7a/d5e1dc2d1a7b0a65b51df34fa8ce823cd1b50629fe5b63d2a0522aa59d73/hugr-0.11.0.tar.gz", hash = "sha256:5c391241753ad9f05ed9eb73aef0c062471b8d247a52a26776027ef3ce7142dd", size = 115579 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/71/83556457cfe27f4a1613cd49041cfe4c6e9e087a53b5beec48a8d709c36d/hugr-0.10.0-py3-none-any.whl", hash = "sha256:591e252ef3e4182fd0de99274ebb4999ddd9572a0ec823519de154e4bd9f14ec", size = 83000 },
+    { url = "https://files.pythonhosted.org/packages/1c/54/94bc7044f0dd3e8b1b4e9ff004ca1799b176b113bd3c3604c4a5b949d7cc/hugr-0.11.0-py3-none-any.whl", hash = "sha256:c1f9c5558ea041ce8a828edbd8ecac885c20ec52decddbed5934bec3096fe2a3", size = 87604 },
 ]
 
 [[package]]
@@ -837,7 +837,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hugr", specifier = ">=0.10.0,<0.11" },
+    { name = "hugr", specifier = ">=0.11.0,<0.12" },
     { name = "pytket", specifier = ">=2.0,<3" },
     { name = "tket2-eccs", editable = "tket2-eccs" },
     { name = "tket2-exts", editable = "tket2-exts" },
@@ -857,7 +857,7 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "hugr", specifier = ">=0.10.0,<0.11" }]
+requires-dist = [{ name = "hugr", specifier = ">=0.11.0,<0.12" }]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
wait for release

mainly cherry pick from 6f171b772bdefe7cb9f13e027bd950b19b40e93a

BREAKING CHANGE: `Node` is now an associated type of `HugrView`
BREAKING CHANGE: `Circuit::load_function_reader` takes a `BufRead` rather than `Read`