### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "tket"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "tket-qsystem"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/tket-py/Cargo.toml
+++ b/tket-py/Cargo.toml
@@ -19,7 +19,7 @@ test = false
 bench = false
 
 [dependencies]
-tket = { path = "../tket", version = "0.12.3", features = [
+tket = { path = "../tket", version = "0.13.0", features = [
     "portmatching",
     "binary-eccs",
 ] }

--- a/tket-qsystem/CHANGELOG.md
+++ b/tket-qsystem/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.17.0](https://github.com/CQCL/tket2/compare/tket2-hseries-v0.16.1...tket-qsystem-v0.17.0) - 2025-07-25
+
+### New Features
+
+- [**breaking] Rename tket2.* HUGR extensions to tket.* ([#988](https://github.com/CQCL/tket2/pull/988))
+- [**breaking] Rename tket2* libs to tket* ([#987](https://github.com/CQCL/tket2/pull/987))
+- [**breaking**] Update to `hugr 0.21` ([#965](https://github.com/CQCL/tket2/pull/965))
+- Add guppy extension with drop operation ([#962](https://github.com/CQCL/tket2/pull/962))
 
 ## [0.16.1](https://github.com/CQCL/tket2/compare/tket2-hseries-v0.16.0...tket2-hseries-v0.16.1) - 2025-07-08
 

--- a/tket-qsystem/Cargo.toml
+++ b/tket-qsystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tket-qsystem"
-version = "0.16.1"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 
@@ -24,7 +24,7 @@ required-features = ["cli"]
 
 [dependencies]
 hugr.workspace = true
-tket = { path = "../tket", version = "0.12.3" }
+tket = { path = "../tket", version = "0.13.0" }
 lazy_static.workspace = true
 serde = { workspace = true, features = ["derive"] }
 smol_str.workspace = true

--- a/tket/CHANGELOG.md
+++ b/tket/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
-All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.13.0](https://github.com/CQCL/tket2/compare/tket2-v0.12.3...tket-v0.13.0) - 2025-07-25
+
+### New Features
+
+- [**breaking] Rename tket2.* HUGR extensions to tket.* ([#988](https://github.com/CQCL/tket2/pull/988))
+- [**breaking] Rename tket2* libs to tket* ([#987](https://github.com/CQCL/tket2/pull/987))
+- [**breaking**] Update to `hugr 0.21` ([#965](https://github.com/CQCL/tket2/pull/965))
+- Add guppy extension with drop operation ([#962](https://github.com/CQCL/tket2/pull/962))
+- [**breaking**] Split the pytket extension encoder trait ([#970](https://github.com/CQCL/tket2/pull/970))
 
 ## [0.12.3](https://github.com/CQCL/tket2/compare/tket2-v0.12.2...tket2-v0.12.3) - 2025-07-08
 

--- a/tket/Cargo.toml
+++ b/tket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tket"
-version = "0.12.3"
+version = "0.13.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 


### PR DESCRIPTION

## 🧑  New release

* `tket2`: 0.12.3 -> `tket` 0.13.0 (New crate name!)
* `tket2-hseries`: 0.16.1 -> `tket-qsystem` 0.17.0 (New crate name!)

<details><summary><i><b>Changelog</b></i></summary><p>

## `tket`

<blockquote>

## [0.13.0](https://github.com/CQCL/tket2/compare/tket2-v0.12.3...tket-v0.13.0) - 2025-07-25

### New Features

- [**breaking] Rename tket2.* HUGR extensions to tket.* ([#988](https://github.com/CQCL/tket2/pull/988))
- [**breaking] Rename tket2* libs to tket* ([#987](https://github.com/CQCL/tket2/pull/987))
- [**breaking**] Update to `hugr 0.21` ([#965](https://github.com/CQCL/tket2/pull/965))
- Add guppy extension with drop operation ([#962](https://github.com/CQCL/tket2/pull/962))
- [**breaking**] Split the pytket extension encoder trait ([#970](https://github.com/CQCL/tket2/pull/970))
</blockquote>

## `tket-qsystem`

<blockquote>

## [0.17.0](https://github.com/CQCL/tket2/compare/tket2-hseries-v0.16.1...tket-qsystem-v0.17.0) - 2025-07-25

### New Features

- [**breaking] Rename tket2.* HUGR extensions to tket.* ([#988](https://github.com/CQCL/tket2/pull/988))
- [**breaking] Rename tket2* libs to tket* ([#987](https://github.com/CQCL/tket2/pull/987))
- [**breaking**] Update to `hugr 0.21` ([#965](https://github.com/CQCL/tket2/pull/965))
- Add guppy extension with drop operation ([#962](https://github.com/CQCL/tket2/pull/962))
</blockquote>


</p></details>

---
This PR was generated by a human.