### PR TITLE
feat!: Change array result ops signature to return array result

### DIFF
--- a/tket2-hseries/src/extension/result.rs
+++ b/tket2-hseries/src/extension/result.rs
@@ -161,11 +161,27 @@ impl ResultOpDef {
     }
 
     fn result_signature(&self) -> SignatureFunc {
-        PolyFuncType::new(
-            [vec![TypeParam::String], self.type_params()].concat(),
-            Signature::new(self.arg_type(), type_row![]),
+        if self.is_array_result_op() {
+            // Arrays need to be returned to preserve no-implicit copy guarantees.
+            PolyFuncType::new(
+                [vec![TypeParam::String], self.type_params()].concat(),
+                Signature::new(self.arg_type(), vec![self.arg_type()]),
+            )
+            .into()
+        } else {
+            PolyFuncType::new(
+                [vec![TypeParam::String], self.type_params()].concat(),
+                Signature::new(self.arg_type(), type_row![]),
+            )
+            .into()
+        }
+    }
+
+    fn is_array_result_op(&self) -> bool {
+        matches!(
+            self,
+            Self::ArrBool | Self::ArrF64 | Self::ArrInt | Self::ArrUInt
         )
-        .into()
     }
 }
 
@@ -390,10 +406,23 @@ impl TryFrom<&OpType> for ResultOpDef {
 pub trait ResultOpBuilder: Dataflow {
     /// Add a "tket2.result" op.
     fn add_result(&mut self, result_wire: Wire, op: ResultOp) -> Result<(), BuildError> {
+        debug_assert!(!op.result_op.is_array_result_op());
         let handle = self.add_dataflow_op(op, [result_wire])?;
 
         debug_assert_eq!(handle.outputs().len(), 0);
         Ok(())
+    }
+
+    /// Add a "tket2.result" op with array result type.
+    fn add_array_result(
+        &mut self,
+        result_wire: Wire,
+        op: ResultOp,
+    ) -> Result<[Wire; 1], BuildError> {
+        debug_assert!(op.result_op.is_array_result_op());
+        Ok(self
+            .add_dataflow_op(op.clone(), [result_wire])?
+            .outputs_arr())
     }
 }
 
@@ -402,7 +431,7 @@ impl<D: Dataflow> ResultOpBuilder for D {}
 #[cfg(test)]
 pub(crate) mod test {
     use cool_asserts::assert_matches;
-    use hugr::types::Signature;
+    use hugr::types::{NoRV, Signature, TypeBase};
     use hugr::HugrView;
     use hugr::{
         builder::{Dataflow, DataflowHugr, FunctionBuilder},
@@ -436,17 +465,15 @@ pub(crate) mod test {
             INT_TYPES[5].clone(),
             INT_TYPES[6].clone(),
         ];
-        let in_row = [
-            in_row.clone(),
-            in_row
-                .into_iter()
-                .map(|t| array_type(ARR_SIZE, t))
-                .collect(),
-        ]
-        .concat();
+        let arrs: Vec<TypeBase<NoRV>> = in_row
+            .clone()
+            .into_iter()
+            .map(|t| array_type(ARR_SIZE, t))
+            .collect();
+        let in_row = [in_row.clone(), arrs.clone()].concat();
         let hugr = {
             let mut func_builder =
-                FunctionBuilder::new("circuit", Signature::new(in_row, type_row![])).unwrap();
+                FunctionBuilder::new("circuit", Signature::new(in_row, arrs)).unwrap();
             let ops = [
                 ResultOp::new_bool("b"),
                 ResultOp::new_f64("f"),
@@ -474,13 +501,15 @@ pub(crate) mod test {
             for (w, op) in [b, f, i, u].iter().zip(ops.iter()) {
                 func_builder.add_result(*w, op.clone()).unwrap();
             }
+            let mut outputs = Vec::new();
             for (w, op) in [a_b, a_f, a_i, a_u].iter().zip(ops.iter()) {
-                func_builder
-                    .add_result(*w, op.clone().array_op(ARR_SIZE))
+                let [out_w] = func_builder
+                    .add_array_result(*w, op.clone().array_op(ARR_SIZE))
                     .unwrap();
+                outputs.push(out_w);
             }
 
-            func_builder.finish_hugr_with_outputs([]).unwrap()
+            func_builder.finish_hugr_with_outputs(outputs).unwrap()
         };
         assert_matches!(hugr.validate(), Ok(_));
     }


### PR DESCRIPTION
Needed for https://github.com/CQCL/guppylang/issues/981

BREAKING CHANGE: `ResultOpDef::ArrBool`,  `ResultOpDef::ArrInt`, `ResultOpDef::ArrUInt` and `ResultOpDef::ArrF64` signatures now return array results