### PR TITLE
refactor!: Remove node parameter from Circuit

### DIFF
--- a/tket2/src/circuit.rs
+++ b/tket2/src/circuit.rs
@@ -34,16 +34,16 @@ use self::units::{filter, LinearUnit, Units};
 
 /// A quantum circuit, represented as a function in a HUGR.
 #[derive(Debug, Clone)]
-pub struct Circuit<T = Hugr, N = Node> {
+pub struct Circuit<T: HugrView = Hugr> {
     /// The HUGR containing the circuit.
     hugr: T,
     /// The parent node of the circuit.
     ///
     /// This is checked at runtime to ensure that the node is a DFG node.
-    parent: N,
+    parent: T::Node,
 }
 
-impl<T: Default + HugrView> Default for Circuit<T, T::Node> {
+impl<T: Default + HugrView> Default for Circuit<T> {
     fn default() -> Self {
         let hugr = T::default();
         let parent = hugr.root();
@@ -82,7 +82,7 @@ fn issue_1496_remains() {
     assert_eq!("Noop", NoopDef.name())
 }
 
-impl<T: HugrView> Circuit<T, T::Node> {
+impl<T: HugrView> Circuit<T> {
     /// Create a new circuit from a HUGR and a node.
     ///
     /// # Errors
@@ -289,7 +289,7 @@ impl<T: HugrView> Circuit<T, T::Node> {
     }
 }
 
-impl<T: HugrView<Node = Node>> Circuit<T, Node> {
+impl<T: HugrView<Node = Node>> Circuit<T> {
     /// Ensures the circuit contains an owned HUGR.
     pub fn to_owned(&self) -> Circuit<Hugr> {
         let hugr = self.hugr.base_hugr().clone();
@@ -362,7 +362,7 @@ impl<T: HugrView<Node = Node>> Circuit<T, Node> {
     }
 }
 
-impl<T: HugrView> From<T> for Circuit<T, T::Node> {
+impl<T: HugrView> From<T> for Circuit<T> {
     fn from(hugr: T) -> Self {
         let parent = hugr.root();
         Self::new(hugr, parent)
@@ -535,7 +535,7 @@ pub enum CircuitMutError {
 /// Shift ports in range (free_port + 1 .. max_ind) by -1.
 fn shift_ports<C: HugrMut + ?Sized>(
     circ: &mut C,
-    node: Node,
+    node: C::Node,
     free_port: impl Into<Port>,
     max_ind: usize,
 ) -> Result<Port, hugr::hugr::HugrError> {

--- a/tket2/src/circuit/command.rs
+++ b/tket2/src/circuit/command.rs
@@ -22,7 +22,7 @@ pub use hugr::types::{EdgeKind, Type, TypeRow};
 pub use hugr::{CircuitUnit, Direction, Node, Port, PortIndex, Wire};
 
 /// An operation applied to specific wires.
-pub struct Command<'circ, T> {
+pub struct Command<'circ, T: HugrView> {
     /// The circuit.
     circ: &'circ Circuit<T>,
     /// The operation node.
@@ -237,7 +237,7 @@ type NodeWalker = pv::Topo<Node, HashSet<Node>>;
 // TODO: this can only be made generic over node type once `SiblingGraph` is
 // generic over node type. See https://github.com/CQCL/hugr/issues/1926
 #[derive(Clone)]
-pub struct CommandIterator<'circ, T> {
+pub struct CommandIterator<'circ, T: HugrView> {
     /// The circuit.
     circ: &'circ Circuit<T>,
     /// A view of the top-level region of the circuit.

--- a/tket2/src/circuit/units.rs
+++ b/tket2/src/circuit/units.rs
@@ -84,7 +84,7 @@ impl<N: HugrNode> Units<OutgoingPort, N, DefaultUnitLabeller> {
     /// This iterator will yield all units originating from the circuit's input
     /// node.
     #[inline]
-    pub(super) fn new_circ_input<T: HugrView<Node = N>>(circuit: &Circuit<T, N>) -> Self {
+    pub(super) fn new_circ_input<T: HugrView<Node = N>>(circuit: &Circuit<T>) -> Self {
         Self::new_outgoing(circuit, circuit.input_node(), DefaultUnitLabeller)
     }
 }
@@ -96,7 +96,7 @@ where
     /// Create a new iterator over the units originating from node.
     #[inline]
     pub(super) fn new_outgoing<T: HugrView<Node = N>>(
-        circuit: &Circuit<T, N>,
+        circuit: &Circuit<T>,
         node: N,
         unit_labeller: UL,
     ) -> Self {
@@ -111,7 +111,7 @@ where
     /// Create a new iterator over the units terminating on the node.
     #[inline]
     pub(super) fn new_incoming<T: HugrView<Node = N>>(
-        circuit: &Circuit<T, N>,
+        circuit: &Circuit<T>,
         node: N,
         unit_labeller: UL,
     ) -> Self {
@@ -127,7 +127,7 @@ where
     /// Create a new iterator over the units of a node.
     #[inline]
     fn new_with_dir<T: HugrView<Node = N>>(
-        circuit: &Circuit<T, N>,
+        circuit: &Circuit<T>,
         node: N,
         direction: Direction,
         unit_labeller: UL,
@@ -151,9 +151,9 @@ where
     // We should revisit it once this is reworked on the HUGR side.
     //
     // TODO: EdgeKind::Function is not currently supported.
-    fn init_types<T: HugrView<Node = N>>(
-        circuit: &Circuit<T, N>,
-        node: N,
+    fn init_types<T: HugrView>(
+        circuit: &Circuit<T>,
+        node: T::Node,
         direction: Direction,
     ) -> TypeRow {
         let hugr = circuit.hugr();

--- a/tket2/src/rewrite.rs
+++ b/tket2/src/rewrite.rs
@@ -37,7 +37,7 @@ impl<N: HugrNode> Subcircuit<N> {
     /// Create a new subcircuit induced from a set of nodes.
     pub fn try_from_nodes(
         nodes: impl Into<Vec<N>>,
-        circ: &Circuit<impl HugrView<Node = N>, N>,
+        circ: &Circuit<impl HugrView<Node = N>>,
     ) -> Result<Self, InvalidSubgraph<N>> {
         let subgraph = SiblingSubgraph::try_from_nodes(nodes, circ.hugr())?;
         Ok(Self { subgraph })
@@ -54,7 +54,7 @@ impl<N: HugrNode> Subcircuit<N> {
     }
 
     /// The signature of the subcircuit.
-    pub fn signature(&self, circ: &Circuit<impl HugrView<Node = N>, N>) -> Signature {
+    pub fn signature(&self, circ: &Circuit<impl HugrView<Node = N>>) -> Signature {
         self.subgraph.signature(circ.hugr())
     }
 }

--- a/tket2/src/serialize.rs
+++ b/tket2/src/serialize.rs
@@ -32,7 +32,7 @@ use crate::{Circuit, CircuitError};
 #[allow(unused)]
 const METADATA_ENTRYPOINT: &str = "TKET2.entrypoint";
 
-impl<T: HugrView> Circuit<T, T::Node> {
+impl<T: HugrView> Circuit<T> {
     /// Store the circuit as a HUGR envelope, using the given configuration.
     ///
     /// If the circuit is not a function in a module-rooted HUGR, a new module


### PR DESCRIPTION
The update to `hugr 0.15` added a `Node` associated type to `HugrView`.
Over here, that got implemented as a new type parameter in `Circuit`,
```rust
struct Circuit<T = Hugr, N = Node>
```
All `impl` blocks however restrain it to the specific hugr support,
```rust
impl<T: HugrView> Circuit<T, T::Node> { ... }
```
Given how both types are connected, we should be using `T::Node` directly since an unrelated node type is not usable here.

This PR changes the definition to
```rust
pub struct Circuit<T: HugrView = Hugr>
```

As this is a breaking change, it can wait until the next breaking release.

BREAKING CHANGE: Removed node type parameter from `Circuit`