### PR TITLE
feat(qsystem): native gateset decomposition improvements

### DIFF
--- a/tket-qsystem/src/extension/qsystem.rs
+++ b/tket-qsystem/src/extension/qsystem.rs
@@ -410,13 +410,9 @@ pub trait QSystemOpBuilder: Dataflow + UnwrapBuilder + ArrayOpBuilder {
 
     /// Build a CZ gate in terms of QSystem primitives.
     fn build_cz(&mut self, a: Wire, b: Wire) -> Result<[Wire; 2], BuildError> {
-        let pi = pi_mul_f64(self, 1.0);
         let pi_2 = pi_mul_f64(self, 0.5);
-        let pi_minus_2 = pi_mul_f64(self, -0.5);
 
-        let a = self.add_phased_x(a, pi, pi_2)?;
         let [a, b] = self.build_zz_max(a, b)?;
-        let a = self.add_phased_x(a, pi, pi_minus_2)?;
         let b = self.add_rz(b, pi_2)?;
         let a = self.add_rz(a, pi_2)?;
 


### PR DESCRIPTION
1. Fix CY decomposition Closes #1058

Found using
```python
from pytket import Circuit, OpType
from pytket.passes import AutoSquash


c = Circuit(2).CY(0, 1)
AutoRebase({OpType.PhasedX, OpType.Rz, OpType.ZZPhase}).apply(c)
AutoSquash({OpType.PhasedX, OpType.Rz}).apply(c)
```

```
[PhasedX(3, 1) q[0]; PhasedX(1.5, 1) q[1]; ZZPhase(0.5) q[0], q[1]; PhasedX(3, 0.5) q[0]; PhasedX(3.5, 1.5) q[1]; Rz(3.5) q[0]; Rz(2.5) q[1]; ]
```

2. Remove unnecessary PhasedX in build_cz

BEGIN_COMMIT_OVERRIDE
fix(qsystem): correct CY decomposition to hardware gateset

feat(qsystem): remove unecessary phasedx wrappers in CZ
END_COMMIT_OVERRIDE