### PR TITLE
fix: Use `TypeArg::List` instead of `TypeArg::Tuple`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.20.2"
-source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
+source = "git+https://github.com/CQCL/hugr?rev=5da112b#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.20.2"
-source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
+source = "git+https://github.com/CQCL/hugr?rev=5da112b#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "anyhow",
  "clap",
@@ -1013,7 +1013,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.20.2"
-source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
+source = "git+https://github.com/CQCL/hugr?rev=5da112b#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "base64",
  "cgmath",
@@ -1050,7 +1050,7 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.20.2"
-source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
+source = "git+https://github.com/CQCL/hugr?rev=5da112b#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "anyhow",
  "delegate 0.13.3",
@@ -1069,7 +1069,7 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.20.2"
-source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
+source = "git+https://github.com/CQCL/hugr?rev=5da112b#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1089,7 +1089,7 @@ dependencies = [
 [[package]]
 name = "hugr-passes"
 version = "0.20.2"
-source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
+source = "git+https://github.com/CQCL/hugr?rev=5da112b#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "ascent",
  "derive_more 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,8 +984,8 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.20.1"
-source = "git+https://github.com/CQCL/hugr?rev=8982997a#8982997a809be4280964e0caae4aa95e1c57e808"
+version = "0.20.2"
+source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -984,8 +995,8 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.20.1"
-source = "git+https://github.com/CQCL/hugr?rev=8982997a#8982997a809be4280964e0caae4aa95e1c57e808"
+version = "0.20.2"
+source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "anyhow",
  "clap",
@@ -1001,8 +1012,8 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.20.1"
-source = "git+https://github.com/CQCL/hugr?rev=8982997a#8982997a809be4280964e0caae4aa95e1c57e808"
+version = "0.20.2"
+source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "base64",
  "cgmath",
@@ -1021,22 +1032,25 @@ dependencies = [
  "petgraph 0.8.2",
  "portgraph 0.14.1",
  "regex",
+ "relrc",
  "semver",
  "serde",
  "serde_json",
  "serde_with",
+ "smallvec",
  "smol_str",
  "static_assertions",
  "strum",
  "thiserror 2.0.12",
+ "tracing",
  "typetag",
  "zstd",
 ]
 
 [[package]]
 name = "hugr-llvm"
-version = "0.20.1"
-source = "git+https://github.com/CQCL/hugr?rev=8982997a#8982997a809be4280964e0caae4aa95e1c57e808"
+version = "0.20.2"
+source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "anyhow",
  "delegate 0.13.3",
@@ -1054,8 +1068,8 @@ dependencies = [
 
 [[package]]
 name = "hugr-model"
-version = "0.20.1"
-source = "git+https://github.com/CQCL/hugr?rev=8982997a#8982997a809be4280964e0caae4aa95e1c57e808"
+version = "0.20.2"
+source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1074,8 +1088,8 @@ dependencies = [
 
 [[package]]
 name = "hugr-passes"
-version = "0.20.1"
-source = "git+https://github.com/CQCL/hugr?rev=8982997a#8982997a809be4280964e0caae4aa95e1c57e808"
+version = "0.20.2"
+source = "git+https://github.com/CQCL/hugr#5da112b631fc7795215441511c99b0f66bfaa840"
 dependencies = [
  "ascent",
  "derive_more 1.0.0",
@@ -1833,6 +1847,21 @@ name = "relative-path"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "relrc"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b9e2100a2ee7d9efb575064b2f9a552d7f9f60289d7b95b9c22175101c7c4a"
+dependencies = [
+ "derive-where",
+ "derive_more 0.99.20",
+ "fxhash",
+ "itertools 0.13.0",
+ "petgraph 0.6.5",
+ "serde",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "rmp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/CQCL/hugr", rev = "8982997a" }
-hugr-core = { git = "https://github.com/CQCL/hugr", rev = "8982997a" }
-hugr-passes = { git = "https://github.com/CQCL/hugr", rev = "8982997a" }
-hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "8982997a" }
+hugr = { git = "https://github.com/CQCL/hugr" }
+hugr-core = { git = "https://github.com/CQCL/hugr" }
+hugr-passes = { git = "https://github.com/CQCL/hugr" }
+hugr-cli = { git = "https://github.com/CQCL/hugr" }
 # portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 [workspace.dependencies]
 
@@ -48,9 +48,9 @@ hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "8982997a" }
 # hugr = "0.20.1"
 # hugr-core = "0.20.1"
 # hugr-cli = "0.20.1"
-hugr = { git = "https://github.com/CQCL/hugr", rev = "8982997a" }
-hugr-core = { git = "https://github.com/CQCL/hugr", rev = "8982997a" }
-hugr-cli = { git = "https://github.com/CQCL/hugr", rev = "8982997a" }
+hugr = { git = "https://github.com/CQCL/hugr" }
+hugr-core = { git = "https://github.com/CQCL/hugr" }
+hugr-cli = { git = "https://github.com/CQCL/hugr" }
 portgraph = "0.14.1"
 pyo3 = ">= 0.23.4, < 0.26"
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/CQCL/hugr" }
-hugr-core = { git = "https://github.com/CQCL/hugr" }
-hugr-passes = { git = "https://github.com/CQCL/hugr" }
-hugr-cli = { git = "https://github.com/CQCL/hugr" }
+hugr = { git = "https://github.com/CQCL/hugr", "rev" = "5da112b" }
+hugr-core = { git = "https://github.com/CQCL/hugr", "rev" = "5da112b" }
+hugr-passes = { git = "https://github.com/CQCL/hugr", "rev" = "5da112b" }
+hugr-cli = { git = "https://github.com/CQCL/hugr", "rev" = "5da112b" }
 # portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 [workspace.dependencies]
 
@@ -48,9 +48,9 @@ hugr-cli = { git = "https://github.com/CQCL/hugr" }
 # hugr = "0.20.1"
 # hugr-core = "0.20.1"
 # hugr-cli = "0.20.1"
-hugr = { git = "https://github.com/CQCL/hugr" }
-hugr-core = { git = "https://github.com/CQCL/hugr" }
-hugr-cli = { git = "https://github.com/CQCL/hugr" }
+hugr = { git = "https://github.com/CQCL/hugr", "rev" = "5da112b" }
+hugr-core = { git = "https://github.com/CQCL/hugr", "rev" = "5da112b" }
+hugr-cli = { git = "https://github.com/CQCL/hugr", "rev" = "5da112b" }
 portgraph = "0.14.1"
 pyo3 = ">= 0.23.4, < 0.26"
 itertools = "0.14.0"

--- a/tket2-hseries/src/extension/wasm.rs
+++ b/tket2-hseries/src/extension/wasm.rs
@@ -215,7 +215,7 @@ impl WasmType {
         extension_ref: &Weak<Extension>,
     ) -> CustomType {
         let row_to_arg =
-            |row: TypeRowRV| TypeArg::Tuple(row.into_owned().into_iter().map_into().collect());
+            |row: TypeRowRV| TypeArg::List(row.into_owned().into_iter().map_into().collect());
         CustomType::new(
             FUNC_TYPE_NAME.to_owned(),
             [row_to_arg(inputs.into()), row_to_arg(outputs.into())],


### PR DESCRIPTION
This replaces `TypeArg::Tuple` with `TypeArg::List` in the construction of a function type. It also changes the `Cargo.toml` to use the main branch of `hugr` so that https://github.com/CQCL/hugr/pull/2378 is integrated, fixing more test failures.

There's now one remaining test failure, related to https://github.com/CQCL/hugr/issues/2387. It's unclear to me whether that is to be fixed in `tket2` or in `hugr`.