### PR TITLE
chore: devenv cleanups

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -94,29 +94,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741951873,
+        "lastModified": 1741865919,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce52a4d87a33258646dde1a1bfcaa88074e9c821",
+        "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2305": {
-      "locked": {
-        "lastModified": 1704290814,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -127,7 +113,6 @@
         "fenix": "fenix",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-2305": "nixpkgs-2305",
         "pre-commit-hooks": [
           "git-hooks"
         ]

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,16 +1,11 @@
-{ pkgs, lib, config, inputs, ... }:
-let
-  pkgs-2305 = import inputs.nixpkgs-2305 { system = pkgs.stdenv.system; };
-in
+{ pkgs, lib, ... }:
+
 {
   # https://devenv.sh/packages/
   # on macos frameworks have to be explicitly specified
   # otherwise a linker error ocurs on rust packages
   packages = [
     pkgs.just
-    pkgs.llvmPackages_16.libllvm
-    # cargo-llvm-cov is currently marked broken on nixpkgs unstable
-    pkgs-2305.cargo-llvm-cov
   ]
   ++ lib.optionals pkgs.stdenv.isLinux [
     pkgs.stdenv.cc.cc.lib
@@ -22,23 +17,11 @@ in
     ]
   );
 
-  # Certain Rust tools won't work without this
-  # This can also be fixed by using oxalica/rust-overlay and specifying the rust-src extension
-  # See https://discourse.nixos.org/t/rust-src-not-found-and-other-misadventures-of-developing-rust-on-nixos/11570/3?u=samuela. for more details.
-  #env.RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
-  # https://devenv.sh/scripts/
-  scripts.hello.exec = "echo Welcome to tket2proto devenv!";
 
   enterShell = ''
-    hello
     cargo --version
     python --version
     uv --version
-    export LLVM_COV="${pkgs.llvmPackages_16.libllvm}/bin/llvm-cov"
-    export LLVM_PROFDATA="${pkgs.llvmPackages_16.libllvm}/bin/llvm-profdata"
-
-    just setup
-    source .venv/bin/activate
   '';
 
   # https://devenv.sh/languages/
@@ -53,7 +36,10 @@ in
     enable = true;
     uv = {
       enable = true;
+      sync.enable = true;
     };
+    venv.enable = true;
   };
+
 
 }

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,8 +1,6 @@
 inputs:
   nixpkgs:
-    url: github:NixOS/nixpkgs
-  nixpkgs-2305:
-    url: github:NixOS/nixpkgs/nixos-23.05
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
   fenix:
     url: github:nix-community/fenix
     inputs:


### PR DESCRIPTION
I started getting link errors on uv sync with mismatched symbols

this repo no longer requires the llvm package, removing it fixed my problems