### PR TITLE
feat: Add a LoadedParam struct for the pytket decoder

### DIFF
--- a/tket/Cargo.toml
+++ b/tket/Cargo.toml
@@ -57,6 +57,7 @@ derive_more = { workspace = true, features = [
     "into",
     "sum",
     "add",
+    "add_assign",
 ] }
 hugr = { workspace = true }
 hugr-core = { workspace = true }

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -31,7 +31,7 @@ use crate::extension::rotation::{rotation_type, RotationOp};
 use crate::serialize::pytket::METADATA_INPUT_PARAMETERS;
 use crate::symbolic_constant_op;
 use op::Tk1Op;
-use param::{parse_pytket_param, PytketParam};
+use param::parser::{parse_pytket_param, PytketParam};
 
 /// The state of an in-progress [`FunctionBuilder`] being built from a [`SerialCircuit`].
 ///

--- a/tket/src/serialize/pytket/decoder/param.rs
+++ b/tket/src/serialize/pytket/decoder/param.rs
@@ -1,250 +1,117 @@
-//! Definitions for decoding parameter expressions from pytket operations.
-//!
-//! This is based on the `pest` grammar defined in `param.pest`.
+//! Definition of a loaded parameter (either floating point or a rotation type) attached to a HUGR wire.
+#![expect(
+    dead_code,
+    reason = "Temporarily unused while we refactor the pytket decoder"
+)]
 
-use derive_more::Display;
-use hugr::ops::OpType;
-use hugr::std_extensions::arithmetic::float_ops::FloatOps;
-use itertools::Itertools;
-use pest::iterators::{Pair, Pairs};
-use pest::pratt_parser::PrattParser;
-use pest::Parser;
-use pest_derive::Parser;
+pub(super) mod parser;
+use std::sync::LazyLock;
 
-/// The parsed AST for a pytket operation parameter.
+use hugr::builder::{Dataflow, FunctionBuilder};
+use hugr::std_extensions::arithmetic::float_types::float64_type;
+use hugr::types::Type;
+use hugr::{Hugr, Wire};
+
+use crate::extension::rotation::{rotation_type, RotationOp};
+
+/// The type of a loaded parameter in the Hugr.
+#[derive(Debug, derive_more::Display, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum LoadedParameterType {
+    /// A float parameter.
+    Float,
+    /// A rotation parameter.
+    Rotation,
+}
+
+/// A loaded parameter in the Hugr.
 ///
-/// The leafs of the AST are either a constant value, a variable name, or an
-/// unrecognized sympy expression.
-///
-/// Return type of [`parse_pytket_param`].
-#[derive(Debug, Display, Clone, PartialEq)]
-pub enum PytketParam<'a> {
-    /// A constant value that can be loaded directly.
-    #[display("{_0}")]
-    Constant(f64),
-    /// A variable that should be routed as an input.
-    #[display("\"{name}\"")]
-    InputVariable {
-        /// The variable name.
-        name: &'a str,
-    },
-    /// Unrecognized sympy expression.
-    /// Will be emitted as a [`SympyOp`].
-    #[display("Sympy(\"{_0}\")")]
-    Sympy(&'a str),
-    /// An operation on some nested expressions.
-    #[display("{}({})", op.to_string(), args.iter().map(|a| a.to_string()).join(", "))]
-    Operation {
-        op: OpType,
-        args: Vec<PytketParam<'a>>,
-    },
+/// Tracking the type of the wire lets us delay conversion between the types
+/// until they are actually needed.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct LoadedParameter {
+    /// The type of the parameter.
+    pub typ: LoadedParameterType,
+    /// The wire where the parameter is loaded.
+    pub wire: Wire,
 }
 
