### PR TITLE
ci: Setup trusted Crates.io publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -7,9 +7,18 @@ on:
       - main
 
 jobs:
-  release-plz:
-    name: Release-plz
+  release-plz-pr:
+    name: Create release-plz PR
     runs-on: ubuntu-latest
+
+    # Ensure only one release-plz tries to create a PR at a time.
+    #
+    # If two instances update the PR simultaneously, one will see an outdated git ref
+    # and end up recreating the PR unnecessarily.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-pr
+      cancel-in-progress: true
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -18,8 +27,41 @@ jobs:
           token: ${{ secrets.HUGRBOT_PAT }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Create release PR
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.HUGRBOT_PAT }}
+        with:
+          command: release-pr
+
+  # This job triggers the release to crates.io if the current crate version is higher than the
+  # ones in the registry.
+  #
+  # Release-plz will only run on commits originating from a PR whose source branch started with
+  # `release-plz-` (see `release-always=false` in the config).
+  release-plz:
+    name: Release the crates
+    runs-on: ubuntu-latest
+    environment: crate-release
+    permissions:
+      id-token: write     # Required for OIDC token exchange
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.HUGRBOT_PAT }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
-          GITHUB_TOKEN:  ${{ secrets.HUGRBOT_PAT }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HUGRBOT_PAT }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        with:
+          command: release


### PR DESCRIPTION
Includes the changes from https://github.com/CQCL/hugr/pull/2472 to avoid release-plz closing release PRs due to dataraces.