### PR TITLE
feat!: Allow PytketTypeTranslators to translate nested types

### DIFF
--- a/tket/src/serialize/pytket/config.rs
+++ b/tket/src/serialize/pytket/config.rs
@@ -4,7 +4,7 @@ mod encoder_config;
 mod type_translators;
 
 pub use encoder_config::Tk1EncoderConfig;
-use type_translators::TypeTranslatorSet;
+pub use type_translators::TypeTranslatorSet;
 
 use crate::serialize::pytket::extension::{
     BoolEmitter, FloatEmitter, PreludeEmitter, RotationEmitter, Tk1Emitter, Tk2Emitter,

--- a/tket/src/serialize/pytket/extension.rs
+++ b/tket/src/serialize/pytket/extension.rs
@@ -27,6 +27,7 @@ pub(crate) use bool::set_bits_op;
 pub(crate) use tk1::OpaqueTk1Op;
 
 use super::encoder::TrackedValues;
+use crate::serialize::pytket::config::TypeTranslatorSet;
 use crate::serialize::pytket::encoder::{EncodeStatus, Tk1EncoderContext};
 use crate::serialize::pytket::Tk1ConvertError;
 use crate::Circuit;
@@ -105,8 +106,11 @@ pub trait PytketTypeTranslator {
     /// If the type cannot be fully translated into a list of the aforementioned
     /// values, return `None`. Operations dealing with such types will be marked
     /// as unsupported and will be serialized as opaque operations.
-    fn type_to_pytket(&self, typ: &CustomType) -> Option<RegisterCount> {
-        let _ = typ;
+    ///
+    /// The `set` argument is a set of known type translators. This can be used
+    /// when translating types that wrap over other types.
+    fn type_to_pytket(&self, typ: &CustomType, set: &TypeTranslatorSet) -> Option<RegisterCount> {
+        let _ = (typ, set);
         None
     }
 }

--- a/tket/src/serialize/pytket/extension/bool.rs
+++ b/tket/src/serialize/pytket/extension/bool.rs
@@ -2,6 +2,7 @@
 
 use super::PytketEmitter;
 use crate::extension::bool::{BoolOp, ConstBool, BOOL_EXTENSION_ID, BOOL_TYPE_NAME};
+use crate::serialize::pytket::config::TypeTranslatorSet;
 use crate::serialize::pytket::encoder::{
     make_tk1_classical_expression, make_tk1_classical_operation, EncodeStatus, Tk1EncoderContext,
     TrackedValues,
@@ -92,7 +93,11 @@ impl PytketTypeTranslator for BoolEmitter {
         vec![BOOL_EXTENSION_ID]
     }
 
-    fn type_to_pytket(&self, typ: &hugr::types::CustomType) -> Option<RegisterCount> {
+    fn type_to_pytket(
+        &self,
+        typ: &hugr::types::CustomType,
+        _set: &TypeTranslatorSet,
+    ) -> Option<RegisterCount> {
         if typ.name() == &*BOOL_TYPE_NAME {
             Some(RegisterCount::only_bits(1))
         } else {

--- a/tket/src/serialize/pytket/extension/float.rs
+++ b/tket/src/serialize/pytket/extension/float.rs
@@ -1,6 +1,7 @@
 //! Encoder and decoder for floating point operations.
 
 use super::PytketEmitter;
+use crate::serialize::pytket::config::TypeTranslatorSet;
 use crate::serialize::pytket::encoder::{EncodeStatus, Tk1EncoderContext, TrackedValues};
 use crate::serialize::pytket::extension::{PytketTypeTranslator, RegisterCount};
 use crate::serialize::pytket::Tk1ConvertError;
@@ -98,7 +99,11 @@ impl PytketTypeTranslator for FloatEmitter {
         vec![float_types::EXTENSION_ID]
     }
 
-    fn type_to_pytket(&self, typ: &hugr::types::CustomType) -> Option<RegisterCount> {
+    fn type_to_pytket(
+        &self,
+        typ: &hugr::types::CustomType,
+        _set: &TypeTranslatorSet,
+    ) -> Option<RegisterCount> {
         match typ.name() == &float_types::FLOAT_TYPE_ID {
             true => Some(RegisterCount::only_params(1)),
             false => None,

--- a/tket/src/serialize/pytket/extension/prelude.rs
+++ b/tket/src/serialize/pytket/extension/prelude.rs
@@ -1,6 +1,7 @@
 //! Encoder and decoder for tket operations with native pytket counterparts.
 
 use super::PytketEmitter;
+use crate::serialize::pytket::config::TypeTranslatorSet;
 use crate::serialize::pytket::encoder::{EncodeStatus, Tk1EncoderContext};
 use crate::serialize::pytket::extension::{PytketTypeTranslator, RegisterCount};
 use crate::serialize::pytket::Tk1ConvertError;
@@ -45,7 +46,11 @@ impl PytketTypeTranslator for PreludeEmitter {
         vec![PRELUDE_ID]
     }
 
-    fn type_to_pytket(&self, typ: &hugr::types::CustomType) -> Option<RegisterCount> {
+    fn type_to_pytket(
+        &self,
+        typ: &hugr::types::CustomType,
+        _set: &TypeTranslatorSet,
+    ) -> Option<RegisterCount> {
         match typ.name().as_str() {
             "usize" => Some(RegisterCount::only_bits(64)),
             "qubit" => Some(RegisterCount::only_qubits(1)),

--- a/tket/src/serialize/pytket/extension/rotation.rs
+++ b/tket/src/serialize/pytket/extension/rotation.rs
@@ -4,6 +4,7 @@ use super::PytketEmitter;
 use crate::extension::rotation::{
     ConstRotation, RotationOp, ROTATION_EXTENSION_ID, ROTATION_TYPE_ID,
 };
+use crate::serialize::pytket::config::TypeTranslatorSet;
 use crate::serialize::pytket::encoder::{EncodeStatus, Tk1EncoderContext, TrackedValues};
 use crate::serialize::pytket::extension::{PytketTypeTranslator, RegisterCount};
 use crate::serialize::pytket::Tk1ConvertError;
@@ -74,7 +75,11 @@ impl PytketTypeTranslator for RotationEmitter {
         vec![ROTATION_EXTENSION_ID]
     }
 
-    fn type_to_pytket(&self, typ: &hugr::types::CustomType) -> Option<RegisterCount> {
+    fn type_to_pytket(
+        &self,
+        typ: &hugr::types::CustomType,
+        _set: &TypeTranslatorSet,
+    ) -> Option<RegisterCount> {
         match typ.name() == &ROTATION_TYPE_ID {
             true => Some(RegisterCount::only_params(1)),
             false => None,


### PR DESCRIPTION
Passes the set of type translators when translating a type, so e.g. `Future<T>` can translate `T` recursively.

BREAKING CHANGE: Added a `TypeTranslatorSet` to the `PytketTypeTranslator::type_to_pytket` trait method.