### PR TITLE
feat(pytket-encoding): Bit initialization and bool operations

### DIFF
--- a/tket2/src/serialize/pytket/encoder.rs
+++ b/tket2/src/serialize/pytket/encoder.rs
@@ -10,6 +10,7 @@ use hugr::envelope::EnvelopeConfig;
 use hugr::hugr::views::SiblingSubgraph;
 use hugr::package::Package;
 use hugr_core::hugr::internal::PortgraphNodeMap;
+use tket_json_rs::clexpr::InputClRegister;
 pub use value_tracker::{
     RegisterCount, TrackedBit, TrackedParam, TrackedQubit, TrackedValue, TrackedValues,
     ValueTracker,
@@ -303,15 +304,17 @@ impl<H: HugrView> Tk1EncoderContext<H> {
     ///
     /// ## Arguments
     ///
-    /// - `node`: The HUGR node for which to emit the command. Qubits and bits are
-    ///   automatically retrieved from the node's inputs/outputs.
+    /// - `node`: The HUGR node for which to emit the command. Qubits and bits
+    ///   are automatically retrieved from the node's inputs/outputs. Input
+    ///   arguments are listed in order, followed by output-only args.
     /// - `circ`: The circuit containing the node.
     /// - `output_params`: A function that computes the output parameter
-    ///   expressions from the list of input parameters. If the number of parameters
-    ///   does not match the expected number, the encoding will fail.
-    /// - `make_operation`: A function that takes the number of qubits, bits, and
-    ///   the list of input parameter expressions and returns a pytket operation.
-    ///   See [`make_tk1_operation`] for a helper function to create it.
+    ///   expressions from the list of input parameters. If the number of
+    ///   parameters does not match the expected number, the encoding will fail.
+    /// - `make_operation`: A function that takes the number of qubits, bits,
+    ///   and the list of input parameter expressions and returns a pytket
+    ///   operation. See [`make_tk1_operation`] for a helper function to create
+    ///   it.
     pub fn emit_node_command(
         &mut self,
         node: H::Node,
@@ -808,5 +811,84 @@ pub fn make_tk1_operation(
         ]
         .concat(),
     );
+    op
+}
+
+/// Initialize a tket1 [Operation](circuit_json::Operation) that only operates
+/// on classical values.
+///
+/// This method is specific to some classical operations in
+/// [`tket_json_rs::OpType`]. For the classical _expressions_ in
+/// [`tket_json_rs::OpType::ClExpr`] / [`tket_json_rs::clexpr::op::ClOp`] use
+/// [`make_tk1_classical_expression`].
+///
+/// This can be passed to [`Tk1EncoderContext::emit_command`].
+///
+/// See [`make_tk1_operation`] for a more general case.
+///
+/// ## Arguments
+/// - `tk1_optype`: The operation type to use.
+/// - `bit_count`: The number of linear bits used by the operation.
+/// - `classical`: The parameters to the classical operation.
+pub fn make_tk1_classical_operation(
+    tk1_optype: tket_json_rs::OpType,
+    bit_count: usize,
+    classical: tket_json_rs::circuit_json::Classical,
+) -> tket_json_rs::circuit_json::Operation {
+    let args = MakeOperationArgs {
+        num_qubits: 0,
+        num_bits: bit_count,
+        params: &[],
+    };
+    let mut op = make_tk1_operation(tk1_optype, args);
+    op.classical = Some(Box::new(classical));
+    op
+}
+
+/// Initialize a tket1 [Operation](circuit_json::Operation) that represent a
+/// classical expression.
+///
+/// This method is specific to [`tket_json_rs::OpType::ClExpr`] /
+/// [`tket_json_rs::clexpr::op::ClOp`]. For other classical operations in
+/// [`tket_json_rs::OpType`] use [`make_tk1_classical_operation`].
+///
+/// Classical expressions are a bit different from other operations in pytket as
+/// they refer to their inputs and outputs by their position in the operation's
+/// bit and register list. See the arguments below for more details.
+///
+/// This can be passed to [`Tk1EncoderContext::emit_command`]. See
+/// [`make_tk1_operation`] for a more general case.
+///
+/// ## Arguments
+/// - `bit_count`: The number of bits (both inputs and outputs) referenced by
+///   the operation. The operation will refer to the bits by an index in the
+///   range `0..bit_count`.
+/// - `output_bits`: Slice of bit indices in `0..bit_count` that are the outputs
+///   of the operation.
+/// - `registers`: groups of bits that are used as registers in the operation.
+///   Each group is a slice of bit indices in `0..bit_count`, plus a register
+///   identifier. The operation may refer to these registers.
+/// - `expression`: The classical expression, expressed in term of the local
+///   bit and register indices.
+/// ```
+pub fn make_tk1_classical_expression(
+    bit_count: usize,
+    output_bits: &[u32],
+    registers: &[InputClRegister],
+    expression: tket_json_rs::clexpr::operator::ClOperator,
+) -> tket_json_rs::circuit_json::Operation {
+    let mut clexpr = tket_json_rs::clexpr::ClExpr::default();
+    clexpr.bit_posn = (0..bit_count as u32).map(|i| (i, i)).collect();
+    clexpr.reg_posn = registers.to_vec();
+    clexpr.output_posn = tket_json_rs::clexpr::ClRegisterBits(output_bits.to_vec());
+    clexpr.expr = expression;
+
+    let args = MakeOperationArgs {
+        num_qubits: 0,
+        num_bits: 0,
+        params: &[],
+    };
+    let mut op = make_tk1_operation(tket_json_rs::OpType::ClExpr, args);
+    op.classical_expr = Some(clexpr);
     op
 }

--- a/tket2/src/serialize/pytket/extension.rs
+++ b/tket2/src/serialize/pytket/extension.rs
@@ -9,19 +9,21 @@
 //! creates a configuration with the decoders for the standard library and tket2
 //! extension.
 
+mod bool;
 mod float;
 mod prelude;
 mod rotation;
 mod tk1;
 mod tk2;
 
+pub use bool::BoolEmitter;
 pub use float::FloatEmitter;
-use hugr::ops::constant::OpaqueValue;
 pub use prelude::PreludeEmitter;
 pub use rotation::RotationEmitter;
 pub use tk1::Tk1Emitter;
 pub use tk2::Tk2Emitter;
 
+pub(crate) use bool::set_bits_op;
 pub(crate) use tk1::OpaqueTk1Op;
 
 use super::encoder::{RegisterCount, TrackedValues};
@@ -29,6 +31,7 @@ use super::Tk1EncoderContext;
 use crate::serialize::pytket::Tk1ConvertError;
 use crate::Circuit;
 use hugr::extension::ExtensionId;
+use hugr::ops::constant::OpaqueValue;
 use hugr::ops::ExtensionOp;
 use hugr::types::CustomType;
 use hugr::HugrView;

--- a/tket2/src/serialize/pytket/extension/bool.rs
+++ b/tket2/src/serialize/pytket/extension/bool.rs
@@ -1,0 +1,109 @@
+//! Encoder and decoder for the tket2.bool extension
+
+use super::PytketEmitter;
+use crate::extension::bool::{BoolOp, ConstBool, BOOL_EXTENSION_ID, BOOL_TYPE_NAME};
+use crate::serialize::pytket::encoder::{
+    make_tk1_classical_expression, make_tk1_classical_operation, RegisterCount, Tk1EncoderContext,
+    TrackedValues,
+};
+use crate::serialize::pytket::Tk1ConvertError;
+use crate::Circuit;
+use hugr::extension::simple_op::MakeExtensionOp;
+use hugr::extension::ExtensionId;
+use hugr::ops::constant::OpaqueValue;
+use hugr::ops::ExtensionOp;
+use hugr::HugrView;
+use itertools::Itertools;
+use tket_json_rs::clexpr::op::ClOp;
+use tket_json_rs::clexpr::operator::{ClArgument, ClOperator, ClTerminal, ClVariable};
+
+/// Encoder for [prelude](hugr::extension::prelude) operations.
+#[derive(Debug, Clone, Default)]
+pub struct BoolEmitter;
+
+impl<H: HugrView> PytketEmitter<H> for BoolEmitter {
+    fn extensions(&self) -> Option<Vec<ExtensionId>> {
+        Some(vec![BOOL_EXTENSION_ID])
+    }
+
+    fn op_to_pytket(
+        &self,
+        node: H::Node,
+        op: &ExtensionOp,
+        circ: &Circuit<H>,
+        encoder: &mut Tk1EncoderContext<H>,
+    ) -> Result<bool, Tk1ConvertError<H::Node>> {
+        let Ok(rot_op) = BoolOp::from_extension_op(op) else {
+            return Ok(false);
+        };
+
+        let (num_inputs, num_outputs, clop) = match rot_op {
+            // Conversion ops between native bools and `tket2.bool`.
+            // Both are represented as a pytket bit, so this is a no-op.
+            BoolOp::read | BoolOp::make_opaque => {
+                encoder.emit_transparent_node(node, circ, |_| Vec::new())?;
+                return Ok(true);
+            }
+            BoolOp::eq => (2, 1, ClOp::BitEq),
+            BoolOp::not => (1, 1, ClOp::BitNot),
+            BoolOp::and => (2, 1, ClOp::BitAnd),
+            BoolOp::or => (2, 1, ClOp::BitOr),
+            BoolOp::xor => (2, 1, ClOp::BitXor),
+        };
+
+        // We assume here all operations are a single expression node, with only
+        // variable inputs. If new [`BoolOp`]s are added that do not follow
+        // this, the following code will need to be adjusted.
+        let bit_count = (num_inputs + num_outputs) as usize;
+        let output_bits = (0..num_outputs).collect_vec();
+        let mut expression = ClOperator::default();
+        expression.op = clop;
+        expression.args = (0..num_inputs)
+            .map(|i| ClArgument::Terminal(ClTerminal::Variable(ClVariable::Bit { index: i })))
+            .collect_vec();
+
+        let op = make_tk1_classical_expression(bit_count, &output_bits, &[], expression);
+        encoder.emit_node_command(node, circ, |_args| Vec::new(), move |_| op)?;
+        Ok(true)
+    }
+
+    fn type_to_pytket(
+        &self,
+        typ: &hugr::types::CustomType,
+    ) -> Result<Option<RegisterCount>, Tk1ConvertError<<H>::Node>> {
+        if typ.name() == &*BOOL_TYPE_NAME {
+            Ok(Some(RegisterCount::only_bits(1)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn const_to_pytket(
+        &self,
+        value: &OpaqueValue,
+        encoder: &mut Tk1EncoderContext<H>,
+    ) -> Result<Option<TrackedValues>, Tk1ConvertError<H::Node>> {
+        let Some(const_b) = value.value().downcast_ref::<ConstBool>() else {
+            return Ok(None);
+        };
+
+        let new_bit = encoder.values.new_bit();
+        if const_b.value() {
+            let op = set_bits_op(&[true]);
+            encoder.emit_command(op, &[], &[new_bit], None);
+        }
+
+        Ok(Some(TrackedValues::new_bits([new_bit])))
+    }
+}
+
+/// Return a pytket operation setting the values of a list of bits.
+pub(crate) fn set_bits_op(values: &[bool]) -> tket_json_rs::circuit_json::Operation {
+    make_tk1_classical_operation(
+        tket_json_rs::OpType::SetBits,
+        values.len(),
+        tket_json_rs::circuit_json::Classical::SetBits {
+            values: values.to_vec(),
+        },
+    )
+}


### PR DESCRIPTION
Adds a pytket emitter for the `tket2.bool` extension, and constant bits initialization (for both `tket2.bool` and `[]+[]` sum bools).

While encoding `tket2.bool` ops is not urgent, the main goal was to define the `make_tk1_classical_operation` and `make_tk1_classical_expression` helpers.

Unit tests are again waiting for the decoding support, so we can test the roundtrips.