### PR TITLE
feat: Use hugr envelopes to store/load circuits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,12 @@ repository = "https://github.com/CQCL/tket2"
 license = "Apache-2.0"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ci_run)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    # Set by our CI
+    'cfg(ci_run)',
+    # Set by codecov
+    'cfg(coverage,coverage_nightly)',
+] }
 missing_docs = "warn"
 
 [patch.crates-io]

--- a/tket2-py/examples/utils/__init__.py
+++ b/tket2-py/examples/utils/__init__.py
@@ -35,6 +35,6 @@ def guppy_to_circuit(func_def: Any) -> Tk2Circuit:
     pkg = module.compile()
 
     json = pkg.package.to_str(EnvelopeConfig.TEXT)
-    circ = Tk2Circuit.from_package_json(json, func_def.name)
+    circ = Tk2Circuit.from_str(json, func_def.name)
 
     return lower_to_pytket(circ)

--- a/tket2-py/tket2/_tket2/circuit.pyi
+++ b/tket2-py/tket2/_tket2/circuit.pyi
@@ -2,6 +2,17 @@ from typing import Any, Callable
 from pytket._tket.circuit import Circuit as Tk1Circuit
 
 from tket2._tket2.ops import Tk2Op
+from hugr.envelope import EnvelopeConfig
+
+try:
+    from warnings import deprecated  # type: ignore[attr-defined]
+except ImportError:
+    # Python < 3.13
+    def deprecated(_msg):  # type: ignore[no-redef]
+        def _deprecated(func):
+            return func
+
+        return _deprecated
 
 class Tk2Circuit:
     """Rust representation of a TKET2 circuit."""
@@ -56,14 +67,69 @@ class Tk2Circuit:
     def to_hugr_json(self) -> str:
         """Encode the circuit as a HUGR json."""
 
-    def to_package_json(self) -> str:
-        """Encode the circuit as a HUGR Package json."""
-
     @staticmethod
     def from_hugr_json(json: str) -> Tk2Circuit:
         """Decode a HUGR json string to a Tk2Circuit."""
 
+    def to_bytes(self, config: EnvelopeConfig) -> bytes:
+        """Encode the circuit as a HUGR envelope, according to the given config.
+
+        Some envelope formats can be encoded into a string. See :meth:`to_str`.
+
+        Args:
+            config: The envelope configuration to use.
+        """
+
+    def to_str(self, config: EnvelopeConfig | None = None) -> str:
+        """Encode the circuit as a HUGR envelope string.
+
+        Not all envelope formats can be encoded into a string.
+        See :meth:`to_bytes` for a more general method.
+
+        Args:
+            config: The envelope configuration to use.
+                If not given, uses the default textual encoding.
+        """
+
     @staticmethod
+    def from_bytes(envelope: bytes, function_name: str | None = None) -> Tk2Circuit:
+        """Load a Circuit from a HUGR envelope.
+
+        Some envelope formats can be read from a string. See :meth:`from_str`.
+
+        Args:
+            envelope: The byte string representing a Package.
+            function_name: The name of the function in the envelope's module to load.
+                Defaults to `main`.
+
+        Returns:
+            The loaded circuit.
+        """
+
+    @staticmethod
+    def from_str(envelope: str, function_name: str | None = None) -> Tk2Circuit:
+        """Load a Circuit from a HUGR envelope string.
+
+        Not all envelope formats can be represented as strings.
+        See :meth:`from_bytes` for a more general method.
+
+        Args:
+            envelope: The string representing a Package.
+            function_name: The name of the function in the envelope's module to load.
+                Defaults to `main`.
+
+        Returns:
+            The loaded circuit.
+        """
+
+    @deprecated("Use HUGR envelopes instead. See the `to_bytes` and `to_str` methods.")
+    def to_package_json(self) -> str:
+        """Encode the circuit as a HUGR Package json."""
+
+    @staticmethod
+    @deprecated(
+        "Use HUGR envelopes instead. See the `from_bytes` and `from_str` methods."
+    )
     def from_package_json(json: str, function_name: str | None = None) -> Tk2Circuit:
         """Decode a HUGR Package json to a circuit.
 

--- a/tket2-py/tket2/circuit/build.py
+++ b/tket2-py/tket2/circuit/build.py
@@ -76,7 +76,7 @@ class CircBuild(TrackedDfg):
         """Finish building the circuit by setting all the qubits as the output
         and validate."""
 
-        return Tk2Circuit.from_package_json(
+        return Tk2Circuit.from_str(
             self.finish_package(other_extensions=other_extensions).to_str(
                 EnvelopeConfig.TEXT
             )

--- a/tket2/src/lib.rs
+++ b/tket2/src/lib.rs
@@ -42,6 +42,7 @@
 //! ```
 //!
 //! [quantinuum-hugr]: https://lib.rs/crates/quantinuum-hugr
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod circuit;
 pub mod extension;


### PR DESCRIPTION
Deprecates the Circuit's "read/write package" API in favour of using the new HUGR envelopes.

#806 modified these to make them work with envelopes as a hack. This PR rolls those changes back and instead adds new methods for these.

I also renamed some hugr storing methods, so now these all have the same names as their `hugr` counterparts.

##### Rust side
- `store` / `store_str` / `store_hugr` to write circuits
- `load_function` / `load_function_str` / `load_hugr` to read circuits.
  - In the future we may add `load` methods that do not need the extra `function_name` attribute, once we have hugr root pointers.
  
  ##### Python side
  - `to_bytes` / `to_str`
  - `from_bytes` / `from_str` (with optional function name parameters)
 