### PR TITLE
rfc: tket2 rust releases with warnings/errors pointing to crate renames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "tket2"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "tket2-hseries"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/tket2-hseries/Cargo.toml
+++ b/tket2-hseries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tket2-hseries"
-version = "0.16.1"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 
@@ -24,7 +24,7 @@ required-features = ["cli"]
 
 [dependencies]
 hugr.workspace = true
-tket2 = { path = "../tket2", version = "0.12.3" }
+tket2 = { path = "../tket2", version = "0.13.0" }
 lazy_static.workspace = true
 serde = { workspace = true, features = ["derive"] }
 smol_str.workspace = true

--- a/tket2-hseries/README.md
+++ b/tket2-hseries/README.md
@@ -2,6 +2,10 @@
 
 ![msrv][]
 
+> [!WARNING]
+> This crate has been renamed to `tket-qsystem`.
+> Please update your `Cargo.toml` accordingly.
+
 A TKET2 tool for preparing and validating `Hugr`s for compilation targeting
 Quantinuum System  quantum computers.
 

--- a/tket2-hseries/src/lib.rs
+++ b/tket2-hseries/src/lib.rs
@@ -1,5 +1,11 @@
 //! Provides a preparation and validation workflow for Hugrs targeting
 //! Quantinuum H-series quantum computers.
+//!
+//! <div class="warning">This crate has been renamed to <code>tket-qsystem</code>.
+//!   Please update your <code>Cargo.toml</code> accordingly.
+//! </div>
+
+std::compile_error!("The `tket2-hseries` crate has been renamed to `tket-qsystem`. Please update your `Cargo.toml` or downgrade to a previous version of `tket2-hseries`.");
 
 use derive_more::{Display, Error, From};
 use hugr::{

--- a/tket2-py/Cargo.toml
+++ b/tket2-py/Cargo.toml
@@ -19,7 +19,7 @@ test = false
 bench = false
 
 [dependencies]
-tket2 = { path = "../tket2", version = "0.12.3", features = [
+tket2 = { path = "../tket2", version = "0.13.0", features = [
     "portmatching",
     "binary-eccs",
 ] }

--- a/tket2/Cargo.toml
+++ b/tket2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tket2"
-version = "0.12.3"
+version = "0.13.0"
 edition = { workspace = true }
 rust-version = { workspace = true }
 

--- a/tket2/README.md
+++ b/tket2/README.md
@@ -4,6 +4,11 @@
 ![msrv][]
 [![codecov][]](https://codecov.io/gh/CQCL/tket2)
 
+
+> [!WARNING]
+> This crate has been renamed to `tket`.
+> Please update your `Cargo.toml` accordingly.
+
 TKET2 is an open source quantum compiler developed by Quantinuum. Central to
 TKET2's design is its hardware agnosticism which allows researchers and quantum
 software developers to take advantage of its powerful compilation for many

--- a/tket2/src/lib.rs
+++ b/tket2/src/lib.rs
@@ -1,5 +1,9 @@
 //! TKET2: The Hardware Agnostic Quantum Compiler
 //!
+//! <div class="warning">This crate has been renamed to <code>tket</code>.
+//!   Please update your <code>Cargo.toml</code> accordingly.
+//! </div>
+//!
 //! TKET2 is an open source quantum compiler developed by Quantinuum. Central to
 //! TKET2's design is its hardware agnosticism which allows researchers and
 //! quantum software developers to take advantage of its state of the art
@@ -43,6 +47,8 @@
 //!
 //! [quantinuum-hugr]: https://lib.rs/crates/quantinuum-hugr
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+std::compile_error!("The `tket2` crate has been renamed to `tket`. Please update your `Cargo.toml` or downgrade to a previous version of `tket2`.");
 
 pub mod circuit;
 pub mod extension;


### PR DESCRIPTION
Adds warnings and errors pointing the user to the renamed `tket` and `tket-qsystem` crates.

- Added unconditional `compile_error`s to both crates. Having them as a dependency will result in a compilation error.
  <img width="740" height="149" alt="image" src="https://github.com/user-attachments/assets/06935c52-4562-4d95-a52e-09e36d501667" />

- Added a warning box to the rustdocs shown on `docs.rs`, and the README in rendered on crates.io.
<img width="711" height="196" alt="image" src="https://github.com/user-attachments/assets/b6c11ab7-11eb-49db-a337-2c54fdd3f740" />

This PR is an RFC, **not meant to be merged**. I'll `cargo release` the crates manually from this branch.