### PR TITLE
feat!: Split the pytket extension encoder trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -67,36 +67,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -163,14 +163,14 @@ dependencies = [
  "petgraph 0.6.5",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "badger-optimiser"
@@ -214,7 +214,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -295,9 +295,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -315,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -430,14 +430,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "clio"
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compile-rewriter"
@@ -594,9 +594,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -650,7 +650,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -661,7 +661,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -697,7 +697,7 @@ checksum = "b9b6483c2bbed26f97861cf57651d4f2b731964a28cd2257f934a4b452480d21"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -718,7 +718,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -729,7 +729,7 @@ checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -762,7 +762,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -821,7 +821,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -842,12 +842,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -900,7 +900,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1012,9 +1012,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1244,7 +1244,7 @@ checksum = "f365c8de536236cfdebd0ba2130de22acefed18b1fb99c32783b3840aec5fb46"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1365,7 +1365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1405,9 +1405,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -1476,6 +1476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,15 +1506,15 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1554,7 +1560,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1637,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portgraph"
@@ -1710,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1744,11 +1750,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
- "cfg-if",
  "indoc",
  "libc",
  "memoffset",
@@ -1762,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1772,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1782,34 +1787,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pythonize"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5bcac0d0b71821f0d69e42654f1e15e5c94b85196446c4de9588951a2117e7b"
+checksum = "597907139a488b22573158793aa7539df36ae863eba300c75f3a0d65fc475e27"
 dependencies = [
  "pyo3",
  "serde",
@@ -1826,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -1877,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -1901,7 +1906,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2002,7 +2007,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.103",
+ "syn 2.0.104",
  "unicode-ident",
 ]
 
@@ -2042,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -2117,7 +2122,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2161,7 +2166,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2198,18 +2203,15 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -2255,7 +2257,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2271,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2331,7 +2333,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2342,17 +2344,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -2530,15 +2531,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
  "toml_datetime",
@@ -2570,20 +2571,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2653,7 +2654,7 @@ checksum = "35f5380909ffc31b4de4f4bdf96b877175a016aa2ca98cee39fcfd8c4d53d952"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2763,7 +2764,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -2785,7 +2786,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2842,9 +2843,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2861,7 +2862,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2872,29 +2873,29 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -2920,7 +2921,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2932,11 +2942,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2952,6 +2978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2994,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2976,10 +3014,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2994,6 +3044,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,6 +3060,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3018,6 +3080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,10 +3098,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.10"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -3058,22 +3132,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/tket2/src/serialize/pytket.rs
+++ b/tket2/src/serialize/pytket.rs
@@ -1,10 +1,11 @@
 //! Serialization and deserialization of circuits using the `pytket` JSON format.
 
+mod config;
 mod decoder;
 pub mod encoder;
 pub mod extension;
 
-pub use encoder::{default_encoder_config, Tk1EncoderConfig, Tk1EncoderContext};
+pub use encoder::Tk1EncoderContext;
 pub use extension::PytketEmitter;
 
 use hugr::core::HugrNode;
@@ -27,9 +28,9 @@ use tket_json_rs::circuit_json::SerialCircuit;
 use tket_json_rs::register::{Bit, ElementId, Qubit};
 
 use crate::circuit::Circuit;
+use crate::serialize::pytket::config::{default_encoder_config, Tk1EncoderConfig};
 
 use self::decoder::Tk1DecoderContext;
-
 pub use crate::passes::pytket::lower_to_pytket;
 
 /// Prefix used for storing metadata in the hugr nodes.
@@ -53,9 +54,9 @@ const METADATA_INPUT_PARAMETERS: &str = "TKET1.input_parameters";
 ///
 /// Implemented by [`SerialCircuit`], the JSON format used by tket1's `pytket` library.
 pub trait TKETDecode: Sized {
-    /// The error type for decoding.
+    /// Error type of decoding errors.
     type DecodeError;
-    /// The error type for decoding.
+    /// Error type of encoding errors.
     type EncodeError;
     /// Convert the serialized circuit to a circuit.
     fn decode(self) -> Result<Circuit, Self::DecodeError>;
@@ -178,12 +179,6 @@ pub fn save_tk1_json_str(circ: &Circuit) -> Result<String, Tk1ConvertError> {
 #[non_exhaustive]
 #[debug(bounds(N: HugrNode))]
 pub enum OpConvertError<N = hugr::Node> {
-    /// The serialized operation is not supported.
-    #[display("Cannot serialize tket2 operation: {op}")]
-    UnsupportedOpSerialization {
-        /// The operation.
-        op: OpType,
-    },
     /// Tried to decode a tket1 operation with not enough parameters.
     #[display(
         "Operation {} is missing encoded parameters. Expected at least {expected} but only \"{}\" were specified.",
@@ -277,8 +272,10 @@ pub enum Tk1ConvertError<N = hugr::Node> {
 
 impl<N> Tk1ConvertError<N> {
     /// Create a new error with a custom message.
-    pub fn custom(msg: impl Into<String>) -> Self {
-        Self::CustomError { msg: msg.into() }
+    pub fn custom(msg: impl ToString) -> Self {
+        Self::CustomError {
+            msg: msg.to_string(),
+        }
     }
 }
 

--- a/tket2/src/serialize/pytket/config.rs
+++ b/tket2/src/serialize/pytket/config.rs
@@ -1,0 +1,32 @@
+//! Configuration structs for pytket encoders and decoders.
+
+mod encoder_config;
+mod type_translators;
+
+pub use encoder_config::Tk1EncoderConfig;
+use type_translators::TypeTranslatorSet;
+
+use crate::serialize::pytket::extension::{
+    BoolEmitter, FloatEmitter, PreludeEmitter, RotationEmitter, Tk1Emitter, Tk2Emitter,
+};
+use hugr::HugrView;
+
+/// Default encoder configuration for [`Circuit`]s.
+///
+/// Contains emitters for std and tket2 operations.
+pub fn default_encoder_config<H: HugrView>() -> Tk1EncoderConfig<H> {
+    let mut config = Tk1EncoderConfig::new();
+    config.add_emitter(PreludeEmitter);
+    config.add_emitter(BoolEmitter);
+    config.add_emitter(FloatEmitter);
+    config.add_emitter(RotationEmitter);
+    config.add_emitter(Tk1Emitter);
+    config.add_emitter(Tk2Emitter);
+
+    config.add_type_translator(PreludeEmitter);
+    config.add_type_translator(BoolEmitter);
+    config.add_type_translator(FloatEmitter);
+    config.add_type_translator(RotationEmitter);
+
+    config
+}

--- a/tket2/src/serialize/pytket/config/encoder_config.rs
+++ b/tket2/src/serialize/pytket/config/encoder_config.rs
@@ -8,34 +8,17 @@ use std::collections::{BTreeSet, HashMap, VecDeque};
 
 use hugr::extension::{ExtensionId, ExtensionSet};
 use hugr::ops::{ExtensionOp, Value};
-use hugr::types::{SumType, Type, TypeEnum};
+use hugr::types::{SumType, Type};
 
 use crate::serialize::pytket::encoder::EncodeStatus;
-use crate::serialize::pytket::extension::{
-    set_bits_op, BoolEmitter, FloatEmitter, PreludeEmitter, RotationEmitter, Tk1Emitter, Tk2Emitter,
-};
+use crate::serialize::pytket::extension::{set_bits_op, RegisterCount, TypeTranslator};
 use crate::serialize::pytket::{PytketEmitter, Tk1ConvertError};
 use crate::Circuit;
 
-use super::value_tracker::RegisterCount;
-use super::{Tk1EncoderContext, TrackedValues};
-use hugr::extension::prelude::bool_t;
+use super::super::encoder::{Tk1EncoderContext, TrackedValues};
+use super::TypeTranslatorSet;
 use hugr::HugrView;
 use itertools::Itertools;
-
-/// Default encoder configuration for [`Circuit`]s.
-///
-/// Contains emitters for std and tket2 operations.
-pub fn default_encoder_config<H: HugrView>() -> Tk1EncoderConfig<H> {
-    let mut config = Tk1EncoderConfig::new();
-    config.add_emitter(PreludeEmitter);
-    config.add_emitter(BoolEmitter);
-    config.add_emitter(FloatEmitter);
-    config.add_emitter(RotationEmitter);
-    config.add_emitter(Tk1Emitter);
-    config.add_emitter(Tk2Emitter);
-    config
-}
 
 /// Configuration for converting [`Circuit`] into
 /// [`tket_json_rs::circuit_json::SerialCircuit`].
@@ -54,16 +37,14 @@ pub struct Tk1EncoderConfig<H: HugrView> {
     extension_emitters: HashMap<ExtensionId, Vec<usize>>,
     /// Emitters that request to be called for all operations.
     no_extension_emitters: Vec<usize>,
+    /// Set of type translators used to translate HUGR types into pytket registers.
+    type_translators: TypeTranslatorSet,
 }
 
 impl<H: HugrView> Tk1EncoderConfig<H> {
     /// Create a new [`Tk1EncoderConfig`] with no encoders.
     pub fn new() -> Self {
-        Self {
-            emitters: vec![],
-            extension_emitters: HashMap::new(),
-            no_extension_emitters: vec![],
-        }
+        Self::default()
     }
 
     /// Add an encoder to the configuration.
@@ -84,6 +65,11 @@ impl<H: HugrView> Tk1EncoderConfig<H> {
         self.emitters.push(Box::new(encoder));
     }
 
+    /// Add a type translator to the configuration.
+    pub fn add_type_translator(&mut self, translator: impl TypeTranslator + Send + Sync + 'static) {
+        self.type_translators.add_type_translator(translator);
+    }
+
     /// List the extensions supported by the encoders.
     ///
     /// Some encoders may not specify an extension, in which case they will be called
@@ -98,7 +84,7 @@ impl<H: HugrView> Tk1EncoderConfig<H> {
     ///
     /// Returns `true` if the operation was successfully converted and no further
     /// encoders should be called.
-    pub(super) fn op_to_pytket(
+    pub fn op_to_pytket(
         &self,
         node: H::Node,
         op: &ExtensionOp,
@@ -116,57 +102,12 @@ impl<H: HugrView> Tk1EncoderConfig<H> {
         Ok(result)
     }
 
-    /// Translate a HUGR type into a count of qubits, bits, and parameters,
-    /// using the registered custom encoders.
-    ///
-    /// Only tuple sums, bools, and custom types are supported.
-    /// Other types will return `None`.
-    pub fn type_to_pytket(
-        &self,
-        typ: &Type,
-    ) -> Result<Option<RegisterCount>, Tk1ConvertError<H::Node>> {
-        match typ.as_type_enum() {
-            TypeEnum::Sum(sum) => {
-                if typ == &bool_t() {
-                    return Ok(Some(RegisterCount {
-                        qubits: 0,
-                        bits: 1,
-                        params: 0,
-                    }));
-                }
-                if let Some(tuple) = sum.as_tuple() {
-                    let count: Result<Option<RegisterCount>, Tk1ConvertError<H::Node>> = tuple
-                        .iter()
-                        .map(|ty| {
-                            match ty.clone().try_into() {
-                                Ok(ty) => Ok(self.type_to_pytket(&ty)?),
-                                // Sum types with row variables (variable tuple lengths) are not supported.
-                                Err(_) => Ok(None),
-                            }
-                        })
-                        .sum();
-                    return count;
-                }
-            }
-            TypeEnum::Extension(custom) => {
-                let type_ext = custom.extension();
-                for encoder in self.emitters_for_extension(type_ext) {
-                    if let Some(count) = encoder.type_to_pytket(custom)? {
-                        return Ok(Some(count));
-                    }
-                }
-            }
-            _ => {}
-        }
-        Ok(None)
-    }
-
     /// Encode a const value into the pytket context using the registered custom
     /// encoders.
     ///
     /// Returns the values associated to the loaded constant, or `None` if the
     /// constant could not be encoded.
-    pub(super) fn const_to_pytket(
+    pub fn const_to_pytket(
         &self,
         value: &Value,
         encoder: &mut Tk1EncoderContext<H>,
@@ -216,6 +157,15 @@ impl<H: HugrView> Tk1EncoderConfig<H> {
         Ok(Some(values))
     }
 
+    /// Translate a HUGR type into a count of qubits, bits, and parameters,
+    /// using the registered custom translator.
+    ///
+    /// Only tuple sums, bools, and custom types are supported.
+    /// Other types will return `None`.
+    pub fn type_to_pytket(&self, typ: &Type) -> Option<RegisterCount> {
+        self.type_translators.type_to_pytket(typ)
+    }
+
     /// Lists the emitters that can handle a given extension.
     fn emitters_for_extension(
         &self,
@@ -250,6 +200,7 @@ impl<H: HugrView> Default for Tk1EncoderConfig<H> {
             emitters: Default::default(),
             extension_emitters: Default::default(),
             no_extension_emitters: Default::default(),
+            type_translators: TypeTranslatorSet::default(),
         }
     }
 }

--- a/tket2/src/serialize/pytket/config/type_translators.rs
+++ b/tket2/src/serialize/pytket/config/type_translators.rs
@@ -1,0 +1,122 @@
+//! Sets of extensions for translating HUGR types into pytket registers.
+//!
+//! Defines sets of [`TypeTranslator`]s used by the encoders and decoders to
+//! translate HUGR types into pytket primitives.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use hugr::extension::prelude::bool_t;
+use hugr::extension::ExtensionId;
+use hugr::types::{Type, TypeEnum};
+use itertools::Itertools;
+
+use crate::serialize::pytket::extension::{RegisterCount, TypeTranslator};
+
+/// A set of [`TypeTranslator`]s that can be used to translate HUGR types
+/// into pytket registers (qubits, bits, and parameter expressions).
+#[derive(Default, derive_more::Debug)]
+pub(super) struct TypeTranslatorSet {
+    /// Registered type translators
+    #[debug(skip)]
+    pub(super) type_translators: Vec<Box<dyn TypeTranslator + Send + Sync>>,
+    /// Pre-computed map from extension ids to corresponding type translators in
+    /// `type_translators`, identified by their index.
+    #[debug("{:?}", extension_translators.keys().collect_vec())]
+    extension_translators: HashMap<ExtensionId, Vec<usize>>,
+    /// A cache of translated types.
+    #[debug(skip)]
+    type_cache: RwLock<HashMap<Type, Option<RegisterCount>>>,
+}
+
+impl TypeTranslatorSet {
+    /// Add a translator to the set.
+    ///
+    /// This operation invalidates the type translation cache.
+    pub fn add_type_translator(&mut self, translator: impl TypeTranslator + Send + Sync + 'static) {
+        let idx = self.type_translators.len();
+
+        for ext in translator.extensions() {
+            self.extension_translators.entry(ext).or_default().push(idx);
+        }
+
+        self.type_translators.push(Box::new(translator));
+
+        // Clear the cache, or create a new one if it's poisoned.
+        let cache = self.type_cache.write();
+        if let Ok(mut cache) = cache {
+            cache.clear();
+        } else {
+            drop(cache);
+            self.type_cache = RwLock::new(HashMap::new());
+        }
+    }
+
+    /// Translate a HUGR type into a count of qubits, bits, and parameters,
+    /// using the registered custom translator.
+    ///
+    /// Only tuple sums, bools, and custom types are supported.
+    /// Other types will return `None`.
+    pub fn type_to_pytket(&self, typ: &Type) -> Option<RegisterCount> {
+        let cache = self.type_cache.read().ok();
+        if let Some(count) = cache.and_then(|c| c.get(typ).cloned()) {
+            return count;
+        }
+
+        let res = match typ.as_type_enum() {
+            TypeEnum::Sum(sum) => {
+                if typ == &bool_t() {
+                    return Some(RegisterCount {
+                        qubits: 0,
+                        bits: 1,
+                        params: 0,
+                    });
+                }
+                if let Some(tuple) = sum.as_tuple() {
+                    let count: Option<RegisterCount> = tuple
+                        .iter()
+                        .map(|ty| {
+                            match ty.clone().try_into() {
+                                Ok(ty) => self.type_to_pytket(&ty),
+                                // Sum types with row variables (variable tuple lengths) are not supported.
+                                Err(_) => None,
+                            }
+                        })
+                        .sum();
+                    count
+                } else {
+                    None
+                }
+            }
+            TypeEnum::Extension(custom) => 'outer: {
+                let type_ext = custom.extension();
+                for encoder in self.translators_for_extension(type_ext) {
+                    if let Some(count) = encoder.type_to_pytket(custom) {
+                        break 'outer Some(count);
+                    }
+                }
+                None
+            }
+            _ => None,
+        };
+
+        // Insert the result into the cache. Ignoring it if it's poisoned.
+        if let Ok(mut cache) = self.type_cache.write() {
+            cache.insert(typ.clone(), res);
+        }
+
+        res
+    }
+
+    /// Lists the translators that can handle a given extension.
+    fn translators_for_extension(
+        &self,
+        ext: &ExtensionId,
+    ) -> impl Iterator<Item = &Box<dyn TypeTranslator + Send + Sync>> {
+        self.extension_translators
+            .get(ext)
+            .into_iter()
+            .flatten()
+            .map(move |idx| &self.type_translators[*idx])
+    }
+}

--- a/tket2/src/serialize/pytket/extension.rs
+++ b/tket2/src/serialize/pytket/extension.rs
@@ -26,9 +26,8 @@ pub use tk2::Tk2Emitter;
 pub(crate) use bool::set_bits_op;
 pub(crate) use tk1::OpaqueTk1Op;
 
-use super::encoder::{RegisterCount, TrackedValues};
-use super::Tk1EncoderContext;
-use crate::serialize::pytket::encoder::EncodeStatus;
+use super::encoder::TrackedValues;
+use crate::serialize::pytket::encoder::{EncodeStatus, Tk1EncoderContext};
 use crate::serialize::pytket::Tk1ConvertError;
 use crate::Circuit;
 use hugr::extension::ExtensionId;
@@ -45,11 +44,14 @@ use hugr::HugrView;
 /// constant in the HUGR being encoded, the configuration will call each of
 /// the encoders declaring support for the specific extension sequentially until
 /// one of them indicates a successful conversion.
+//
+// Note: The HugrView type needs to be fixed at the type level rather than on
+// the method signatures to ensure the trait is dyn compatible.
 pub trait PytketEmitter<H: HugrView> {
-    /// The name of the extension this encoder/decoder is for.
+    /// The name of the extension this encoder is for.
     ///
-    /// [`PytketEmitter::op_to_pytket`] and [`PytketEmitter::type_to_pytket`] will
-    /// only be called for operations/types of these extensions.
+    /// [`PytketEmitter::op_to_pytket`] will only be called for operations/types
+    /// of these extensions.
     ///
     /// If the function returns `None`, the encoder will be called for all
     /// operations/types irrespective of their extension.
@@ -73,20 +75,6 @@ pub trait PytketEmitter<H: HugrView> {
         Ok(EncodeStatus::Unsupported)
     }
 
-    /// Given a HUGR type, return the number of qubits, bits, and parameter
-    /// expressions of its pytket counterpart.
-    ///
-    /// If the type cannot be translated into a list of the aforementioned
-    /// values, return `None`. Operations dealing with such types will be
-    /// marked as unsupported and will be serialized as opaque operations.
-    fn type_to_pytket(
-        &self,
-        typ: &CustomType,
-    ) -> Result<Option<RegisterCount>, Tk1ConvertError<H::Node>> {
-        let _ = typ;
-        Ok(None)
-    }
-
     /// Given an opaque constant value, add it to the pytket encoder and return
     /// the values to associate to the loaded constant.
     fn const_to_pytket(
@@ -96,5 +84,99 @@ pub trait PytketEmitter<H: HugrView> {
     ) -> Result<Option<TrackedValues>, Tk1ConvertError<H::Node>> {
         let _ = (value, encoder);
         Ok(None)
+    }
+}
+
+/// A translator of HUGR types that describes how to encode them as pytket
+/// registers (qubits, bits, and parameter expressions).
+///
+/// This is used both during encoding and decoding of pytket operations and
+/// types.
+pub trait TypeTranslator {
+    /// The name of the extensions this encoder is for.
+    ///
+    /// [`TypeTranslator::type_to_pytket`] will only be called for
+    /// operations/types of these extensions.
+    fn extensions(&self) -> Vec<ExtensionId>;
+
+    /// Given a HUGR opaque type, return the number of qubits, bits, and
+    /// parameter expressions of its pytket counterpart.
+    ///
+    /// If the type cannot be fully translated into a list of the aforementioned
+    /// values, return `None`. Operations dealing with such types will be marked
+    /// as unsupported and will be serialized as opaque operations.
+    fn type_to_pytket(&self, typ: &CustomType) -> Option<RegisterCount> {
+        let _ = typ;
+        None
+    }
+}
+
+/// A count of pytket qubits, bits, and sympy parameters.
+///
+/// Used as return value for [`TrackedValues::count`].
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Debug,
+    Default,
+    derive_more::Display,
+    derive_more::Add,
+    derive_more::Sub,
+    derive_more::Sum,
+)]
+#[display("{qubits} qubits, {bits} bits, {params} parameters")]
+#[non_exhaustive]
+pub struct RegisterCount {
+    /// Amount of qubits.
+    pub qubits: usize,
+    /// Amount of bits.
+    pub bits: usize,
+    /// Amount of sympy parameters.
+    pub params: usize,
+}
+
+impl RegisterCount {
+    /// Create a new [`RegisterCount`] from the number of qubits, bits, and parameters.
+    pub const fn new(qubits: usize, bits: usize, params: usize) -> Self {
+        RegisterCount {
+            qubits,
+            bits,
+            params,
+        }
+    }
+
+    /// Create a new [`RegisterCount`] containing only qubits.
+    pub const fn only_qubits(qubits: usize) -> Self {
+        RegisterCount {
+            qubits,
+            bits: 0,
+            params: 0,
+        }
+    }
+
+    /// Create a new [`RegisterCount`] containing only bits.
+    pub const fn only_bits(bits: usize) -> Self {
+        RegisterCount {
+            qubits: 0,
+            bits,
+            params: 0,
+        }
+    }
+
+    /// Create a new [`RegisterCount`] containing only parameters.
+    pub const fn only_params(params: usize) -> Self {
+        RegisterCount {
+            qubits: 0,
+            bits: 0,
+            params,
+        }
+    }
+
+    /// Returns the number of qubits, bits, and parameters associated with the wire.
+    pub const fn total(&self) -> usize {
+        self.qubits + self.bits + self.params
     }
 }

--- a/tket2/src/serialize/pytket/extension/bool.rs
+++ b/tket2/src/serialize/pytket/extension/bool.rs
@@ -3,9 +3,10 @@
 use super::PytketEmitter;
 use crate::extension::bool::{BoolOp, ConstBool, BOOL_EXTENSION_ID, BOOL_TYPE_NAME};
 use crate::serialize::pytket::encoder::{
-    make_tk1_classical_expression, make_tk1_classical_operation, EncodeStatus, RegisterCount,
-    Tk1EncoderContext, TrackedValues,
+    make_tk1_classical_expression, make_tk1_classical_operation, EncodeStatus, Tk1EncoderContext,
+    TrackedValues,
 };
+use crate::serialize::pytket::extension::{RegisterCount, TypeTranslator};
 use crate::serialize::pytket::Tk1ConvertError;
 use crate::Circuit;
 use hugr::extension::simple_op::MakeExtensionOp;
@@ -67,17 +68,6 @@ impl<H: HugrView> PytketEmitter<H> for BoolEmitter {
         Ok(EncodeStatus::Success)
     }
 
-    fn type_to_pytket(
-        &self,
-        typ: &hugr::types::CustomType,
-    ) -> Result<Option<RegisterCount>, Tk1ConvertError<<H>::Node>> {
-        if typ.name() == &*BOOL_TYPE_NAME {
-            Ok(Some(RegisterCount::only_bits(1)))
-        } else {
-            Ok(None)
-        }
-    }
-
     fn const_to_pytket(
         &self,
         value: &OpaqueValue,
@@ -94,6 +84,20 @@ impl<H: HugrView> PytketEmitter<H> for BoolEmitter {
         }
 
         Ok(Some(TrackedValues::new_bits([new_bit])))
+    }
+}
+
+impl TypeTranslator for BoolEmitter {
+    fn extensions(&self) -> Vec<ExtensionId> {
+        vec![BOOL_EXTENSION_ID]
+    }
+
+    fn type_to_pytket(&self, typ: &hugr::types::CustomType) -> Option<RegisterCount> {
+        if typ.name() == &*BOOL_TYPE_NAME {
+            Some(RegisterCount::only_bits(1))
+        } else {
+            None
+        }
     }
 }
 

--- a/tket2/src/serialize/pytket/extension/float.rs
+++ b/tket2/src/serialize/pytket/extension/float.rs
@@ -1,9 +1,8 @@
 //! Encoder and decoder for floating point operations.
 
 use super::PytketEmitter;
-use crate::serialize::pytket::encoder::{
-    EncodeStatus, RegisterCount, Tk1EncoderContext, TrackedValues,
-};
+use crate::serialize::pytket::encoder::{EncodeStatus, Tk1EncoderContext, TrackedValues};
+use crate::serialize::pytket::extension::{RegisterCount, TypeTranslator};
 use crate::serialize::pytket::Tk1ConvertError;
 use crate::Circuit;
 use hugr::extension::simple_op::MakeExtensionOp;
@@ -59,16 +58,6 @@ impl<H: HugrView> PytketEmitter<H> for FloatEmitter {
         }
     }
 
-    fn type_to_pytket(
-        &self,
-        typ: &hugr::types::CustomType,
-    ) -> Result<Option<RegisterCount>, Tk1ConvertError<<H>::Node>> {
-        match typ.name() == &float_types::FLOAT_TYPE_ID {
-            true => Ok(Some(RegisterCount::only_params(1))),
-            false => Ok(None),
-        }
-    }
-
     fn const_to_pytket(
         &self,
         value: &OpaqueValue,
@@ -101,6 +90,19 @@ impl<H: HugrView> PytketEmitter<H> for FloatEmitter {
 
         let param = encoder.values.new_param(float.to_string());
         Ok(Some(TrackedValues::new_params([param])))
+    }
+}
+
+impl TypeTranslator for FloatEmitter {
+    fn extensions(&self) -> Vec<ExtensionId> {
+        vec![float_types::EXTENSION_ID]
+    }
+
+    fn type_to_pytket(&self, typ: &hugr::types::CustomType) -> Option<RegisterCount> {
+        match typ.name() == &float_types::FLOAT_TYPE_ID {
+            true => Some(RegisterCount::only_params(1)),
+            false => None,
+        }
     }
 }
 

--- a/tket2/src/serialize/pytket/extension/prelude.rs
+++ b/tket2/src/serialize/pytket/extension/prelude.rs
@@ -1,7 +1,8 @@
 //! Encoder and decoder for tket2 operations with native pytket counterparts.
 
 use super::PytketEmitter;
-use crate::serialize::pytket::encoder::{EncodeStatus, RegisterCount, Tk1EncoderContext};
+use crate::serialize::pytket::encoder::{EncodeStatus, Tk1EncoderContext};
+use crate::serialize::pytket::extension::{RegisterCount, TypeTranslator};
 use crate::serialize::pytket::Tk1ConvertError;
 use crate::Circuit;
 use hugr::extension::prelude::{BarrierDef, TupleOpDef, PRELUDE_ID};
@@ -37,15 +38,18 @@ impl<H: HugrView> PytketEmitter<H> for PreludeEmitter {
         };
         Ok(EncodeStatus::Unsupported)
     }
+}
 
-    fn type_to_pytket(
-        &self,
-        typ: &hugr::types::CustomType,
-    ) -> Result<Option<RegisterCount>, Tk1ConvertError<<H>::Node>> {
+impl TypeTranslator for PreludeEmitter {
+    fn extensions(&self) -> Vec<ExtensionId> {
+        vec![PRELUDE_ID]
+    }
+
+    fn type_to_pytket(&self, typ: &hugr::types::CustomType) -> Option<RegisterCount> {
         match typ.name().as_str() {
-            "usize" => Ok(Some(RegisterCount::only_bits(64))),
-            "qubit" => Ok(Some(RegisterCount::only_qubits(1))),
-            _ => Ok(None),
+            "usize" => Some(RegisterCount::only_bits(64)),
+            "qubit" => Some(RegisterCount::only_qubits(1)),
+            _ => None,
         }
     }
 }
@@ -80,7 +84,7 @@ impl PreludeEmitter {
                     let TypeArg::Runtime(ty) = arg else {
                         return Ok(EncodeStatus::Unsupported);
                     };
-                    let count = encoder.config().type_to_pytket(ty)?;
+                    let count = encoder.config().type_to_pytket(ty);
                     if count.is_none() {
                         return Ok(EncodeStatus::Unsupported);
                     }

--- a/tket2/src/serialize/pytket/extension/rotation.rs
+++ b/tket2/src/serialize/pytket/extension/rotation.rs
@@ -4,9 +4,8 @@ use super::PytketEmitter;
 use crate::extension::rotation::{
     ConstRotation, RotationOp, ROTATION_EXTENSION_ID, ROTATION_TYPE_ID,
 };
-use crate::serialize::pytket::encoder::{
-    EncodeStatus, RegisterCount, Tk1EncoderContext, TrackedValues,
-};
+use crate::serialize::pytket::encoder::{EncodeStatus, Tk1EncoderContext, TrackedValues};
+use crate::serialize::pytket::extension::{RegisterCount, TypeTranslator};
 use crate::serialize::pytket::Tk1ConvertError;
 use crate::Circuit;
 use hugr::extension::simple_op::MakeExtensionOp;
@@ -56,16 +55,6 @@ impl<H: HugrView> PytketEmitter<H> for RotationEmitter {
         }
     }
 
-    fn type_to_pytket(
-        &self,
-        typ: &hugr::types::CustomType,
-    ) -> Result<Option<RegisterCount>, Tk1ConvertError<<H>::Node>> {
-        match typ.name() == &ROTATION_TYPE_ID {
-            true => Ok(Some(RegisterCount::only_params(1))),
-            false => Ok(None),
-        }
-    }
-
     fn const_to_pytket(
         &self,
         value: &OpaqueValue,
@@ -77,6 +66,19 @@ impl<H: HugrView> PytketEmitter<H> for RotationEmitter {
 
         let param = encoder.values.new_param(const_f.half_turns());
         Ok(Some(TrackedValues::new_params([param])))
+    }
+}
+
+impl TypeTranslator for RotationEmitter {
+    fn extensions(&self) -> Vec<ExtensionId> {
+        vec![ROTATION_EXTENSION_ID]
+    }
+
+    fn type_to_pytket(&self, typ: &hugr::types::CustomType) -> Option<RegisterCount> {
+        match typ.name() == &ROTATION_TYPE_ID {
+            true => Some(RegisterCount::only_params(1)),
+            false => None,
+        }
     }
 }
 


### PR DESCRIPTION
Splits the `type_to_pytket` method out of the `PytketEmitter` trait implemented by extensions, and into a new `TypeTranslator` trait as we'll use them in the decoder trait too.

Adds a `TypeTranslatorSet` used by the encoder/decoder config that caches the translation, since it gets called multiple times with the same types.