### PR TITLE
feat!: Update WASM extension

### DIFF
--- a/tket-exts/src/tket_exts/data/tket/wasm.json
+++ b/tket-exts/src/tket_exts/data/tket/wasm.json
@@ -46,6 +46,24 @@
         "b": "Explicit",
         "bound": "C"
       }
+    },
+    "result": {
+      "extension": "tket.wasm",
+      "name": "result",
+      "params": [
+        {
+          "tp": "List",
+          "param": {
+            "tp": "Type",
+            "b": "A"
+          }
+        }
+      ],
+      "description": "wasm result",
+      "bound": {
+        "b": "Explicit",
+        "bound": "A"
+      }
     }
   },
   "operations": {
@@ -129,30 +147,23 @@
             {
               "t": "Opaque",
               "extension": "tket.wasm",
-              "id": "context",
-              "args": [],
-              "bound": "A"
-            },
-            {
-              "t": "Opaque",
-              "extension": "tket.futures",
-              "id": "Future",
+              "id": "result",
               "args": [
                 {
-                  "tya": "Type",
-                  "ty": {
-                    "t": "Sum",
-                    "s": "General",
-                    "rows": [
-                      [
-                        {
-                          "t": "R",
-                          "i": 1,
+                  "tya": "List",
+                  "elems": [
+                    {
+                      "tya": "Variable",
+                      "idx": 1,
+                      "cached_decl": {
+                        "tp": "List",
+                        "param": {
+                          "tp": "Type",
                           "b": "C"
                         }
-                      ]
-                    ]
-                  }
+                      }
+                    }
+                  ]
                 }
               ],
               "bound": "A"
@@ -217,10 +228,91 @@
       },
       "binary": false
     },
-    "lookup": {
+    "lookup_by_id": {
       "extension": "tket.wasm",
-      "name": "lookup",
-      "description": "lookup",
+      "name": "lookup_by_id",
+      "description": "lookup_by_id",
+      "signature": {
+        "params": [
+          {
+            "tp": "BoundedNat",
+            "bound": null
+          },
+          {
+            "tp": "List",
+            "param": {
+              "tp": "Type",
+              "b": "A"
+            }
+          },
+          {
+            "tp": "List",
+            "param": {
+              "tp": "Type",
+              "b": "A"
+            }
+          }
+        ],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "tket.wasm",
+              "id": "module",
+              "args": [],
+              "bound": "C"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "tket.wasm",
+              "id": "func",
+              "args": [
+                {
+                  "tya": "List",
+                  "elems": [
+                    {
+                      "tya": "Variable",
+                      "idx": 1,
+                      "cached_decl": {
+                        "tp": "List",
+                        "param": {
+                          "tp": "Type",
+                          "b": "C"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "tya": "List",
+                  "elems": [
+                    {
+                      "tya": "Variable",
+                      "idx": 2,
+                      "cached_decl": {
+                        "tp": "List",
+                        "param": {
+                          "tp": "Type",
+                          "b": "C"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "bound": "C"
+            }
+          ]
+        }
+      },
+      "binary": false
+    },
+    "lookup_by_name": {
+      "extension": "tket.wasm",
+      "name": "lookup_by_name",
+      "description": "lookup_by_name",
       "signature": {
         "params": [
           {
@@ -291,6 +383,65 @@
                 }
               ],
               "bound": "C"
+            }
+          ]
+        }
+      },
+      "binary": false
+    },
+    "read_result": {
+      "extension": "tket.wasm",
+      "name": "read_result",
+      "description": "read_result",
+      "signature": {
+        "params": [
+          {
+            "tp": "List",
+            "param": {
+              "tp": "Type",
+              "b": "A"
+            }
+          }
+        ],
+        "body": {
+          "input": [
+            {
+              "t": "Opaque",
+              "extension": "tket.wasm",
+              "id": "result",
+              "args": [
+                {
+                  "tya": "List",
+                  "elems": [
+                    {
+                      "tya": "Variable",
+                      "idx": 0,
+                      "cached_decl": {
+                        "tp": "List",
+                        "param": {
+                          "tp": "Type",
+                          "b": "C"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ],
+              "bound": "A"
+            }
+          ],
+          "output": [
+            {
+              "t": "Opaque",
+              "extension": "tket.wasm",
+              "id": "context",
+              "args": [],
+              "bound": "A"
+            },
+            {
+              "t": "R",
+              "i": 0,
+              "b": "C"
             }
           ]
         }

--- a/tket-exts/src/tket_exts/data/tket/wasm.json
+++ b/tket-exts/src/tket_exts/data/tket/wasm.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.4.0",
   "name": "tket.wasm",
   "types": {
     "context": {

--- a/tket-qsystem/src/extension/wasm.rs
+++ b/tket-qsystem/src/extension/wasm.rs
@@ -27,9 +27,10 @@
 //!  `tket.wasm.module`. It carries type args defining its signature, but not
 //!  its name.
 //!
-//!  A `tket.wasm.func` is obtained from a `tket.wasm.lookup` op, which takes
-//!  a compile-time name and signature, and a runtime module. TODO Likely the
-//!  module should be compile time here, but I think we need
+//!  A `tket.wasm.func` is obtained from either a `tket.wasm.lookup_by_id` or
+//!  `tket.wasm.lookup_by_name`op, which takes a compile-time identifier (name or id)
+//!  and signature, and a runtime module.
+//!  TODO Likely the module should be compile time here, but I think we need
 //!  extension-op-static-edges to do this properly.
 //!
 //!  `tket.wasm.func`s are called via the `tket.wasm.call` op. This op takes:
@@ -78,10 +79,6 @@ use serde::{Deserialize, Serialize};
 use smol_str::{format_smolstr, SmolStr};
 use strum::{EnumIter, EnumString, IntoStaticStr};
 
-use crate::extension::futures;
-
-use super::futures::future_type;
-
 /// The "tket.wasm" extension id.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("tket.wasm");
 /// The "tket.wasm" extension version.
@@ -102,7 +99,6 @@ lazy_static! {
     /// dependencies.
     pub static ref REGISTRY: ExtensionRegistry = ExtensionRegistry::new([
         EXTENSION.to_owned(),
-        futures::EXTENSION.to_owned(),
         PRELUDE.to_owned()
     ]);
 
@@ -113,7 +109,12 @@ lazy_static! {
     /// The name of the `tket.wasm.func` type.
     pub static ref FUNC_TYPE_NAME: SmolStr = SmolStr::new_inline("func");
 
-    /// The [TypeParam] of `tket.wasm.lookup` specifying the name of the function.
+    /// The name of the `tket.wasm.result` type.
+    pub static ref RESULT_TYPE_NAME: SmolStr = SmolStr::new_inline("result");
+
+    /// The [TypeParam] of `tket.wasm.lookup_by_id` specifying the id of the function.
+    pub static ref ID_PARAM: TypeParam = TypeParam::max_nat_type();
+    /// The [TypeParam] of `tket.wasm.lookup_by_name` specifying the name of the function.
     pub static ref NAME_PARAM: TypeParam = TypeParam::StringType;
     /// The [TypeParam] of various types and ops specifying the input signature of a function.
     pub static ref INPUTS_PARAM: TypeParam =
@@ -147,6 +148,13 @@ fn add_wasm_type_defs(
         TypeDefBound::copyable(),
         extension_ref,
     )?;
+    extension.add_type(
+        RESULT_TYPE_NAME.to_owned(),
+        vec![OUTPUTS_PARAM.to_owned()],
+        "wasm result".into(),
+        TypeDefBound::any(),
+        extension_ref,
+    )?;
     Ok(())
 }
 
@@ -171,8 +179,10 @@ fn add_wasm_type_defs(
 pub enum WasmOpDef {
     get_context,
     dispose_context,
-    lookup,
+    lookup_by_id,
+    lookup_by_name,
     call,
+    read_result,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -190,6 +200,12 @@ pub enum WasmType {
         /// The input signature of the function. Note that row variables are
         /// allowed.
         inputs: TypeRowRV,
+        /// The output signature of the function. Note that row variables are
+        /// allowed.
+        outputs: TypeRowRV,
+    },
+    /// `tket.wasm.result`
+    Result {
         /// The output signature of the function. Note that row variables are
         /// allowed.
         outputs: TypeRowRV,
@@ -225,6 +241,21 @@ impl WasmType {
         )
     }
 
+    fn result_custom_type(
+        outputs: impl Into<TypeRowRV>,
+        extension_ref: &Weak<Extension>,
+    ) -> CustomType {
+        let row_to_arg =
+            |row: TypeRowRV| TypeArg::List(row.into_owned().into_iter().map_into().collect());
+        CustomType::new(
+            RESULT_TYPE_NAME.to_owned(),
+            [row_to_arg(outputs.into())],
+            EXTENSION_ID,
+            TypeBound::Linear,
+            extension_ref,
+        )
+    }
+
     fn custom_type(&self, extension_ref: &Weak<Extension>) -> CustomType {
         match self {
             Self::Module => CustomType::new(
@@ -241,33 +272,23 @@ impl WasmType {
                 TypeBound::Linear,
                 extension_ref,
             ),
-            s @ Self::Func { .. } => s.clone().into_custom_type(extension_ref),
-        }
-    }
-
-    fn into_custom_type(self, extension_ref: &Weak<Extension>) -> CustomType {
-        match self {
-            Self::Module | Self::Context => self.custom_type(extension_ref),
             Self::Func { inputs, outputs } => {
-                Self::func_custom_type(inputs, outputs, extension_ref)
+                Self::func_custom_type(inputs.clone(), outputs.clone(), extension_ref)
             }
+            Self::Result { outputs } => Self::result_custom_type(outputs.clone(), extension_ref),
         }
-    }
-
-    fn into_type(self, extension_ref: &Weak<Extension>) -> Type {
-        self.into_custom_type(extension_ref).into()
     }
 }
 
 impl From<WasmType> for CustomType {
     fn from(value: WasmType) -> Self {
-        value.into_custom_type(&EXTENSION_REF)
+        value.custom_type(&EXTENSION_REF)
     }
 }
 
 impl From<WasmType> for Type {
     fn from(value: WasmType) -> Self {
-        value.into_type(&EXTENSION_REF)
+        value.get_type(&EXTENSION_REF)
     }
 }
 
@@ -305,6 +326,14 @@ impl TryFrom<CustomType> for WasmType {
 
                 Ok(WasmType::Func { inputs, outputs })
             }
+            n if *n == *RESULT_TYPE_NAME => {
+                let [outputs] = value.args() else {
+                    Err(SignatureError::InvalidTypeArgs)?
+                };
+                let outputs = TypeRowRV::try_from(outputs.clone())?;
+
+                Ok(WasmType::Result { outputs })
+            }
             n => Err(SignatureError::NameMismatch(
                 format_smolstr!(
                     "{}, {} or {}",
@@ -335,8 +364,24 @@ impl MakeOpDef for WasmOpDef {
             .into(),
             // [Context] -> []
             Self::dispose_context => Signature::new(context_type, type_row![]).into(),
+            // <id: usize, inputs: TypeRow, outputs: TypeRow> [Module] -> [WasmType::Func { inputs, outputs }]
+            Self::lookup_by_id => {
+                let inputs = TypeRV::new_row_var_use(1, TypeBound::Copyable);
+                let outputs = TypeRV::new_row_var_use(2, TypeBound::Copyable);
+
+                let func_type = WasmType::func_custom_type(inputs, outputs, extension_ref).into();
+                PolyFuncTypeRV::new(
+                    [
+                        ID_PARAM.to_owned(),
+                        INPUTS_PARAM.to_owned(),
+                        OUTPUTS_PARAM.to_owned(),
+                    ],
+                    Signature::new(vec![module_type], vec![func_type]),
+                )
+                .into()
+            }
             // <name: String, inputs: TypeRow, outputs: TypeRow> [Module] -> [WasmType::Func { inputs, outputs }]
-            Self::lookup => {
+            Self::lookup_by_name => {
                 let inputs = TypeRV::new_row_var_use(1, TypeBound::Copyable);
                 let outputs = TypeRV::new_row_var_use(2, TypeBound::Copyable);
 
@@ -361,14 +406,28 @@ impl MakeOpDef for WasmOpDef {
                     outputs.clone(),
                     extension_ref,
                 ));
-                let future_type: TypeRV = future_type(Type::new_tuple(outputs)).into();
+                let result_type =
+                    TypeRV::new_extension(WasmType::result_custom_type(outputs, extension_ref));
 
                 PolyFuncTypeRV::new(
                     [INPUTS_PARAM.to_owned(), OUTPUTS_PARAM.to_owned()],
                     FuncValueType::new(
                         vec![context_type.clone(), func_type.into(), inputs],
-                        vec![context_type, future_type],
+                        vec![result_type],
                     ),
+                )
+                .into()
+            }
+            Self::read_result => {
+                let context_type: TypeRV = context_type.into();
+                let outputs = TypeRV::new_row_var_use(0, TypeBound::Copyable);
+                let result_type = TypeRV::new_extension(WasmType::result_custom_type(
+                    outputs.clone(),
+                    extension_ref,
+                ));
+                PolyFuncTypeRV::new(
+                    [OUTPUTS_PARAM.to_owned()],
+                    FuncValueType::new(vec![result_type], vec![context_type, outputs]),
                 )
                 .into()
             }
@@ -396,7 +455,7 @@ impl HasConcrete for WasmOpDef {
 
     fn instantiate(&self, type_args: &[TypeArg]) -> Result<Self::Concrete, OpLoadError> {
         match self {
-            WasmOpDef::get_context => {
+            Self::get_context => {
                 let [] = type_args else {
                     Err(SignatureError::from(TermTypeError::WrongNumberArgs(
                         type_args.len(),
@@ -405,7 +464,7 @@ impl HasConcrete for WasmOpDef {
                 };
                 Ok(WasmOp::GetContext)
             }
-            WasmOpDef::dispose_context => {
+            Self::dispose_context => {
                 let [] = type_args else {
                     Err(SignatureError::from(TermTypeError::WrongNumberArgs(
                         type_args.len(),
@@ -414,8 +473,45 @@ impl HasConcrete for WasmOpDef {
                 };
                 Ok(WasmOp::DisposeContext)
             }
+            // <usize,in_row,out_row> [] -> []
+            Self::lookup_by_id => {
+                let Some([id_arg, inputs_arg, outputs_arg]): Option<[_; 3]> =
+                    type_args.to_vec().try_into().ok()
+                else {
+                    Err(SignatureError::from(TermTypeError::WrongNumberArgs(
+                        type_args.len(),
+                        3,
+                    )))?
+                };
+
+                let Some(id) = id_arg.as_nat() else {
+                    Err(SignatureError::from(TermTypeError::TypeMismatch {
+                        term: Box::new(id_arg),
+                        type_: Box::new(ID_PARAM.to_owned()),
+                    }))?
+                };
+
+                let Ok(inputs) = TypeRowRV::try_from(inputs_arg.clone()) else {
+                    Err(SignatureError::from(TermTypeError::TypeMismatch {
+                        term: Box::new(inputs_arg),
+                        type_: Box::new(INPUTS_PARAM.to_owned()),
+                    }))?
+                };
+
+                let Ok(outputs) = TypeRowRV::try_from(outputs_arg.clone()) else {
+                    Err(SignatureError::from(TermTypeError::TypeMismatch {
+                        term: Box::new(outputs_arg),
+                        type_: Box::new(OUTPUTS_PARAM.to_owned()),
+                    }))?
+                };
+                Ok(WasmOp::LookupById {
+                    id,
+                    inputs,
+                    outputs,
+                })
+            }
             // <String,in_row,out_row> [] -> []
-            WasmOpDef::lookup => {
+            Self::lookup_by_name => {
                 let Some([name_arg, inputs_arg, outputs_arg]): Option<[_; 3]> =
                     type_args.to_vec().try_into().ok()
                 else {
@@ -445,13 +541,13 @@ impl HasConcrete for WasmOpDef {
                         type_: Box::new(OUTPUTS_PARAM.to_owned()),
                     }))?
                 };
-                Ok(WasmOp::Lookup {
+                Ok(WasmOp::LookupByName {
                     name,
                     inputs,
                     outputs,
                 })
             }
-            WasmOpDef::call => {
+            Self::call => {
                 let Some([inputs_arg, outputs_arg]): Option<[_; 2]> =
                     type_args.to_vec().try_into().ok()
                 else {
@@ -480,6 +576,24 @@ impl HasConcrete for WasmOpDef {
                     outputs: outputs.try_into()?,
                 })
             }
+            Self::read_result => {
+                let Some([outputs_arg]): Option<[_; 1]> = type_args.to_vec().try_into().ok() else {
+                    Err(SignatureError::from(TermTypeError::WrongNumberArgs(
+                        type_args.len(),
+                        1,
+                    )))?
+                };
+
+                let Ok(outputs) = TypeRowRV::try_from(outputs_arg.clone()) else {
+                    Err(SignatureError::from(TermTypeError::TypeMismatch {
+                        term: Box::new(outputs_arg),
+                        type_: Box::new(OUTPUTS_PARAM.to_owned()),
+                    }))?
+                };
+                Ok(WasmOp::ReadResult {
+                    outputs: outputs.try_into()?,
+                })
+            }
         }
     }
 }
@@ -503,8 +617,19 @@ pub enum WasmOp {
     GetContext,
     /// A `tket.wasm.dispose_context` op.
     DisposeContext,
-    /// A `tket.wasm.lookup` op.
-    Lookup {
+    /// A `tket.wasm.lookup_by_id` op.
+    LookupById {
+        /// The name of the function to be looked up.
+        id: u64,
+        /// The input signature of the function to be looked up.
+        /// Note that row variables are allowed here.
+        inputs: TypeRowRV,
+        /// The output signature of the function to be looked up.
+        /// Note that row variables are allowed here.
+        outputs: TypeRowRV,
+    },
+    /// A `tket.wasm.lookup_by_name` op.
+    LookupByName {
         /// The name of the function to be looked up.
         name: String,
         /// The input signature of the function to be looked up.
@@ -523,6 +648,12 @@ pub enum WasmOp {
         /// Note that row variables are not allowed here.
         outputs: TypeRow,
     },
+    /// A `tket.wasm.read_result` op.
+    ReadResult {
+        /// The output signature of the function to be called
+        /// Note that row variables are not allowed here.
+        outputs: TypeRow,
+    },
 }
 
 impl WasmOp {
@@ -530,15 +661,15 @@ impl WasmOp {
         match self {
             Self::GetContext => WasmOpDef::get_context,
             Self::DisposeContext => WasmOpDef::dispose_context,
-            Self::Lookup { .. } => WasmOpDef::lookup,
+            Self::LookupById { .. } => WasmOpDef::lookup_by_id,
+            Self::LookupByName { .. } => WasmOpDef::lookup_by_name,
             Self::Call { .. } => WasmOpDef::call,
+            Self::ReadResult { .. } => WasmOpDef::read_result,
         }
     }
 
     fn get_context_return_type(extension_ref: &Weak<Extension>) -> SumType {
-        option_type(Type::new_extension(
-            WasmType::Context.into_custom_type(extension_ref),
-        ))
+        option_type(WasmType::Context.get_type(extension_ref))
     }
 }
 
@@ -562,7 +693,16 @@ impl MakeExtensionOp for WasmOp {
         match self {
             WasmOp::GetContext => vec![],
             WasmOp::DisposeContext => vec![],
-            WasmOp::Lookup {
+            WasmOp::LookupById {
+                id,
+                inputs,
+                outputs,
+            } => {
+                let inputs = TypeArg::from(inputs.clone());
+                let outputs = TypeArg::from(outputs.clone());
+                vec![TypeArg::BoundedNat(*id), inputs, outputs]
+            }
+            WasmOp::LookupByName {
                 name,
                 inputs,
                 outputs,
@@ -576,6 +716,7 @@ impl MakeExtensionOp for WasmOp {
                 let outputs = TypeArg::from(outputs.clone());
                 vec![inputs, outputs]
             }
+            WasmOp::ReadResult { outputs } => vec![outputs.clone().into()],
         }
     }
 }
@@ -595,15 +736,13 @@ impl MakeRegisteredOp for WasmOp {
 /// Loading this is the only way to obtain a value of `tket.wasm.module` type.
 pub struct ConstWasmModule {
     /// The name of the module.
-    pub name: String,
-    /// The hash of the module.
-    pub hash: u64,
+    pub module_filename: String,
 }
 
 #[typetag::serde]
 impl CustomConst for ConstWasmModule {
     fn name(&self) -> ValueName {
-        format!("wasm:{}", self.name).into()
+        format!("wasm:{}", self.module_filename).into()
     }
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
         downcast_equal_consts(self, other)
@@ -629,8 +768,28 @@ pub trait WasmOpBuilder: Dataflow {
         Ok(())
     }
 
-    /// Add a `tket.wasm.lookup` op.
-    fn add_lookup(
+    /// Add a `tket.wasm.lookup_by_id` op.
+    fn add_lookup_by_id(
+        &mut self,
+        id: impl Into<u64>,
+        inputs: impl Into<TypeRowRV>,
+        outputs: impl Into<TypeRowRV>,
+        module: Wire,
+    ) -> Result<Wire, BuildError> {
+        Ok(self
+            .add_dataflow_op(
+                WasmOp::LookupById {
+                    id: id.into(),
+                    inputs: inputs.into(),
+                    outputs: outputs.into(),
+                },
+                [module],
+            )?
+            .out_wire(0))
+    }
+
+    /// Add a `tket.wasm.lookup_by_name` op.
+    fn add_lookup_by_name(
         &mut self,
         name: impl Into<String>,
         inputs: impl Into<TypeRowRV>,
@@ -639,7 +798,7 @@ pub trait WasmOpBuilder: Dataflow {
     ) -> Result<Wire, BuildError> {
         Ok(self
             .add_dataflow_op(
-                WasmOp::Lookup {
+                WasmOp::LookupByName {
                     name: name.into(),
                     inputs: inputs.into(),
                     outputs: outputs.into(),
@@ -657,7 +816,7 @@ pub trait WasmOpBuilder: Dataflow {
         context: Wire,
         func: Wire,
         inputs: impl IntoIterator<Item = Wire>,
-    ) -> Result<[Wire; 2], BuildError> {
+    ) -> Result<Wire, BuildError> {
         let func_wire_type = self.get_wire_type(func)?;
         let Some(WasmType::Func {
             inputs: in_types,
@@ -677,14 +836,30 @@ pub trait WasmOpBuilder: Dataflow {
                 },
                 [context, func].into_iter().chain(inputs),
             )?
-            .outputs_arr())
+            .out_wire(0))
+    }
+
+    /// Add a `tket.wasm.read_result` op.
+    fn add_read_result(&mut self, result: Wire) -> Result<(Wire, Vec<Wire>), BuildError> {
+        let result_wire_type = self.get_wire_type(result)?;
+        let Some(WasmType::Result { outputs }) =
+            self.get_wire_type(result)?.clone().try_into().ok()
+        else {
+            // TODO Add an Error variant to BuildError for: Input wire has wrong type
+            panic!("result wire is not a result type: {result_wire_type}")
+        };
+        let outputs = TypeRow::try_from(outputs)?;
+
+        let op = self.add_dataflow_op(WasmOp::ReadResult { outputs }, [result])?;
+        let context = op.out_wire(0);
+        let results = op.outputs().skip(1).collect_vec();
+        Ok((context, results))
     }
 
     /// Add a [ConstWasmModule] and load it.
-    fn add_const_module(&mut self, name: impl Into<String>, hash: u64) -> Result<Wire, BuildError> {
+    fn add_const_module(&mut self, module_filename: impl Into<String>) -> Result<Wire, BuildError> {
         Ok(self.add_load_value(ConstWasmModule {
-            name: name.into(),
-            hash,
+            module_filename: module_filename.into(),
         }))
     }
 }
@@ -703,12 +878,10 @@ mod test {
     #[test]
     fn const_wasm_module() {
         let m1 = ConstWasmModule {
-            name: "test_mod".to_string(),
-            hash: 1,
+            module_filename: "test_mod".to_string(),
         };
         let m2 = ConstWasmModule {
-            name: "test_mod".to_string(),
-            hash: 1,
+            module_filename: "test_mod".to_string(),
         };
         assert_eq!(m1.name(), "wasm:test_mod");
         assert!(m1.equal_consts(&m2));
@@ -736,13 +909,25 @@ mod test {
             Ok(WasmOp::DisposeContext)
         );
         assert_eq!(
-            WasmOpDef::lookup.instantiate(&[
+            WasmOpDef::lookup_by_name.instantiate(&[
                 "lookup_name".into(),
                 TypeArg::new_var_use(0, TypeParam::ListType(Box::new(TypeBound::Linear.into()))),
                 vec![].into()
             ]),
-            Ok(WasmOp::Lookup {
+            Ok(WasmOp::LookupByName {
                 name: "lookup_name".to_string(),
+                inputs: vec![TypeRV::new_row_var_use(0, TypeBound::Linear)].into(),
+                outputs: TypeRowRV::from(Vec::<TypeRV>::new())
+            })
+        );
+        assert_eq!(
+            WasmOpDef::lookup_by_id.instantiate(&[
+                TypeArg::BoundedNat(42),
+                TypeArg::new_var_use(0, TypeParam::ListType(Box::new(TypeBound::Linear.into()))),
+                vec![].into()
+            ]),
+            Ok(WasmOp::LookupById {
+                id: 42,
                 inputs: vec![TypeRV::new_row_var_use(0, TypeBound::Linear)].into(),
                 outputs: TypeRowRV::from(Vec::<TypeRV>::new())
             })
@@ -776,12 +961,12 @@ mod test {
         #[case] outputs: impl Into<TypeRowRV>,
     ) {
         let (inputs, outputs) = (inputs.into(), outputs.into());
-        let op = WasmOp::Lookup {
+        let op = WasmOp::LookupByName {
             name: "test".into(),
             inputs: inputs.clone(),
             outputs: outputs.clone(),
         };
-        let module_ty = Type::new_extension(WasmType::Module.into_custom_type(&op.extension_ref()));
+        let module_ty = WasmType::Module.get_type(&op.extension_ref());
         let func_ty = Type::new_extension(WasmType::func_custom_type(
             inputs.clone(),
             outputs.clone(),
@@ -797,10 +982,9 @@ mod test {
     #[case(type_row![], type_row![])]
     #[case(vec![Type::UNIT], TypeRow::try_from(Term::from(vec![TypeArg::from(Type::UNIT),TypeArg::from(usize_t())])).unwrap())]
     fn build_all(#[case] in_types: impl Into<TypeRow>, #[case] out_types: impl Into<TypeRow>) {
-        use futures::FutureOpBuilder as _;
         use hugr::{
             builder::DataflowHugr as _,
-            extension::prelude::{ConstUsize, UnpackTuple, UnwrapBuilder as _},
+            extension::prelude::{ConstUsize, UnwrapBuilder as _},
         };
 
         let (in_types, out_types) = (in_types.into(), out_types.into());
@@ -814,23 +998,26 @@ mod test {
                     .build_unwrap_sum(1, WasmOp::get_context_return_type(&EXTENSION_REF), mb_c)
                     .unwrap()
             };
-            let module = builder.add_const_module("test_module", 0).unwrap();
-            let func = builder
-                .add_lookup("test_func", in_types, out_types.clone(), module)
+            let module = builder.add_const_module("test_module").unwrap();
+            let func0 = builder
+                .add_lookup_by_id(42_u64, in_types.clone(), out_types.clone(), module)
                 .unwrap();
 
-            let [context, results_future] = builder
-                .add_call(context, func, builder.input_wires())
+            let func1 = builder
+                .add_lookup_by_name("test_func", in_types, out_types.clone(), module)
                 .unwrap();
 
-            let results = {
-                let tuple_ty = Type::new_tuple(out_types.clone());
-                let [results_tuple] = builder.add_read(results_future, tuple_ty).unwrap();
-                builder
-                    .add_dataflow_op(UnpackTuple::new(out_types), [results_tuple])
-                    .unwrap()
-                    .outputs()
-            };
+            let result = builder
+                .add_call(context, func0, builder.input_wires())
+                .unwrap();
+
+            let (context, _results) = builder.add_read_result(result).unwrap();
+
+            let result = builder
+                .add_call(context, func1, builder.input_wires())
+                .unwrap();
+
+            let (context, results) = builder.add_read_result(result).unwrap();
 
             builder.add_dispose_context(context).unwrap();
 

--- a/tket-qsystem/src/extension/wasm.rs
+++ b/tket-qsystem/src/extension/wasm.rs
@@ -82,7 +82,7 @@ use strum::{EnumIter, EnumString, IntoStaticStr};
 /// The "tket.wasm" extension id.
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("tket.wasm");
 /// The "tket.wasm" extension version.
-pub const EXTENSION_VERSION: Version = Version::new(0, 3, 0);
+pub const EXTENSION_VERSION: Version = Version::new(0, 4, 0);
 
 lazy_static! {
     /// The `tket.wasm` extension.


### PR DESCRIPTION
Upstream changes to the WASM extension from the `gpu` branch. Namely,
* Add a new type `Result`, which can be lazily read to get the operation result and return the context
* The `call` operation returns a `Result` instead of a context + future
* Functions can now be looked up either by name or by id in the wasm module
* `ConstWasmModule` no longer contains a `hash` field (that we weren't using) and its other field has been renamed

BREAKING CHANGE: This is a breaking change to the WASM extension and its serialised representation