### PR TITLE
feat(tket2-py): Expose `ConstWasmModule`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ name = "tket2-py"
 version = "0.0.0"
 dependencies = [
  "cool_asserts",
+ "delegate 0.13.3",
  "derive_more 1.0.0",
  "hugr",
  "itertools 0.14.0",
@@ -2323,6 +2324,8 @@ dependencies = [
  "strum",
  "tket-json-rs",
  "tket2",
+ "tket2-hseries",
+ "typetag",
 ]
 
 [[package]]

--- a/tket2-py/Cargo.toml
+++ b/tket2-py/Cargo.toml
@@ -23,7 +23,7 @@ tket2 = { path = "../tket2", version = "0.10.0", features = [
     "portmatching",
     "binary-eccs",
 ] }
-tket2-hseries = { path = "../tket2-hseries", version = "0.11.0" }
+tket2-hseries = { path = "../tket2-hseries" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tket-json-rs = { workspace = true, features = ["pyo3"] }

--- a/tket2-py/Cargo.toml
+++ b/tket2-py/Cargo.toml
@@ -23,6 +23,7 @@ tket2 = { path = "../tket2", version = "0.10.0", features = [
     "portmatching",
     "binary-eccs",
 ] }
+tket2-hseries = { path = "../tket2-hseries", version = "0.11.0" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tket-json-rs = { workspace = true, features = ["pyo3"] }
@@ -33,6 +34,8 @@ derive_more = { workspace = true, features = ["into", "from"] }
 itertools = { workspace = true }
 portmatching = { workspace = true }
 strum = { workspace = true }
+delegate = { workspace = true }
+typetag = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/tket2-py/src/extension.rs
+++ b/tket2-py/src/extension.rs
@@ -1,3 +1,5 @@
+//! Extra stuff needed for using the extensions
+
 use delegate::delegate;
 use hugr::extension::ExtensionSet;
 use hugr::ops::constant::CustomConst;
@@ -8,12 +10,14 @@ use tket2_hseries::extension::wasm::ConstWasmModule;
 
 use pyo3::prelude::*;
 
+/// Build the python module
 pub fn module(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
     let m = PyModule::new(py, "extension")?;
     m.add("ConstWasmModule", py.get_type::<PyConstWasmModule>())?;
     Ok(m)
 }
 
+/// A wrapper for tket2's `ConstWasmModule`
 #[pyclass]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct PyConstWasmModule {
@@ -22,6 +26,8 @@ pub struct PyConstWasmModule {
 
 #[pymethods]
 impl PyConstWasmModule {
+    /// Create a new constant WASM module which refers to a wasm file with a
+    /// given name and hash
     #[new]
     pub fn new(file_name: String, file_hash: u64) -> Self {
         PyConstWasmModule {

--- a/tket2-py/src/extension.rs
+++ b/tket2-py/src/extension.rs
@@ -23,9 +23,9 @@ pub struct PyConstWasmModule {
 #[pymethods]
 impl PyConstWasmModule {
     #[new]
-    pub fn new(name: String, hash: u64) -> Self {
+    pub fn new(file_name: String, file_hash: u64) -> Self {
         PyConstWasmModule {
-            module: ConstWasmModule { name, hash },
+            module: ConstWasmModule { name: file_name, hash: file_hash },
         }
     }
 }

--- a/tket2-py/src/extension.rs
+++ b/tket2-py/src/extension.rs
@@ -1,0 +1,43 @@
+use delegate::delegate;
+use hugr::extension::ExtensionSet;
+use hugr::ops::constant::CustomConst;
+use hugr::ops::constant::ValueName;
+use hugr::types::Type;
+use serde::{Deserialize, Serialize};
+use tket2_hseries::extension::wasm::ConstWasmModule;
+
+use pyo3::prelude::*;
+
+pub fn module(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
+    let m = PyModule::new(py, "extension")?;
+    m.add("ConstWasmModule", py.get_type::<PyConstWasmModule>())?;
+    Ok(m)
+}
+
+#[pyclass]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PyConstWasmModule {
+    module: ConstWasmModule,
+}
+
+#[pymethods]
+impl PyConstWasmModule {
+    #[new]
+    pub fn new(name: String, hash: u64) -> Self {
+        PyConstWasmModule {
+            module: ConstWasmModule { name, hash },
+        }
+    }
+}
+
+#[typetag::serde]
+impl CustomConst for PyConstWasmModule {
+    delegate! {
+        to self.module {
+            fn name(&self) -> ValueName;
+            fn equal_consts(&self, other: &dyn CustomConst) -> bool;
+            fn extension_reqs(&self) -> ExtensionSet;
+            fn get_type(&self) -> Type;
+        }
+    }
+}

--- a/tket2-py/src/extension.rs
+++ b/tket2-py/src/extension.rs
@@ -1,7 +1,6 @@
 //! Extra stuff needed for using the extensions
 
 use delegate::delegate;
-use hugr::extension::ExtensionSet;
 use hugr::ops::constant::CustomConst;
 use hugr::ops::constant::ValueName;
 use hugr::types::Type;
@@ -31,7 +30,10 @@ impl PyConstWasmModule {
     #[new]
     pub fn new(file_name: String, file_hash: u64) -> Self {
         PyConstWasmModule {
-            module: ConstWasmModule { name: file_name, hash: file_hash },
+            module: ConstWasmModule {
+                name: file_name,
+                hash: file_hash,
+            },
         }
     }
 }
@@ -42,7 +44,6 @@ impl CustomConst for PyConstWasmModule {
         to self.module {
             fn name(&self) -> ValueName;
             fn equal_consts(&self, other: &dyn CustomConst) -> bool;
-            fn extension_reqs(&self) -> ExtensionSet;
             fn get_type(&self) -> Type;
         }
     }

--- a/tket2-py/src/lib.rs
+++ b/tket2-py/src/lib.rs
@@ -1,5 +1,6 @@
 //! Python bindings for TKET2.
 pub mod circuit;
+pub mod extension;
 pub mod ops;
 pub mod optimiser;
 pub mod passes;
@@ -14,6 +15,7 @@ use pyo3::prelude::*;
 #[pymodule]
 fn _tket2(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     add_submodule(py, m, circuit::module(py)?)?;
+    add_submodule(py, m, extension::module(py)?)?;
     add_submodule(py, m, ops::module(py)?)?;
     add_submodule(py, m, optimiser::module(py)?)?;
     add_submodule(py, m, passes::module(py)?)?;

--- a/tket2-py/tket2/__init__.py
+++ b/tket2-py/tket2/__init__.py
@@ -9,9 +9,9 @@ working with quantum circuits. See also the Rust library with the same name on
 [crates.io](https://crates.io/crates/tket2).
 """
 
-from . import circuit, ops, optimiser, passes, pattern, rewrite
+from . import circuit, extension, ops, optimiser, passes, pattern, rewrite
 
-__all__ = ["circuit", "ops", "optimiser", "passes", "pattern", "rewrite"]
+__all__ = ["circuit", "extension", "ops", "optimiser", "passes", "pattern", "rewrite"]
 
 
 # This is updated by our release-please workflow, triggered by this

--- a/tket2-py/tket2/_tket2/extension.pyi
+++ b/tket2-py/tket2/_tket2/extension.pyi
@@ -1,0 +1,3 @@
+class ConstWasmModule:
+    def __init__(self, name: str, hash: int) -> None:
+        """Create a new CosntWasmModule"""

--- a/tket2-py/tket2/_tket2/extension.pyi
+++ b/tket2-py/tket2/_tket2/extension.pyi
@@ -1,3 +1,3 @@
 class ConstWasmModule:
-    def __init__(self, name: str, hash: int) -> None:
+    def __init__(self, file_name: str, file_hash: int) -> None:
         """Create a new CosntWasmModule"""

--- a/tket2-py/tket2/extension.py
+++ b/tket2-py/tket2/extension.py
@@ -1,0 +1,3 @@
+from ._tket2.extension import ConstWasmModule
+
+__all__ = ["ConstWasmModule"]

--- a/tket2-py/tket2/extension.py
+++ b/tket2-py/tket2/extension.py
@@ -1,3 +1,3 @@
-from ._tket2.extension import ConstWasmModule
+from tket2._tket2.extension import ConstWasmModule
 
 __all__ = ["ConstWasmModule"]


### PR DESCRIPTION
Expose `ConstWasmModule` in python so that WASM modules can be constructed from the python tket2 interface.

This is the canonical way to make a module argument, so I think it makes sense to expose it from the api rather than require some custom python. AFAICT hugr-py doesn't allow us to define a new `CustomConst` type, so I'm not sure a pure python approach would work.