### PR TITLE
feat!: Avoid eagerly cloning SerialCircuits when decoding from pytket

### DIFF
--- a/tket-qsystem/src/pytket/tests.rs
+++ b/tket-qsystem/src/pytket/tests.rs
@@ -168,10 +168,7 @@ fn json_roundtrip(#[case] circ_s: &str, #[case] num_commands: usize, #[case] num
     let ser: circuit_json::SerialCircuit = serde_json::from_str(circ_s).unwrap();
     assert_eq!(ser.commands.len(), num_commands);
 
-    let circ: Circuit = ser
-        .clone()
-        .decode_with_config(qsystem_decoder_config())
-        .unwrap();
+    let circ: Circuit = ser.decode_with_config(qsystem_decoder_config()).unwrap();
 
     assert_eq!(circ.qubit_count(), num_qubits);
 
@@ -189,10 +186,7 @@ fn json_roundtrip(#[case] circ_s: &str, #[case] num_commands: usize, #[case] num
 fn circuit_roundtrip(#[case] circ: Circuit, #[case] decoded_sig: Signature) {
     let ser: SerialCircuit =
         SerialCircuit::encode_with_config(&circ, qsystem_encoder_config()).unwrap();
-    let deser: Circuit = ser
-        .clone()
-        .decode_with_config(qsystem_decoder_config())
-        .unwrap();
+    let deser: Circuit = ser.decode_with_config(qsystem_decoder_config()).unwrap();
 
     let deser_sig = deser.circuit_signature();
     assert_eq!(

--- a/tket/src/serialize/pytket.rs
+++ b/tket/src/serialize/pytket.rs
@@ -69,10 +69,10 @@ pub trait TKETDecode: Sized {
     /// Convert the serialized circuit to a circuit.
     ///
     /// Uses a default set of extension decoders to translate operations.
-    fn decode(self) -> Result<Circuit, Self::DecodeError>;
+    fn decode(&self) -> Result<Circuit, Self::DecodeError>;
     /// Convert the serialized circuit to a circuit.
     fn decode_with_config(
-        self,
+        &self,
         config: impl Into<Arc<PytketDecoderConfig>>,
     ) -> Result<Circuit, Self::DecodeError>;
     /// Convert a circuit to a serialized pytket circuit.
@@ -95,20 +95,20 @@ impl TKETDecode for SerialCircuit {
     type DecodeError = PytketDecodeError;
     type EncodeError = PytketEncodeError;
 
-    fn decode(self) -> Result<Circuit, Self::DecodeError> {
+    fn decode(&self) -> Result<Circuit, Self::DecodeError> {
         let config = default_decoder_config();
         Self::decode_with_config(self, config)
     }
 
     fn decode_with_config(
-        self,
+        &self,
         config: impl Into<Arc<PytketDecoderConfig>>,
     ) -> Result<Circuit, Self::DecodeError> {
         let mut hugr = Hugr::new();
 
         let mut decoder =
-            PytketDecoderContext::new(&self, &mut hugr, None, None, Vec::new(), config)?;
-        decoder.run_decoder(self.commands)?;
+            PytketDecoderContext::new(self, &mut hugr, None, None, Vec::new(), config)?;
+        decoder.run_decoder(&self.commands)?;
         let main_func = decoder.finish()?;
         hugr.set_entrypoint(main_func.node());
         Ok(hugr.into())

--- a/tket/src/serialize/pytket/extension/prelude.rs
+++ b/tket/src/serialize/pytket/extension/prelude.rs
@@ -124,11 +124,6 @@ impl PytketDecoder for PreludeEmitter {
         opgroup: Option<&str>,
         decoder: &mut PytketDecoderContext<'h>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
-        // Qubits, bits and parameters that will be used to register the node outputs.
-        //
-        // These should be modified by the match branches if the node does not have all
-        // its input registers in the outputs.
-
         let op: OpType = match op.op_type {
             PytketOptype::noop => Noop::new(qb_t()).into(),
             PytketOptype::Barrier => {

--- a/tket/src/serialize/pytket/extension/tk1.rs
+++ b/tket/src/serialize/pytket/extension/tk1.rs
@@ -77,7 +77,7 @@ impl<H: HugrView> PytketEmitter<H> for Tk1Emitter {
 /// We should accept arbitrary wires, but the opaque extension op needs to be modified (or replaced with a new one)
 /// since it currently has a limited signature definition.
 pub(crate) fn build_opaque_tket_op<'h>(
-    op: tket_json_rs::circuit_json::Operation,
+    op: &tket_json_rs::circuit_json::Operation,
     qubits: &[TrackedQubit],
     bits: &[TrackedBit],
     params: &[Arc<LoadedParameter>],
@@ -164,11 +164,9 @@ impl OpaqueTk1Op {
     ///
     /// If the operation does not define a signature, one is generated with the
     /// given amounts.
-    pub fn new_from_op(
-        mut op: circuit_json::Operation,
-        num_qubits: usize,
-        num_bits: usize,
-    ) -> Self {
+    pub fn new_from_op(op: &circuit_json::Operation, num_qubits: usize, num_bits: usize) -> Self {
+        let mut op = op.clone();
+
         if op.signature.is_none() {
             op.signature =
                 Some([vec!["Q".into(); num_qubits], vec!["B".into(); num_bits]].concat());

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -397,7 +397,7 @@ fn json_roundtrip(#[case] circ_s: &str, #[case] num_commands: usize, #[case] num
     let ser: circuit_json::SerialCircuit = serde_json::from_str(circ_s).unwrap();
     assert_eq!(ser.commands.len(), num_commands);
 
-    let circ: Circuit = ser.clone().decode().unwrap();
+    let circ: Circuit = ser.decode().unwrap();
 
     assert_eq!(circ.qubit_count(), num_qubits);
 
@@ -412,7 +412,7 @@ fn json_roundtrip(#[case] circ_s: &str, #[case] num_commands: usize, #[case] num
 fn json_file_roundtrip(#[case] circ: impl AsRef<std::path::Path>) {
     let reader = BufReader::new(std::fs::File::open(circ).unwrap());
     let ser: circuit_json::SerialCircuit = serde_json::from_reader(reader).unwrap();
-    let circ: Circuit = ser.clone().decode().unwrap();
+    let circ: Circuit = ser.decode().unwrap();
     let reser: SerialCircuit = SerialCircuit::encode(&circ).unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
@@ -427,7 +427,7 @@ fn json_file_roundtrip(#[case] circ: impl AsRef<std::path::Path>) {
 #[case::preset_parameterized(circ_parameterized(), Signature::new(vec![qb_t(), rotation_type(), rotation_type(), rotation_type()], vec![qb_t()]))]
 fn circuit_roundtrip(#[case] circ: Circuit, #[case] decoded_sig: Signature) {
     let ser: SerialCircuit = SerialCircuit::encode(&circ).unwrap();
-    let deser: Circuit = ser.clone().decode().unwrap();
+    let deser: Circuit = ser.decode().unwrap();
 
     let deser_sig = deser.circuit_signature();
     assert_eq!(
@@ -463,7 +463,7 @@ fn test_add_angle_serialise(#[case] circ_add_angles: (Circuit, String)) {
     assert_eq!(ser.commands[0].op.op_type, optype::OpType::Rx);
     assert_eq!(ser.commands[0].op.params, Some(vec![expected]));
 
-    let deser: Circuit = ser.clone().decode().unwrap();
+    let deser: Circuit = ser.decode().unwrap();
     let reser = SerialCircuit::encode(&deser).unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);


### PR DESCRIPTION
BREAKING CHANGE: TKETDecode now decodes `SerialCircuit`s by reference instead of by value