### PR TITLE
fix(tket2-hseries): ensure deterministic lowering using maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,6 +2295,7 @@ dependencies = [
  "derive_more 1.0.0",
  "hugr",
  "hugr-cli",
+ "indexmap 2.9.0",
  "itertools 0.14.0",
  "lazy_static",
  "petgraph 0.8.1",

--- a/tket2-hseries/Cargo.toml
+++ b/tket2-hseries/Cargo.toml
@@ -39,6 +39,7 @@ derive_more = { workspace = true, features = [
 ] }
 typetag.workspace = true
 delegate.workspace = true
+indexmap.workspace = true
 
 [dev-dependencies]
 cool_asserts.workspace = true

--- a/tket2-hseries/src/extension/qsystem/barrier/barrier_ops.rs
+++ b/tket2-hseries/src/extension/qsystem/barrier/barrier_ops.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -17,6 +16,7 @@ use hugr::{
     },
     Hugr, Wire,
 };
+use indexmap::IndexMap;
 
 use crate::extension::qsystem::{barrier::qtype_analyzer::QTypeAnalyzer, QSystemOpBuilder};
 
@@ -57,7 +57,7 @@ pub struct BarrierOperationFactory {
     /// Temporary extension used for placeholder operations.
     extension: Arc<Extension>,
     /// Function definitions for each instance of the operations.
-    pub(super) funcs: HashMap<OpHashWrapper, Hugr>,
+    pub(super) funcs: IndexMap<OpHashWrapper, Hugr>,
     /// Type analyzer for determining qubit types
     type_analyzer: QTypeAnalyzer,
 }
@@ -79,7 +79,7 @@ impl BarrierOperationFactory {
     pub fn new() -> Self {
         Self {
             extension: Self::build_extension(),
-            funcs: HashMap::new(),
+            funcs: IndexMap::new(),
             type_analyzer: QTypeAnalyzer::new(),
         }
     }

--- a/tket2-hseries/src/extension/qsystem/lower.rs
+++ b/tket2-hseries/src/extension/qsystem/lower.rs
@@ -14,7 +14,8 @@ use hugr::{
     Hugr, HugrView, Node, Wire,
 };
 use lazy_static::lazy_static;
-use std::collections::hash_map::{Entry, HashMap};
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
 use tket2::{extension::rotation::RotationOpBuilder, Tk2Op};
 
 use crate::extension::qsystem::{self, QSystemOp, QSystemOpBuilder};
@@ -92,7 +93,7 @@ pub(super) fn insert_function(hugr: &mut impl HugrMut<Node = Node>, func_def: Hu
 /// # Errors
 /// Returns an error if the replacement fails.
 pub fn lower_tk2_op(hugr: &mut impl HugrMut<Node = Node>) -> Result<Vec<Node>, LowerTk2Error> {
-    let mut funcs: HashMap<Tk2Op, Node> = HashMap::new();
+    let mut funcs: BTreeMap<Tk2Op, Node> = BTreeMap::new();
     let mut lowerer = ReplaceTypes::new_empty();
     let mut barrier_funcs = BarrierInserter::new();
 


### PR DESCRIPTION
Replaces HashMap with BTreeMap and IndexMap (`OpHashWrapper` is not `Ord` so can't use `BTreeMap`) as appropriate.