### PR TITLE
ci: Update miri tests workflow, add justfile recipe

### DIFF
--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -1,9 +1,9 @@
 name: Unsoundness checks
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # Weekly on Monday at 04:00 UTC
+    - cron: '0 4 * * 1'
   workflow_dispatch: {}
 
 concurrency:
@@ -14,13 +14,16 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "--cfg=ci_run"
-  MIRIFLAGS: '-Zmiri-permissive-provenance' # Required due to warnings in bitvec 1.0.1
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  # Permissive provenance is required due to warnings in bitvec 1.0.1
+  # Proptest flags required to fix https://github.com/proptest-rs/proptest/issues/253
+  MIRIFLAGS: '-Zmiri-permissive-provenance -Zmiri-env-forward=PROPTEST_DISABLE_FAILURE_PERSISTENCE'
+  PROPTEST_DISABLE_FAILURE_PERSISTENCE: true
 
 jobs:
 
-   miri:
+  miri:
     name: "Miri"
     runs-on: ubuntu-latest
     steps:
@@ -33,3 +36,18 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.8
       - name: Test with Miri
         run: cargo miri test
+
+  create-issue:
+    uses: CQCL/hugrverse-actions/.github/workflows/create-issue.yml@main
+    needs: miri
+    if: always() && needs.miri.result == 'failure' && github.ref == 'refs/heads/main'
+    secrets:
+        GITHUB_PAT: ${{ secrets.HUGRBOT_PAT }}
+    with:
+        title: "💥 Unsoundness check fail on main"
+        body: |
+            The unsoundness check for `CQCL/tket2` failed.
+
+            [Please investigate](https://github.com/CQCL/tket2/actions/runs/${{ github.run_id }}).
+        unique-label: "unsoundness-checks"
+        other-labels: "bug"

--- a/justfile
+++ b/justfile
@@ -40,6 +40,10 @@ coverage language="[rust|python]": (_run_lang language \
         "uv run maturin develop && uv run pytest --cov=./ --cov-report=html"
     )
 
+# Run Rust unsoundness checks using miri
+miri *TEST_ARGS:
+    PROPTEST_DISABLE_FAILURE_PERSISTENCE=true MIRIFLAGS='-Zmiri-env-forward=PROPTEST_DISABLE_FAILURE_PERSISTENCE' cargo +nightly miri test {{TEST_ARGS}}
+
 # Runs `compile-rewriter` on the ECCs in `test_files/eccs`
 recompile-eccs:
     scripts/compile-test-eccs.sh


### PR DESCRIPTION
Copied straight from CQCL/hugr

- Runs the miri test weekly instead of on each push to main
- Open an issue on the repo when the test fails
- Adds a `just miri` recipe to check unsoundness locally

We should wait until #818 gets merged before adding this.