-/// Parse a TKET1 operation parameter, and return an AST representing the expression.
-#[inline]
-pub fn parse_pytket_param(param: &str) -> PytketParam<'_> {
-    let Ok(mut parsed) = ParamParser::parse(Rule::parameter, param) else {
-        // The parameter could not be parsed, so we just return it as an opaque sympy expression.
-        return PytketParam::Sympy(param);
-    };
-    let parsed = parsed
-        .next()
-        .expect("The `parameter` rule can only be matched once.");
-
-    parse_infix_ops(parsed.into_inner())
-}
-
-#[derive(Parser)]
-#[grammar = "serialize/pytket/decoder/param.pest"]
-struct ParamParser;
-
-lazy_static::lazy_static! {
-    /// Precedence parser used to define the order of infix operations.
-    ///
-    /// Based on the calculator example from `pest`.
-    /// https://pest.rs/book/examples/calculator.html
-    static ref PRATT_PARSER: PrattParser<Rule> = {
-        use pest::pratt_parser::{Assoc::*, Op};
-        use Rule::*;
-
-        // Precedence is defined lowest to highest
-        PrattParser::new()
-            // Addition and subtract have equal precedence
-            .op(Op::infix(add, Left) | Op::infix(subtract, Left))
-            .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
-            .op(Op::infix(power, Left))
-    };
-}
-
-/// Parse a match of the [`Rule::expr`] rule.
-///
-/// This takes a sequence of rule matches alternating [`Rule::term`]s and infix operations.
-fn parse_infix_ops(pairs: Pairs<'_, Rule>) -> PytketParam<'_> {
-    PRATT_PARSER
-        .map_primary(|primary| parse_term(primary))
-        .map_infix(|lhs, op, rhs| {
-            let op = match op.as_rule() {
-                Rule::add => FloatOps::fadd,
-                Rule::subtract => FloatOps::fsub,
-                Rule::multiply => FloatOps::fmul,
-                Rule::divide => FloatOps::fdiv,
-                Rule::power => FloatOps::fpow,
-                rule => unreachable!("Expr::parse expected infix operation, found {:?}", rule),
-            }
-            .into();
-            PytketParam::Operation {
-                op,
-                args: vec![lhs, rhs],
-            }
-        })
-        .parse(pairs)
-}
-
-/// Parse a match of the silent [`Rule::term`] rule.
-fn parse_term(pair: Pair<'_, Rule>) -> PytketParam<'_> {
-    match pair.as_rule() {
-        Rule::expr => parse_infix_ops(pair.into_inner()),
-        Rule::implicit_multiply => {
-            let mut pairs = pair.into_inner();
-            let lhs = parse_term(pairs.next().unwrap());
-            let rhs = parse_term(pairs.next().unwrap());
-            PytketParam::Operation {
-                op: FloatOps::fmul.into(),
-                args: vec![lhs, rhs],
-            }
+impl LoadedParameter {
+    /// Returns a `LoadedParameter` for a float param.
+    pub fn float(wire: Wire) -> LoadedParameter {
+        LoadedParameter {
+            typ: LoadedParameterType::Float,
+            wire,
         }
-        Rule::num => parse_number(pair),
-        Rule::unary_minus => PytketParam::Operation {
-            op: FloatOps::fneg.into(),
-            args: vec![parse_term(pair.into_inner().next().unwrap())],
-        },
-        Rule::function_call => parse_function_call(pair),
-        Rule::ident => PytketParam::InputVariable {
-            name: pair.as_str(),
-        },
-        rule => unreachable!("Term::parse expected a term, found {:?}", rule),
     }
-}
 
-/// Parse a match of the [`Rule::num`] rule.
-fn parse_number(pair: Pair<'_, Rule>) -> PytketParam<'_> {
-    let num = pair.as_str();
-    let half_turns = num
-        .parse::<f64>()
-        .unwrap_or_else(|_| panic!("`num` rule matched invalid number \"{num}\""));
-    PytketParam::Constant(half_turns)
-}
-
-/// Parse a match of the [`Rule::function_call`] rule.
-fn parse_function_call(pair: Pair<'_, Rule>) -> PytketParam<'_> {
-    let pair_str = pair.as_str();
-    let mut args = pair.into_inner();
-    let name = args
-        .next()
-        .expect("Function call must have a name")
-        .as_str();
-    let op = match name {
-        "max" => FloatOps::fmax.into(),
-        "min" => FloatOps::fmin.into(),
-        "abs" => FloatOps::fabs.into(),
-        "floor" => FloatOps::ffloor.into(),
-        "ceil" => FloatOps::fceil.into(),
-        "round" => FloatOps::fround.into(),
-        // Unrecognized function name.
-        // Treat it as an opaque sympy expression.
-        _ => return PytketParam::Sympy(pair_str),
-    };
-
-    let args = args.map(|arg| parse_term(arg)).collect::<Vec<_>>();
-    PytketParam::Operation { op, args }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case::int("42", PytketParam::Constant(42.0))]
-    #[case::float("42.37", PytketParam::Constant(42.37))]
-    #[case::float_pointless("37.", PytketParam::Constant(37.))]
-    #[case::exp("42e4", PytketParam::Constant(42e4))]
-    #[case::neg("-42.55", PytketParam::Constant(-42.55))]
-    #[case::parens("(42)", PytketParam::Constant(42.))]
-    #[case::var("f64", PytketParam::InputVariable{name: "f64"})]
-    #[case::add("42 + f64", PytketParam::Operation {
-        op: FloatOps::fadd.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
-    })]
-    #[case::sub("42 - 2", PytketParam::Operation {
-        op: FloatOps::fsub.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::Constant(2.)]
-    })]
-    #[case::product_implicit("42 f64", PytketParam::Operation {
-        op: FloatOps::fmul.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
-    })]
-    #[case::product_implicit2("42f64", PytketParam::Operation {
-        op: FloatOps::fmul.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
-    })]
-    #[case::product_implicit3("42 e4", PytketParam::Operation {
-        op: FloatOps::fmul.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "e4"}]
-    })]
-    #[case::max("max(42, f64)", PytketParam::Operation {
-        op: FloatOps::fmax.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
-    })]
-    #[case::minus("-f64", PytketParam::Operation {
-        op: FloatOps::fneg.into(),
-        args: vec![PytketParam::InputVariable{name: "f64"}]
-    })]
-    #[case::unknown("unknown_op(42, f64)", PytketParam::Sympy("unknown_op(42, f64)"))]
-    #[case::unknown_no_params("unknown_op()", PytketParam::Sympy("unknown_op()"))]
-    #[case::nested("max(42, unknown_op(37))", PytketParam::Operation {
-        op: FloatOps::fmax.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::Sympy("unknown_op(37)")]
-    })]
-    #[case::precedence("5-2/3x+4**6", PytketParam::Operation {
-        op: FloatOps::fadd.into(),
-        args: vec![
-            PytketParam::Operation {
-                op: FloatOps::fsub.into(),
-                args: vec![
-                    PytketParam::Constant(5.),
-                    PytketParam::Operation { op: FloatOps::fdiv.into(), args: vec![
-                        PytketParam::Constant(2.),
-                        PytketParam::Operation { op: FloatOps::fmul.into(), args: vec![
-                            PytketParam::Constant(3.),
-                            PytketParam::InputVariable{name: "x"},
-                        ]}
-                    ]}
-                ]
-            },
-            PytketParam::Operation { op: FloatOps::fpow.into(), args: vec![
-                PytketParam::Constant(4.),
-                PytketParam::Constant(6.),
-            ]}
-        ]
-    })]
-    #[case::associativity("1-2-3+4", PytketParam::Operation {
-        op: FloatOps::fadd.into(),
-        args: vec![
-            PytketParam::Operation { op: FloatOps::fsub.into(), args: vec![
-                PytketParam::Operation { op: FloatOps::fsub.into(), args: vec![
-                    PytketParam::Constant(1.),
-                    PytketParam::Constant(2.),
-                ]},
-                PytketParam::Constant(3.),
-            ]},
-            PytketParam::Constant(4.),
-        ]
-    })]
-    fn parse_param(#[case] param: &str, #[case] expected: PytketParam) {
-        let parsed = parse_pytket_param(param);
-        if parsed != expected {
-            panic!("Incorrect parameter parsing\n\texpression: \"{param}\"\n\tparsed: {parsed}\n\texpected: {expected}");
+    /// Returns a `LoadedParameter` for a rotation param.
+    pub fn rotation(wire: Wire) -> LoadedParameter {
+        LoadedParameter {
+            typ: LoadedParameterType::Rotation,
+            wire,
         }
+    }
+
+    /// Returns the hugr type for the parameter.
+    pub fn wire_type(&self) -> &Type {
+        static FLOAT_TYPE: LazyLock<Type> = LazyLock::new(float64_type);
+        static ROTATION_TYPE: LazyLock<Type> = LazyLock::new(rotation_type);
+        match self.typ {
+            LoadedParameterType::Float => &FLOAT_TYPE,
+            LoadedParameterType::Rotation => &ROTATION_TYPE,
+        }
+    }
+
+    /// Convert the parameter into a given type, if necessary.
+    ///
+    /// Adds the necessary operations to the Hugr and returns a new wire.
+    ///
+    /// See [`LoadedParameter::as_float`] and [`LoadedParameter::as_rotation`]
+    /// for more convenient methods.
+    pub fn with_type<H: AsRef<Hugr> + AsMut<Hugr>>(
+        &self,
+        typ: LoadedParameterType,
+        hugr: &mut FunctionBuilder<H>,
+    ) -> LoadedParameter {
+        match (self.typ, typ) {
+            (LoadedParameterType::Float, LoadedParameterType::Rotation) => {
+                let wire = hugr
+                    .add_dataflow_op(RotationOp::from_halfturns_unchecked, [self.wire])
+                    .unwrap()
+                    .out_wire(0);
+                LoadedParameter::rotation(wire)
+            }
+            (LoadedParameterType::Rotation, LoadedParameterType::Float) => {
+                let wire = hugr
+                    .add_dataflow_op(RotationOp::to_halfturns, [self.wire])
+                    .unwrap()
+                    .out_wire(0);
+                LoadedParameter::float(wire)
+            }
+            _ => {
+                debug_assert_eq!(self.typ, typ, "cannot convert {} to {}", self.typ, typ);
+                *self
+            }
+        }
+    }
+
+    /// Convert the parameter into a float, if necessary.
+    ///
+    /// Adds the necessary operations to the Hugr and returns a new wire.
+    pub fn as_float<H: AsRef<Hugr> + AsMut<Hugr>>(
+        &self,
+        hugr: &mut FunctionBuilder<H>,
+    ) -> LoadedParameter {
+        self.with_type(LoadedParameterType::Float, hugr)
+    }
+
+    /// Convert the parameter into a rotation, if necessary.
+    ///
+    /// Adds the necessary operations to the Hugr and returns a new wire.
+    pub fn as_rotation<H: AsRef<Hugr> + AsMut<Hugr>>(
+        &self,
+        hugr: &mut FunctionBuilder<H>,
+    ) -> LoadedParameter {
+        self.with_type(LoadedParameterType::Rotation, hugr)
     }
 }

--- a/tket/src/serialize/pytket/decoder/param/param.pest
+++ b/tket/src/serialize/pytket/decoder/param/param.pest
@@ -1,0 +1,55 @@
+//! A parser grammar for pytket operation parameters
+//!
+//! The grammar is a subset of sympy expressions,
+//! unrecognised expressions will be boxed opaquely.
+
+/// Operation and variable identifiers
+///
+/// The atomic marker `@` ensures no whitespace is present inside.
+ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_" )* }
+/// Alias for `ident`.
+variable = _{ ident }
+
+/// Explicit numeric constants.
+///
+/// The atomic marker `@` ensures no whitespace is present inside.
+num = @{
+    "-"?
+    ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*)
+    ~ ("." ~ ASCII_DIGIT*)?
+    ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
+}
+
+/// Infix operations (e.g. `2 + 2`),
+///
+/// The rust parser defines the operator precedence between these.
+infix_operator = _{ add | subtract | power | multiply | divide }
+    add       = { "+" }
+    subtract  = { "-" }
+    power     = { "**" }
+    multiply  = { "*" }
+    divide    = { "/" }
+
+/// Function calls like (`max(2,4)`)
+function_call = { ident ~ ( "()" | "(" ~ expr ~ ("," ~ expr)* ~ ","? ~ ")") }
+/// Unary negation, with a special identifier
+unary_minus = { "-" ~ term }
+
+/// Implicit multiplication lets us write expressions like `2x`.
+/// This has higher precedence that `infix_operator`s.
+///
+/// The second match is a subset of `term`, picked to avoid ambiguity.
+/// If we used `term` directly, the expression `5-2` could be interpreted as `5 * (-2)`.
+implicit_multiply = { num ~ ("(" ~ expr ~ ")" | function_call | variable) }
+
+/// Expressions are sequences of terms and infix operators
+expr = { term ~ (infix_operator ~ term)* }
+/// A standalone term, with no infix operators at the root.
+term = _{ "(" ~ expr ~ ")" | implicit_multiply | num | unary_minus | function_call | variable }
+
+/// Main entry point of the parser. Ensures we always parse the whole input.
+parameter = _{ SOI ~ expr ~ EOI }
+
+/// Allowed whitespace characters.
+/// Each `~` separator in the preceding rules can contain any number of these (including zero).
+WHITESPACE = _{ " " | "\t" }

