### PR TITLE
feat: Add ResourceScope::is_convex

### DIFF
--- a/tket/src/resource.rs
+++ b/tket/src/resource.rs
@@ -49,6 +49,7 @@ pub use scope::{ResourceScope, ResourceScopeConfig};
 pub use types::{CopyableValueId, OpValue, Position, ResourceAllocator, ResourceId};
 
 // Internal modules
+mod convex_checker;
 mod flow;
 mod interval;
 mod scope;

--- a/tket/src/resource/convex_checker.rs
+++ b/tket/src/resource/convex_checker.rs
@@ -1,0 +1,119 @@
+//! Use [`ResourceScope`] to check whether a subcircuit is convex.
+
+use std::collections::{BTreeSet, VecDeque};
+
+use hugr::{Direction, HugrView};
+
+use crate::Subcircuit;
+
+use super::ResourceScope;
+
+impl<H: HugrView> ResourceScope<H> {
+    /// Check if the given subcircuit is convex.
+    ///
+    /// A subcircuit is convex if there is no path from a circuit output to a
+    /// circuit input.
+    pub fn is_convex(&self, subcircuit: Subcircuit<H::Node>) -> bool {
+        let Some(max_start_pos) = subcircuit
+            .intervals_iter()
+            .map(|interval| interval.start_pos())
+            .max()
+        else {
+            // An empty subcircuit is convex
+            return true;
+        };
+
+        let mut future_nodes =
+            VecDeque::from_iter(subcircuit.intervals_iter().filter_map(|interval| {
+                let last_node = interval.end_node();
+                self.resource_path_iter(interval.resource_id(), last_node, Direction::Outgoing)
+                    .nth(1)
+            }));
+        let mut visited = BTreeSet::new();
+
+        // We must prove that all nodes in `future_nodes` are not in the past
+        // of any node at the beginning of a line interval.
+        while let Some(node) = future_nodes.pop_front() {
+            let pos = self.get_position(node).expect("known node");
+            if pos > max_start_pos {
+                // we cannot be in the past of any node at the beginning of a
+                // line interval, so we can stop searching
+                continue;
+            }
+            if !visited.insert(node) {
+                continue; // been here before
+            }
+            for resource_id in self.get_all_resources(node) {
+                if let Some(interval) = subcircuit.get_interval(resource_id) {
+                    debug_assert!(
+                        pos < interval.start_pos() || pos > interval.end_pos(),
+                        "node cannot be in interval [min, max]"
+                    );
+                    if pos < interval.start_pos() {
+                        // we are in the past of min, so there is a path from
+                        // an output to an input! -> not convex
+                        return false;
+                    }
+                }
+            }
+
+            future_nodes.extend(
+                self.hugr()
+                    .output_neighbours(node)
+                    .filter(|&nei| self.contains_node(nei)),
+            );
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{utils::build_simple_circuit, Circuit, TketOp};
+
+    use super::*;
+
+    use rstest::rstest;
+
+    // A circuit made of two CX ladders (v-shape)
+    //  - first ladder is (0, 1), (1, 2), etc
+    //  - second ladder is (n_qubits - 1, n_qubits - 2), (n_qubits - 2, n_qubits - 3), etc
+    fn cx_ladder(n_qubits: usize) -> Circuit {
+        build_simple_circuit(n_qubits, |circ| {
+            for i in 0..n_qubits - 1 {
+                circ.append(TketOp::CX, [i, i + 1]).unwrap();
+            }
+            for i in (1..n_qubits).rev() {
+                circ.append(TketOp::CX, [i, i - 1]).unwrap();
+            }
+            Ok(())
+        })
+        .unwrap()
+    }
+
+    // Any sequence of non-contiguous node indices will be non-convex.
+    // Note that for a lot of non-convex cases, subcircuit construction will
+    // fail. We do not include these cases here.
+    #[rstest]
+    #[case(vec![0, 1], true)]
+    #[case(vec![0, 1, 2, 3, 4], true)]
+    #[case(vec![4, 5, 6], true)]
+    #[case(vec![3, 4], true)]
+    #[case(vec![3, 4, 5, 6, 7], true)]
+    #[case(vec![0, 2], false)]
+    #[case(vec![0, 1, 3, 4], false)]
+    #[case(vec![0, 1, 4], false)]
+    #[case(vec![3, 6, 7], false)]
+    fn test_is_convex(#[case] selected_nodes: Vec<usize>, #[case] is_convex: bool) {
+        let circ = cx_ladder(5);
+        let subgraph = circ.subgraph();
+        let cx_nodes = subgraph.nodes();
+        let circ = ResourceScope::from(circ);
+        let selected_nodes = selected_nodes.into_iter().map(|i| cx_nodes[i]);
+
+        let subcirc = Subcircuit::try_from_nodes(selected_nodes, &circ).unwrap();
+
+        assert_eq!(circ.is_convex(subcirc), is_convex);
+    }
+}

--- a/tket/src/resource/interval.rs
+++ b/tket/src/resource/interval.rs
@@ -70,6 +70,14 @@ impl<N: HugrNode> Interval<N> {
         self.nodes[0]
     }
 
+    pub(crate) fn start_pos(&self) -> Position {
+        self.positions[0]
+    }
+
+    pub(crate) fn end_pos(&self) -> Position {
+        self.positions[1]
+    }
+
     /// Get the end node of the interval.
     pub fn end_node(&self) -> N {
         self.nodes[1]

--- a/tket/src/resource/interval.rs
+++ b/tket/src/resource/interval.rs
@@ -6,7 +6,7 @@ use derive_more::derive::{Display, Error};
 use hugr::{core::HugrNode, Direction, HugrView};
 use itertools::Itertools;
 
-use super::{OpValue, Position, ResourceId, ResourceScope};
+use super::{Position, ResourceId, ResourceScope};
 
 /// A non-empty interval on a resource path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -26,12 +26,9 @@ impl<N: HugrNode> Interval<N> {
         node: N,
         scope: &ResourceScope<impl HugrView<Node = N>>,
     ) -> Self {
-        let port = scope
-            .get_port(node, resource_id, Direction::Outgoing)
-            .expect("node not on resource path");
-        let OpValue::Resource(_, pos) = scope.get_opvalue(node, port) else {
-            panic!("node is not on resource path");
-        };
+        let pos = scope
+            .get_position(node)
+            .expect("node is not on resource path");
 
         Self {
             resource_id,
@@ -47,19 +44,14 @@ impl<N: HugrNode> Interval<N> {
         end_node: N,
         scope: &ResourceScope<impl HugrView<Node = N>>,
     ) -> Self {
-        let start_port = scope
-            .get_port(start_node, resource_id, Direction::Outgoing)
+        let start_pos = scope
+            .get_position(start_node)
             .expect("start node not on resource path");
-        let end_port = scope
-            .get_port(end_node, resource_id, Direction::Outgoing)
+        let end_pos = scope
+            .get_position(end_node)
             .expect("end node not on resource path");
 
-        let OpValue::Resource(_, start_pos) = scope.get_opvalue(start_node, start_port) else {
-            panic!("start_port is a resource port");
-        };
-        let OpValue::Resource(_, end_pos) = scope.get_opvalue(end_node, end_port) else {
-            panic!("end_port is a resource port");
-        };
+        assert!(start_pos <= end_pos);
 
         Self {
             resource_id,
@@ -97,7 +89,7 @@ impl<N: HugrNode> Interval<N> {
         node: N,
         scope: &ResourceScope<impl HugrView<Node = N>>,
     ) -> Result<Option<Direction>, InvalidInterval<N>> {
-        let Some(pos) = scope.get_position(node, self.resource_id) else {
+        let Some(pos) = scope.get_position(node) else {
             return Err(InvalidInterval::NotOnResourcePath(node));
         };
 

--- a/tket/src/resource/scope.rs
+++ b/tket/src/resource/scope.rs
@@ -4,7 +4,7 @@
 //! tracking within a specific region of a HUGR, computing resource paths and
 //! providing efficient lookup of port values.
 
-use std::{iter, mem};
+use std::{cmp, iter, mem};
 
 use crate::resource::flow::{DefaultResourceFlow, ResourceFlow};
 use crate::resource::types::{CopyableValueId, OpValue, PortMap};
@@ -12,6 +12,7 @@ use crate::utils::type_is_linear;
 use crate::Circuit;
 use hugr::hugr::views::SiblingSubgraph;
 use hugr::ops::OpTrait;
+use hugr::types::Signature;
 use hugr::{Direction, HugrView, IncomingPort, Port, PortIndex};
 use hugr_core::hugr::internal::PortgraphNodeMap;
 use indexmap::IndexMap;
@@ -19,7 +20,6 @@ use itertools::Itertools;
 use portgraph::algorithms::{toposort, TopoSort};
 use portgraph::view::{FilteredGraph, NodeFilter, NodeFiltered};
 
-use super::types::{PositionAllocator, ResourceMap};
 use super::{Position, ResourceAllocator, ResourceId};
 
 /// ResourceScope tracks resources within a HUGR subgraph.
@@ -34,7 +34,24 @@ pub struct ResourceScope<H: HugrView> {
     /// The subgraph within which resources are tracked.
     subgraph: SiblingSubgraph<H::Node>,
     /// Mapping from nodes and ports to their OpValues.
-    op_values: IndexMap<H::Node, PortMap<OpValue>>,
+    op_values: IndexMap<H::Node, NodeOpValues>,
+}
+
+#[derive(Debug, Clone)]
+struct NodeOpValues {
+    /// Mapping from ports to their OpValues.
+    port_map: PortMap<OpValue>,
+    /// The position of the node.
+    position: Position,
+}
+
+impl NodeOpValues {
+    fn with_default(default: OpValue, signature: &Signature) -> Self {
+        Self {
+            port_map: PortMap::with_default(default, signature),
+            position: Position::new_integer(0),
+        }
+    }
 }
 
 /// Configuration for a ResourceScope.
@@ -92,48 +109,34 @@ impl<H: HugrView> ResourceScope<H> {
     }
 
     /// Get the opvalue for a given port.
-    pub fn get_opvalue(&self, node: H::Node, port: impl Into<Port>) -> OpValue {
-        let port_map = self.op_values.get(&node).expect("node not in scope");
-        *port_map.get(port)
+    pub fn get_opvalue(&self, node: H::Node, port: impl Into<Port>) -> Option<OpValue> {
+        let port_map = self.port_map(node)?;
+        Some(*port_map.get(port))
     }
 
     /// Get all opvalues for either the incoming or outgoing ports of a node.
-    pub fn get_opvalue_slice(&self, node: H::Node, direction: Direction) -> &[OpValue] {
-        let port_map = self.op_values.get(&node).expect("node not in scope");
-        port_map.get_slice(direction)
+    pub fn get_opvalue_slice(&self, node: H::Node, direction: Direction) -> Option<&[OpValue]> {
+        let port_map = self.port_map(node)?;
+        Some(port_map.get_slice(direction))
     }
 
     /// Get the port of node on the given resource path.
     ///
     /// The returned port will have the direction `dir`.
     pub fn get_port(&self, node: H::Node, resource_id: ResourceId, dir: Direction) -> Option<Port> {
-        let opvals = self.get_opvalue_slice(node, dir);
+        let opvals = self.get_opvalue_slice(node, dir)?;
         let offset = opvals.iter().position(|opval| match opval {
-            &OpValue::Resource(res, _) => res == resource_id,
+            &OpValue::Resource(res) => res == resource_id,
             _ => false,
         })?;
         Some(Port::new(dir, offset))
     }
 
-    /// Get the position of the given node on the given resource path.
-    pub fn get_position(&self, node: H::Node, resource_id: ResourceId) -> Option<Position> {
-        // Get the position of either the incoming port or outgoing port
-        let in_port = self.get_port(node, resource_id, Direction::Incoming);
-        let out_port = self.get_port(node, resource_id, Direction::Outgoing);
-
-        let mut all_pos = [in_port, out_port].into_iter().flatten().map(|port| {
-            let OpValue::Resource(_, pos) = self.get_opvalue(node, port) else {
-                panic!("in_port is not a resource port");
-            };
-            pos
-        });
-
-        debug_assert!(
-            all_pos.clone().all_equal(),
-            "resource has multiple positions in {node:?}"
-        );
-
-        all_pos.next()
+    /// Get the position of the given node.
+    pub fn get_position(&self, node: H::Node) -> Option<Position> {
+        self.op_values
+            .get(&node)
+            .map(|node_op_values| node_op_values.position)
     }
 
     /// All resource IDs on the ports of `node` in the given direction.
@@ -143,10 +146,13 @@ impl<H: HugrView> ResourceScope<H> {
         dir: Direction,
     ) -> impl Iterator<Item = ResourceId> + '_ {
         let opvals = self.get_opvalue_slice(node, dir);
-        opvals.iter().filter_map(|opval| match opval {
-            &OpValue::Resource(res, _) => Some(res),
-            _ => None,
-        })
+        opvals
+            .into_iter()
+            .flatten()
+            .filter_map(|opval| match opval {
+                &OpValue::Resource(res) => Some(res),
+                _ => None,
+            })
     }
 
     /// All resource IDs on the ports of `node`, in both directions.
@@ -167,10 +173,13 @@ impl<H: HugrView> ResourceScope<H> {
         dir: Direction,
     ) -> impl Iterator<Item = CopyableValueId> + '_ {
         let opvals = self.get_opvalue_slice(node, dir);
-        opvals.iter().filter_map(|opval| match opval {
-            &OpValue::Copyable(id) => Some(id),
-            _ => None,
-        })
+        opvals
+            .into_iter()
+            .flatten()
+            .filter_map(|opval| match opval {
+                &OpValue::Copyable(id) => Some(id),
+                _ => None,
+            })
     }
 
     /// Iterate over the nodes on the resource path starting from the given
@@ -220,9 +229,13 @@ impl<'h, H: HugrView<Node = hugr::Node> + Clone> From<&'h Circuit<H>> for Resour
 
 // Private methods to construct the op_values map.
 impl<H: HugrView> ResourceScope<H> {
+    fn port_map(&self, node: H::Node) -> Option<&PortMap<OpValue>> {
+        Some(&self.op_values.get(&node)?.port_map)
+    }
+
     /// Compute op values for all nodes in the subgraph.
     fn compute_op_values(&mut self, flows: &[Box<dyn ResourceFlow>]) {
-        let mut allocator = Allocator::default();
+        let mut allocator = OpValueAllocator::default();
 
         // Sentinel value for uninitialized ports
         let sentinel = OpValue::Copyable(CopyableValueId::new());
@@ -254,7 +267,7 @@ impl<H: HugrView> ResourceScope<H> {
     fn assign_op_values<I: IntoIterator<Item = (H::Node, IncomingPort)>>(
         &mut self,
         port_groups: impl IntoIterator<Item = I>,
-        allocator: &mut Allocator,
+        allocator: &mut OpValueAllocator,
         sentinel: OpValue,
     ) {
         for all_uses_of_value in port_groups {
@@ -266,15 +279,15 @@ impl<H: HugrView> ResourceScope<H> {
             // We allocate one opvalue for all uses of this input
             let op_value = allocator.allocate_op_value(fst_node, fst_port, &self.hugr);
             for (node, port) in all_uses_of_input {
-                let port_map = self.op_values.entry(node).or_insert_with(|| {
+                let node_op_values = self.op_values.entry(node).or_insert_with(|| {
                     let signature = self
                         .hugr
                         .get_optype(node)
                         .dataflow_signature()
                         .expect("dataflow op");
-                    PortMap::with_default(sentinel, &signature)
+                    NodeOpValues::with_default(sentinel, &signature)
                 });
-                port_map.set(port, op_value);
+                node_op_values.port_map.set(port, op_value);
             }
         }
     }
@@ -298,7 +311,7 @@ impl<H: HugrView> ResourceScope<H> {
     fn assign_missing_op_values(
         &mut self,
         node: H::Node,
-        allocator: &mut Allocator,
+        allocator: &mut OpValueAllocator,
         sentinel: OpValue,
     ) {
         let signature = self
@@ -306,14 +319,14 @@ impl<H: HugrView> ResourceScope<H> {
             .get_optype(node)
             .dataflow_signature()
             .expect("dataflow op");
-        let port_map = self
+        let node_op_values = self
             .op_values
             .entry(node)
-            .or_insert_with(|| PortMap::with_default(sentinel, &signature));
+            .or_insert_with(|| NodeOpValues::with_default(sentinel, &signature));
         for p in signature.input_ports() {
-            if port_map.get(p) == &sentinel {
+            if node_op_values.port_map.get(p) == &sentinel {
                 let op_value = allocator.allocate_op_value(node, p, &self.hugr);
-                port_map.set(p, op_value);
+                node_op_values.port_map.set(p, op_value);
             }
         }
     }
@@ -323,15 +336,15 @@ impl<H: HugrView> ResourceScope<H> {
         &mut self,
         node: H::Node,
         flows: &[Box<dyn ResourceFlow>],
-        allocator: &mut Allocator,
+        allocator: &mut OpValueAllocator,
     ) {
-        let port_map = self.op_values.get_mut(&node).expect("known node");
+        let port_map = &mut self.op_values.get_mut(&node).expect("known node").port_map;
 
         let inp_resources = port_map
             .get_slice(Direction::Incoming)
             .iter()
             .map(|&op_val| match op_val {
-                OpValue::Resource(res, _) => Some(res),
+                OpValue::Resource(res) => Some(res),
                 OpValue::Copyable(_) => None,
             })
             .collect_vec();
@@ -372,9 +385,10 @@ impl<H: HugrView> ResourceScope<H> {
             .get_optype(node)
             .dataflow_signature()
             .expect("dataflow op");
+        let pos = self.get_position(node).expect("known node");
 
         for p in signature.output_ports() {
-            let op_value = self.get_opvalue(node, p);
+            let op_value = self.get_opvalue(node, p).expect("known node");
 
             for (in_node, in_port) in self.hugr.linked_inputs(node, p) {
                 if !self.subgraph.nodes().contains(&in_node) {
@@ -384,38 +398,26 @@ impl<H: HugrView> ResourceScope<H> {
                 let Some(signature) = op.dataflow_signature() else {
                     continue;
                 };
-                let next_port_map = self
+                let next_node_op_values = self
                     .op_values
                     .entry(in_node)
-                    .or_insert_with(|| PortMap::with_default(sentinel, &signature));
-                let next_op_value = match op_value {
-                    OpValue::Resource(id, pos) => OpValue::Resource(id, pos.increment()),
-                    copyable @ OpValue::Copyable(_) => copyable,
-                };
-                next_port_map.set(in_port, next_op_value);
+                    .or_insert_with(|| NodeOpValues::with_default(sentinel, &signature));
+                let next_op_value = op_value;
+                next_node_op_values.port_map.set(in_port, next_op_value);
+                next_node_op_values.position =
+                    cmp::max(next_node_op_values.position, pos.increment());
             }
         }
     }
 }
 
 #[derive(Debug, Clone, Default)]
-struct Allocator {
-    /// Allocator for new resource IDs.
-    resource: ResourceAllocator,
-    /// For each resource ID, the allocator for new positions on the resource
-    /// path.
-    position: ResourceMap<PositionAllocator>,
-}
+struct OpValueAllocator(ResourceAllocator);
 
-impl Allocator {
+impl OpValueAllocator {
     fn allocate_resource(&mut self) -> OpValue {
-        let resource_id = self.resource.allocate();
-        if resource_id.as_usize() >= self.position.len() {
-            self.position
-                .resize(resource_id.as_usize() + 1, PositionAllocator::default());
-        }
-        let position = self.position[resource_id.as_usize()].allocate();
-        OpValue::Resource(resource_id, position)
+        let resource_id = self.0.allocate();
+        OpValue::Resource(resource_id)
     }
 
     fn allocate_copyable(&mut self) -> OpValue {
@@ -479,7 +481,11 @@ pub(crate) mod tests {
     use hugr::HugrView;
 
     use super::{OpValue, ResourceScope};
-    use crate::resource::{Position, ResourceId};
+    use crate::{
+        resource::{Position, ResourceId},
+        utils::build_simple_circuit,
+        TketOp,
+    };
 
     pub type PathEl<N> = (Position, N, Port);
 
@@ -496,10 +502,11 @@ pub(crate) mod tests {
             let mut resource_paths: BTreeMap<ResourceId, Vec<PathEl<H::Node>>> = BTreeMap::new();
             let mut copyable_values = HashSet::new();
 
-            for (&node, port_map) in &scope.op_values {
-                for (port, &op_value) in port_map.iter() {
+            for (&node, op_values) in &scope.op_values {
+                let pos = op_values.position;
+                for (port, &op_value) in op_values.port_map.iter() {
                     match op_value {
-                        OpValue::Resource(res, pos) => resource_paths
+                        OpValue::Resource(res) => resource_paths
                             .entry(res)
                             .or_default()
                             .push((pos, node, port)),
@@ -546,6 +553,42 @@ pub(crate) mod tests {
                 writeln!(f)?;
             }
             Ok(())
+        }
+    }
+
+    #[test]
+    fn test_position_monotonic() {
+        const N_HADAMARDS: [usize; 3] = [4, 10, 1];
+        // A circuit with 3 qubits and a certain number of H on each qubit
+        let circ = build_simple_circuit(3, |circ| {
+            for (qb, n_hadamards) in N_HADAMARDS.iter().enumerate() {
+                for _ in 0..*n_hadamards {
+                    circ.append(TketOp::H, [qb])?;
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        let scope = ResourceScope::from(&circ);
+        let first_hadamards = circ
+            .hugr()
+            .all_linked_inputs(circ.input_node())
+            .map(|(n, _)| n);
+
+        for h in first_hadamards {
+            let res = scope
+                .get_all_resources(h)
+                .into_iter()
+                .exactly_one()
+                .unwrap();
+            let nodes_on_path = scope.resource_path_iter(res, h, Direction::Outgoing);
+            let pos_on_path = nodes_on_path.map(|n| scope.get_position(n).unwrap());
+
+            assert!(
+                pos_on_path.collect_vec().windows(2).all(|w| w[0] <= w[1]),
+                "position is not monotonically increasing on path {res:?}"
+            );
         }
     }
 }

--- a/tket/src/resource/scope.rs
+++ b/tket/src/resource/scope.rs
@@ -202,6 +202,11 @@ impl<H: HugrView> ResourceScope<H> {
             Some(mem::replace(&mut curr_node, next_node))
         })
     }
+
+    /// Check if the given node is in the subgraph.
+    pub fn contains_node(&self, node: H::Node) -> bool {
+        self.subgraph.nodes().contains(&node)
+    }
 }
 
 impl<'h, H: HugrView> ResourceScope<&'h H> {

--- a/tket/src/resource/types.rs
+++ b/tket/src/resource/types.rs
@@ -83,8 +83,8 @@ impl Position {
 /// value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OpValue {
-    /// A linear resource with its position along the resource path.
-    Resource(ResourceId, Position),
+    /// A linear resource.
+    Resource(ResourceId),
     /// A copyable value.
     Copyable(CopyableValueId),
 }
@@ -92,26 +92,26 @@ pub enum OpValue {
 impl OpValue {
     /// Returns true if this is a resource value.
     pub fn is_resource(&self) -> bool {
-        matches!(self, OpValue::Resource(_, _))
+        matches!(self, OpValue::Resource(..))
     }
 
     /// Returns true if this is a copyable value.
     pub fn is_copyable(&self) -> bool {
-        matches!(self, OpValue::Copyable(_))
+        matches!(self, OpValue::Copyable(..))
     }
 
     /// Extract the ResourceId and Position if this is a resource.
-    pub fn as_resource(&self) -> Option<(ResourceId, Position)> {
+    pub fn as_resource(&self) -> Option<ResourceId> {
         match self {
-            OpValue::Resource(id, pos) => Some((*id, *pos)),
-            OpValue::Copyable(_) => None,
+            OpValue::Resource(id) => Some(*id),
+            OpValue::Copyable(..) => None,
         }
     }
 
     /// Extract the CopyableValueId if this is a copyable value.
     pub fn as_copyable(&self) -> Option<CopyableValueId> {
         match self {
-            OpValue::Resource(_, _) => None,
+            OpValue::Resource(..) => None,
             OpValue::Copyable(id) => Some(*id),
         }
     }
@@ -194,18 +194,11 @@ impl<T> PortMap<T> {
     }
 }
 
-pub(super) type ResourceMap<T> = Vec<T>;
-
 /// Allocator for ResourceIds that ensures they are assigned in increasing
 /// order.
 #[derive(Debug, Clone)]
 pub struct ResourceAllocator {
     next_id: usize,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct PositionAllocator {
-    next_pos: i64,
 }
 
 impl ResourceAllocator {
@@ -225,13 +218,5 @@ impl ResourceAllocator {
 impl Default for ResourceAllocator {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl PositionAllocator {
-    pub fn allocate(&mut self) -> Position {
-        let pos = Position::new_integer(self.next_pos);
-        self.next_pos += 1;
-        pos
     }
 }

--- a/tket/src/rewrite/strategy.rs
+++ b/tket/src/rewrite/strategy.rs
@@ -516,7 +516,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "reason: subcircuit to subgraph conversion is not implemented"]
     fn test_greedy_strategy() {
         let mut circ = n_cx(10);
         let cx_gates = circ.commands().map(|cmd| cmd.node()).collect_vec();
@@ -546,7 +545,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "reason: subcircuit to subgraph conversion is not implemented"]
     fn test_exhaustive_default_strategy() {
         let mut circ = n_cx(10);
         let cx_gates = circ.commands().map(|cmd| cmd.node()).collect_vec();
@@ -584,7 +582,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "reason: subcircuit to subgraph conversion is not implemented"]
     fn test_exhaustive_gamma_strategy() {
         let circ = n_cx(10);
         let cx_gates = circ.commands().map(|cmd| cmd.node()).collect_vec();

--- a/tket/src/subcircuit.rs
+++ b/tket/src/subcircuit.rs
@@ -179,23 +179,23 @@ impl<N: HugrNode> Subcircuit<N> {
     }
 
     /// Nodes in the subcircuit.
-    pub fn nodes(&self, circuit: &ResourceScope<impl HugrView<Node = N>>) -> Vec<N> {
-        let mut nodes = self
+    pub fn nodes<'a>(
+        &'a self,
+        circuit: &'a ResourceScope<impl HugrView<Node = N>>,
+    ) -> impl Iterator<Item = N> + 'a {
+        let paths = self
             .intervals
             .iter()
-            .flat_map(|interval| circuit.nodes_in_interval(*interval))
-            .collect_vec();
+            .map(|interval| circuit.nodes_in_interval(*interval));
 
-        nodes.sort_unstable();
-        nodes.dedup();
-        nodes.shrink_to_fit();
-
-        nodes
+        paths
+            .kmerge_by(|&a, &b| (circuit.get_position(a), a) < (circuit.get_position(b), b))
+            .dedup()
     }
 
     /// Number of nodes in the subcircuit.
     pub fn node_count(&self, circuit: &ResourceScope<impl HugrView<Node = N>>) -> usize {
-        self.nodes(circuit).len()
+        self.nodes(circuit).count()
     }
 
     /// Whether the subcircuit is empty.
@@ -285,9 +285,9 @@ fn update_intervals<N: HugrNode>(
         let (interval, num_nodes) = intervals
             .entry(res)
             .or_insert_with(|| (Interval::singleton(res, node, circuit), 0));
-        let Some(pos) = circuit.get_position(node, res) else {
-            panic!("node {node:?} is not on resource path {res:?}");
-        };
+        let pos = circuit
+            .get_position(node)
+            .expect("node is not on resource path");
         interval.include_node(node, pos);
         *num_nodes += 1;
     }
@@ -441,7 +441,7 @@ mod tests {
         if should_succeed {
             assert!(result.is_ok(), "Expected success for case: {description}");
             let subcircuit = result.unwrap();
-            assert_eq!(subcircuit.nodes(&scope), nodes);
+            assert_eq!(subcircuit.nodes(&scope).collect_vec(), nodes);
         } else {
             assert!(result.is_err(), "Expected failure for case: {description}");
         }
@@ -475,7 +475,7 @@ mod tests {
         if should_succeed {
             assert!(result.is_ok());
             let subcircuit = result.unwrap();
-            assert_eq!(subcircuit.nodes(&scope), selected_nodes);
+            assert_eq!(subcircuit.nodes(&scope).collect_vec(), selected_nodes);
             assert_eq!(
                 subcircuit.input_resources.len(),
                 expected_input_resources,

--- a/tket/src/subcircuit.rs
+++ b/tket/src/subcircuit.rs
@@ -230,9 +230,14 @@ impl<N: HugrNode> Subcircuit<N> {
     /// Convert the subcircuit to a [`SiblingSubgraph`].
     pub fn try_to_subgraph(
         &self,
-        _circuit: &ResourceScope<impl HugrView<Node = N>>,
+        circuit: &ResourceScope<impl HugrView<Node = N>>,
     ) -> Result<SiblingSubgraph<N>, InvalidSubgraph<N>> {
-        todo!()
+        if !circuit.is_convex(self.clone()) {
+            return Err(InvalidSubgraph::NotConvex);
+        }
+
+        // TODO(performance): this checks convexity again and is very inefficient
+        SiblingSubgraph::try_from_nodes(self.nodes(circuit).collect_vec(), circuit.hugr())
     }
 
     /// Create a rewrite rule to replace the subcircuit with a new circuit.


### PR DESCRIPTION
I'll put this as draft for the time being, given that it is already stacked on top of other two PRs.

Does what the title says: using `ResourceScope`'s resource path tracking, we can check convexity of subcircuits very efficiently. Heavily inspired by portgraph's `LineConvexChecker`, see https://github.com/CQCL/portgraph/pull/240.

As is, the conversion `Subcircuit` -> `SiblingSubgraph` is correct but unnecessarily slow: at construction time, hugr will check convexity of the subgraph again. My plan is to open a PR in hugr that allows us to bypass convexity checks and use that here in place of `SiblingSubgraph::try_new`.