### PR TITLE
test: Add test of importing extensions in python

### DIFF
--- a/tket-exts/tests/test_validate_exts.py
+++ b/tket-exts/tests/test_validate_exts.py
@@ -33,5 +33,5 @@ exts = [
 @pytest.mark.parametrize("ext", exts)
 def test_validate_extension(ext):
     e = ext()
-    assert(len(e.types) + len(e.operations) > 0)
+    assert len(e.types) + len(e.operations) > 0
     return


### PR DESCRIPTION
Historical trivia: the WASM extension was broken when we updated hugr to 0.21, but there was no test to show it! Now there is 🙂 