--- a/tket/src/serialize/pytket/decoder/param/parser.rs
+++ b/tket/src/serialize/pytket/decoder/param/parser.rs
@@ -1,0 +1,250 @@
+//! Definitions for decoding parameter expressions from pytket operations.
+//!
+//! This is based on the `pest` grammar defined in `param.pest`.
+
+use derive_more::Display;
+use hugr::ops::OpType;
+use hugr::std_extensions::arithmetic::float_ops::FloatOps;
+use itertools::Itertools;
+use pest::iterators::{Pair, Pairs};
+use pest::pratt_parser::PrattParser;
+use pest::Parser;
+use pest_derive::Parser;
+
+/// The parsed AST for a pytket operation parameter.
+///
+/// The leafs of the AST are either a constant value, a variable name, or an
+/// unrecognized sympy expression.
+///
+/// Return type of [`parse_pytket_param`].
+#[derive(Debug, Display, Clone, PartialEq)]
+pub enum PytketParam<'a> {
+    /// A constant value that can be loaded directly.
+    #[display("{_0}")]
+    Constant(f64),
+    /// A variable that should be routed as an input.
+    #[display("\"{name}\"")]
+    InputVariable {
+        /// The variable name.
+        name: &'a str,
+    },
+    /// Unrecognized sympy expression.
+    /// Will be emitted as a [`SympyOp`].
+    #[display("Sympy(\"{_0}\")")]
+    Sympy(&'a str),
+    /// An operation on some nested expressions.
+    #[display("{}({})", op.to_string(), args.iter().map(|a| a.to_string()).join(", "))]
+    Operation {
+        op: OpType,
+        args: Vec<PytketParam<'a>>,
+    },
+}
+
+/// Parse a TKET1 operation parameter, and return an AST representing the expression.
+#[inline]
+pub fn parse_pytket_param(param: &str) -> PytketParam<'_> {
+    let Ok(mut parsed) = ParamParser::parse(Rule::parameter, param) else {
+        // The parameter could not be parsed, so we just return it as an opaque sympy expression.
+        return PytketParam::Sympy(param);
+    };
+    let parsed = parsed
+        .next()
+        .expect("The `parameter` rule can only be matched once.");
+
+    parse_infix_ops(parsed.into_inner())
+}
+
+#[derive(Parser)]
+#[grammar = "serialize/pytket/decoder/param/param.pest"]
+struct ParamParser;
+
+lazy_static::lazy_static! {
+    /// Precedence parser used to define the order of infix operations.
+    ///
+    /// Based on the calculator example from `pest`.
+    /// https://pest.rs/book/examples/calculator.html
+    static ref PRATT_PARSER: PrattParser<Rule> = {
+        use pest::pratt_parser::{Assoc::*, Op};
+        use Rule::*;
+
+        // Precedence is defined lowest to highest
+        PrattParser::new()
+            // Addition and subtract have equal precedence
+            .op(Op::infix(add, Left) | Op::infix(subtract, Left))
+            .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
+            .op(Op::infix(power, Left))
+    };
+}
+
+/// Parse a match of the [`Rule::expr`] rule.
+///
+/// This takes a sequence of rule matches alternating [`Rule::term`]s and infix operations.
+fn parse_infix_ops(pairs: Pairs<'_, Rule>) -> PytketParam<'_> {
+    PRATT_PARSER
+        .map_primary(|primary| parse_term(primary))
+        .map_infix(|lhs, op, rhs| {
+            let op = match op.as_rule() {
+                Rule::add => FloatOps::fadd,
+                Rule::subtract => FloatOps::fsub,
+                Rule::multiply => FloatOps::fmul,
+                Rule::divide => FloatOps::fdiv,
+                Rule::power => FloatOps::fpow,
+                rule => unreachable!("Expr::parse expected infix operation, found {:?}", rule),
+            }
+            .into();
+            PytketParam::Operation {
+                op,
+                args: vec![lhs, rhs],
+            }
+        })
+        .parse(pairs)
+}
+
+/// Parse a match of the silent [`Rule::term`] rule.
+fn parse_term(pair: Pair<'_, Rule>) -> PytketParam<'_> {
+    match pair.as_rule() {
+        Rule::expr => parse_infix_ops(pair.into_inner()),
+        Rule::implicit_multiply => {
+            let mut pairs = pair.into_inner();
+            let lhs = parse_term(pairs.next().unwrap());
+            let rhs = parse_term(pairs.next().unwrap());
+            PytketParam::Operation {
+                op: FloatOps::fmul.into(),
+                args: vec![lhs, rhs],
+            }
+        }
+        Rule::num => parse_number(pair),
+        Rule::unary_minus => PytketParam::Operation {
+            op: FloatOps::fneg.into(),
+            args: vec![parse_term(pair.into_inner().next().unwrap())],
+        },
+        Rule::function_call => parse_function_call(pair),
+        Rule::ident => PytketParam::InputVariable {
+            name: pair.as_str(),
+        },
+        rule => unreachable!("Term::parse expected a term, found {:?}", rule),
+    }
+}
+
+/// Parse a match of the [`Rule::num`] rule.
+fn parse_number(pair: Pair<'_, Rule>) -> PytketParam<'_> {
+    let num = pair.as_str();
+    let half_turns = num
+        .parse::<f64>()
+        .unwrap_or_else(|_| panic!("`num` rule matched invalid number \"{num}\""));
+    PytketParam::Constant(half_turns)
+}
+
+/// Parse a match of the [`Rule::function_call`] rule.
+fn parse_function_call(pair: Pair<'_, Rule>) -> PytketParam<'_> {
+    let pair_str = pair.as_str();
+    let mut args = pair.into_inner();
+    let name = args
+        .next()
+        .expect("Function call must have a name")
+        .as_str();
+    let op = match name {
+        "max" => FloatOps::fmax.into(),
+        "min" => FloatOps::fmin.into(),
+        "abs" => FloatOps::fabs.into(),
+        "floor" => FloatOps::ffloor.into(),
+        "ceil" => FloatOps::fceil.into(),
+        "round" => FloatOps::fround.into(),
+        // Unrecognized function name.
+        // Treat it as an opaque sympy expression.
+        _ => return PytketParam::Sympy(pair_str),
+    };
+
+    let args = args.map(|arg| parse_term(arg)).collect::<Vec<_>>();
+    PytketParam::Operation { op, args }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::int("42", PytketParam::Constant(42.0))]
+    #[case::float("42.37", PytketParam::Constant(42.37))]
+    #[case::float_pointless("37.", PytketParam::Constant(37.))]
+    #[case::exp("42e4", PytketParam::Constant(42e4))]
+    #[case::neg("-42.55", PytketParam::Constant(-42.55))]
+    #[case::parens("(42)", PytketParam::Constant(42.))]
+    #[case::var("f64", PytketParam::InputVariable{name: "f64"})]
+    #[case::add("42 + f64", PytketParam::Operation {
+        op: FloatOps::fadd.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+    })]
+    #[case::sub("42 - 2", PytketParam::Operation {
+        op: FloatOps::fsub.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::Constant(2.)]
+    })]
+    #[case::product_implicit("42 f64", PytketParam::Operation {
+        op: FloatOps::fmul.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+    })]
+    #[case::product_implicit2("42f64", PytketParam::Operation {
+        op: FloatOps::fmul.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+    })]
+    #[case::product_implicit3("42 e4", PytketParam::Operation {
+        op: FloatOps::fmul.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "e4"}]
+    })]
+    #[case::max("max(42, f64)", PytketParam::Operation {
+        op: FloatOps::fmax.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+    })]
+    #[case::minus("-f64", PytketParam::Operation {
+        op: FloatOps::fneg.into(),
+        args: vec![PytketParam::InputVariable{name: "f64"}]
+    })]
+    #[case::unknown("unknown_op(42, f64)", PytketParam::Sympy("unknown_op(42, f64)"))]
+    #[case::unknown_no_params("unknown_op()", PytketParam::Sympy("unknown_op()"))]
+    #[case::nested("max(42, unknown_op(37))", PytketParam::Operation {
+        op: FloatOps::fmax.into(),
+        args: vec![PytketParam::Constant(42.), PytketParam::Sympy("unknown_op(37)")]
+    })]
+    #[case::precedence("5-2/3x+4**6", PytketParam::Operation {
+        op: FloatOps::fadd.into(),
+        args: vec![
+            PytketParam::Operation {
+                op: FloatOps::fsub.into(),
+                args: vec![
+                    PytketParam::Constant(5.),
+                    PytketParam::Operation { op: FloatOps::fdiv.into(), args: vec![
+                        PytketParam::Constant(2.),
+                        PytketParam::Operation { op: FloatOps::fmul.into(), args: vec![
+                            PytketParam::Constant(3.),
+                            PytketParam::InputVariable{name: "x"},
+                        ]}
+                    ]}
+                ]
+            },
+            PytketParam::Operation { op: FloatOps::fpow.into(), args: vec![
+                PytketParam::Constant(4.),
+                PytketParam::Constant(6.),
+            ]}
+        ]
+    })]
+    #[case::associativity("1-2-3+4", PytketParam::Operation {
+        op: FloatOps::fadd.into(),
+        args: vec![
+            PytketParam::Operation { op: FloatOps::fsub.into(), args: vec![
+                PytketParam::Operation { op: FloatOps::fsub.into(), args: vec![
+                    PytketParam::Constant(1.),
+                    PytketParam::Constant(2.),
+                ]},
+                PytketParam::Constant(3.),
+            ]},
+            PytketParam::Constant(4.),
+        ]
+    })]
+    fn parse_param(#[case] param: &str, #[case] expected: PytketParam) {
+        let parsed = parse_pytket_param(param);
+        if parsed != expected {
+            panic!("Incorrect parameter parsing\n\texpression: \"{param}\"\n\tparsed: {parsed}\n\texpected: {expected}");
+        }
+    }
+}


### PR DESCRIPTION
- Moves the pytket parameter parser logic into a `param` submodule
- Adds a yet-unused `LoadedParam` definition that keep track of parameter loaded by the decoder that and their types (extracted from #1030)