### PR TITLE
ci: Test `tket2-py` release PRs using released `-exts` and `-eccs`

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -1,0 +1,77 @@
+name: Release checks
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch: {}
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  # Pinned version for the uv package manager
+  UV_VERSION: "0.7.5"
+  UV_FROZEN: 1
+  # The highest and lowest supported Python versions, used for testing
+  PYTHON_HIGHEST: "3.13"
+  PYTHON_LOWEST: "3.10"
+
+jobs:
+  # Check if changes were made to the relevant files.
+  # Always returns true if running on the default branch, to ensure all changes are throughly checked.
+  changes:
+    name: Check for changes
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    # These outputs are always true when running after a merge to main, or if the PR has a `run-ci-checks` label.
+    outputs:
+      rust-release: ${{ steps.source-branch.outputs.rust == 'true' }}
+      python-release: ${{ steps.source-branch.outputs.py == 'true' }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Override label
+      id: source-branch
+      run: |
+        if [ "${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please-') }}" == "true" ]; then
+          echo "This is a python release PR"
+          echo "py=true" >> $GITHUB_OUTPUT
+        elif [ "${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-plz-') }}" == "true" ]; then
+          echo "This is a rust release PR"
+          echo "rust=true" >> $GITHUB_OUTPUT
+        elif [ "${{ github.event_name != 'pull_request' }}" == "true" ]; then
+          echo "Manual trigger"
+          echo "py=true" >> $GITHUB_OUTPUT
+          echo "rust=true" >> $GITHUB_OUTPUT
+        else
+          echo "Not a release PR"
+        fi
+
+  py-release:
+    name: Check `tket2-py` release
+    needs: changes
+    if: ${{ needs.changes.outputs.python-release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - name: Install Python ${{ env.PYTHON_HIGHEST }}
+        run: uv python install ${{ env.PYTHON_HIGHEST }}
+      - name: Setup `tke2-py` with only pypi deps
+        run: |
+          uv sync --no-sources --no-install-workspace \
+            --python ${{ env.PYTHON_HIGHEST }}
+          uv pip install --no-sources --no-deps ./tket2-py
+          echo "\nDone! Installed dependencies:"
+          uv pip list
+      - name: Lint with ruff
+        run: uv run --no-sync ruff check
+      - name: Run python tests
+        run: uv run --no-sync pytest

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -46,9 +46,6 @@ jobs:
           echo "rust=true" >> $GITHUB_OUTPUT
         else
           echo "Not a release PR"
-          # TODO: Remove after testing the PR
-          echo "py=true" >> $GITHUB_OUTPUT
-          echo "rust=true" >> $GITHUB_OUTPUT
         fi
 
   py-release:

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -70,7 +70,9 @@ jobs:
         run: |
           uv sync --no-sources --no-install-workspace \
             --python ${{ env.PYTHON_HIGHEST }}
-          uv pip install --no-sources --no-deps ./tket2-py
+          uv pip install --no-sources tket2-exts
+          uv pip install --no-sources tket2-eccs
+          uv run --no-sync maturin develop
           echo "\nDone! Installed dependencies:"
           uv pip list
       - name: Lint with ruff

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -47,6 +47,9 @@ jobs:
           echo "rust=true" >> $GITHUB_OUTPUT
         else
           echo "Not a release PR"
+          # TODO: Remove after testing the PR
+          echo "py=true" >> $GITHUB_OUTPUT
+          echo "rust=true" >> $GITHUB_OUTPUT
         fi
 
   py-release:

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -11,7 +11,6 @@ env:
   RUSTC_WRAPPER: "sccache"
   # Pinned version for the uv package manager
   UV_VERSION: "0.7.5"
-  UV_FROZEN: 1
   # The highest and lowest supported Python versions, used for testing
   PYTHON_HIGHEST: "3.13"
   PYTHON_LOWEST: "3.10"


### PR DESCRIPTION
Checks that the tests run correctly against the latets published `tket2-exts` and `tket2-eccs`.

If this fails, we may need to publish a new version of those first.

Passing check: https://github.com/CQCL/tket2/actions/runs/15108368429/job/42461967318