### PR TITLE
feat(hseries)!: remove ZZMax operation from Qsystem extension

### DIFF
--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem.json
@@ -265,34 +265,6 @@
       },
       "binary": false
     },
-    "ZZMax": {
-      "extension": "tket2.qsystem",
-      "name": "ZZMax",
-      "description": "Maximally entangling ZZ gate.",
-      "signature": {
-        "params": [],
-        "body": {
-          "input": [
-            {
-              "t": "Q"
-            },
-            {
-              "t": "Q"
-            }
-          ],
-          "output": [
-            {
-              "t": "Q"
-            },
-            {
-              "t": "Q"
-            }
-          ],
-          "runtime_reqs": []
-        }
-      },
-      "binary": false
-    },
     "ZZPhase": {
       "extension": "tket2.qsystem",
       "name": "ZZPhase",

--- a/tket2-exts/src/tket2_exts/data/tket2/qsystem.json
+++ b/tket2-exts/src/tket2_exts/data/tket2/qsystem.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "name": "tket2.qsystem",
   "runtime_reqs": [
     "arithmetic.float.types",

--- a/tket2-hseries/src/extension/qsystem.rs
+++ b/tket2-hseries/src/extension/qsystem.rs
@@ -38,7 +38,7 @@ pub use lower::{check_lowered, lower_tk2_op, LowerTk2Error, LowerTket2ToQSystemP
 /// The "tket2.qsystem" extension id.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("tket2.qsystem");
 /// The "tket2.qsystem" extension version.
-pub const EXTENSION_VERSION: Version = Version::new(0, 2, 0);
+pub const EXTENSION_VERSION: Version = Version::new(0, 3, 0);
 
 lazy_static! {
     /// The "tket2.qsystem" extension.


### PR DESCRIPTION
Closes #850


BREAKING CHANGE: ZZMax removed from Qsystem extension. Use ZZPhase(pi/2).