### PR TITLE
ci: Fix typo in tag match expression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
             else
               BASE_SHA=$(git rev-parse origin/$TARGET_REF)
             fi
-            LAST_TAG=$(git describe --abbrev=0 --match="tket2t c-*" $BASE_SHA)
+            LAST_TAG=$(git describe --abbrev=0 --match="tket2-*" $BASE_SHA)
             echo "Latest tag on target: $LAST_TAG"
 
             python ./scripts/check_extension_versions.py $LAST_TAG


### PR DESCRIPTION
This should match tags like `tket2-v0.12.1` or `tket2-exts-v0.9.1`.
Looks like I accidentally added some extra characters.