### PR TITLE
docs: Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See [DEVELOPMENT.md][] for instructions on setting up the development environmen
 
 This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http://www.apache.org/licenses/LICENSE-2.0).
 
-  [build_status]: https://github.com/CQCL/tket2/workflows/Continuous%20integration/badge.svg?branch=main
-  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket?logo=codecov
+  [build_status]: https://github.com/CQCL/tket2/actions/workflows/ci.yml/badge.svg
+  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket2?logo=codecov
   [LICENSE]: https://github.com/CQCL/tket2/blob/main/LICENCE
   [DEVELOPMENT.md]: https://github.com/CQCL/tket2/blob/main/DEVELOPMENT.md

--- a/tket-eccs/README.md
+++ b/tket-eccs/README.md
@@ -4,7 +4,7 @@
 [![codecov][]](https://codecov.io/gh/CQCL/tket2)
 [![py-version][]](https://pypi.org/project/tket--eccs/)
 
-  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket?logo=codecov
+  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket2?logo=codecov
   [py-version]: https://img.shields.io/pypi/pyversions/tket-eccs
   [pypi]: https://img.shields.io/pypi/v/tket-eccs
 

--- a/tket-exts/README.md
+++ b/tket-exts/README.md
@@ -4,7 +4,7 @@
 [![codecov][]](https://codecov.io/gh/CQCL/tket2)
 [![py-version][]](https://pypi.org/project/tket-exts/)
 
-  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket?logo=codecov
+  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket2?logo=codecov
   [py-version]: https://img.shields.io/pypi/pyversions/tket-exts
   [pypi]: https://img.shields.io/pypi/v/tket-exts
 

--- a/tket-py/README.md
+++ b/tket-py/README.md
@@ -4,7 +4,7 @@
 [![codecov][]](https://codecov.io/gh/CQCL/tket2)
 [![py-version][]](https://pypi.org/project/tket/)
 
-  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket?logo=codecov
+  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket2?logo=codecov
   [py-version]: https://img.shields.io/pypi/pyversions/tket
   [pypi]: https://img.shields.io/pypi/v/tket
 

--- a/tket/README.md
+++ b/tket/README.md
@@ -67,9 +67,9 @@ See [DEVELOPMENT.md][] for instructions on setting up the development environmen
 
 This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http://www.apache.org/licenses/LICENSE-2.0).
 
-  [build_status]: https://github.com/CQCL/tket2/workflows/Continuous%20integration/badge.svg?branch=main
+  [build_status]: https://github.com/CQCL/tket2/actions/workflows/ci.yml/badge.svg
   [msrv]: https://img.shields.io/crates/msrv/tket
-  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket?logo=codecov
+  [codecov]: https://img.shields.io/codecov/c/gh/CQCL/tket2?logo=codecov
   [hugr]: https://lib.rs/crates/hugr
   [hugr Builder]: https://docs.rs/hugr/latest/hugr/builder/index.html
   [API documentation here]: https://docs.rs/tket/


### PR DESCRIPTION
Fixes some over-eager tket renaming in badge urls, and updates the workflow badges that no longer work.