### PR TITLE
fix!: Fix rotation -> float param type conversion

### DIFF
--- a/tket-py/src/ops.rs
+++ b/tket-py/src/ops.rs
@@ -217,7 +217,7 @@ impl PyPauliIter {
 //
 // TODO: These can no longer be constructed from Python. Since `hugr-rs 0.14`
 // we need an extension and `OpDef` to defines these.
-// If fixing this, make sure to fix `PyHugrType` too.
+// When fixing this, make sure to fix `PyHugrType` too.
 #[pyclass]
 #[pyo3(name = "CustomOp")]
 #[repr(transparent)]

--- a/tket-qsystem/src/pytket/qsystem.rs
+++ b/tket-qsystem/src/pytket/qsystem.rs
@@ -6,10 +6,11 @@ use hugr::extension::simple_op::MakeExtensionOp;
 use hugr::extension::ExtensionId;
 use hugr::ops::ExtensionOp;
 use hugr::HugrView;
+use itertools::Itertools as _;
 use tket::serialize::pytket::decoder::{
-    DecodeStatus, LoadedParameter, PytketDecoderContext, TrackedBit, TrackedQubit,
+    DecodeStatus, LoadedParameter, ParameterType, PytketDecoderContext, TrackedBit, TrackedQubit,
 };
-use tket::serialize::pytket::encoder::EncodeStatus;
+use tket::serialize::pytket::encoder::{make_tk1_operation, EncodeStatus};
 use tket::serialize::pytket::extension::PytketDecoder;
 use tket::serialize::pytket::{
     PytketDecodeError, PytketEmitter, PytketEncodeError, PytketEncoderContext,
@@ -83,8 +84,23 @@ impl QSystemEmitter {
             }
         };
 
+        // We have to convert the parameters expressions (in half-turns) to radians.
+
         // Most operations map directly to a pytket one.
-        encoder.emit_node(serial_op, node, circ)?;
+        encoder.emit_node_command(
+            node,
+            circ,
+            |_| Vec::new(),
+            move |mut inputs| {
+                for param in inputs.params.to_mut() {
+                    *param = match param.strip_suffix(") * (pi)") {
+                        Some(s) if s.starts_with("(") => s[1..].to_string(),
+                        _ => format!("{param} / (pi)"),
+                    };
+                }
+                make_tk1_operation(serial_op, inputs)
+            },
+        )?;
 
         Ok(EncodeStatus::Success)
     }
@@ -126,7 +142,8 @@ impl PytketDecoder for QSystemEmitter {
             PytketOptype::ZZPhase => QSystemOp::ZZPhase,
             PytketOptype::ZZMax => {
                 // This is a ZZPhase with a 1/2 angle.
-                let param = decoder.load_parameter("pi/2");
+                let param =
+                    Arc::new(decoder.load_parameter_with_type("pi/2", ParameterType::FloatRadians));
                 decoder.add_node_with_wires(QSystemOp::ZZPhase, qubits, bits, &[param])?;
                 return Ok(DecodeStatus::Success);
             }
@@ -134,7 +151,14 @@ impl PytketDecoder for QSystemEmitter {
                 return Ok(DecodeStatus::Unsupported);
             }
         };
-        decoder.add_node_with_wires(op, qubits, bits, params)?;
+
+        // We expect all parameters to be floats in radians.
+        let params = params
+            .iter()
+            .map(|p| Arc::new(p.as_float_radians(&mut decoder.builder)))
+            .collect_vec();
+
+        decoder.add_node_with_wires(op, qubits, bits, &params)?;
 
         Ok(DecodeStatus::Success)
     }

--- a/tket-qsystem/src/pytket/qsystem.rs
+++ b/tket-qsystem/src/pytket/qsystem.rs
@@ -84,9 +84,8 @@ impl QSystemEmitter {
             }
         };
 
-        // We have to convert the parameters expressions (in half-turns) to radians.
-
-        // Most operations map directly to a pytket one.
+        // pytket parameters are always in half-turns.
+        // Since the `tket.qsystem` op inputs are in radians, we have to convert them here.
         encoder.emit_node_command(
             node,
             circ,

--- a/tket-qsystem/src/pytket/tests.rs
+++ b/tket-qsystem/src/pytket/tests.rs
@@ -128,7 +128,7 @@ fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
         let count_b = b_command_count.get(a).copied().unwrap_or_default();
         assert_eq!(
             count_a, count_b,
-            "command {a:?} appears {count_a} times in rhs and {count_b} times in lhs"
+            "command {a:?} appears {count_a} times in rhs and {count_b} times in lhs.\ncounts for a: {a_command_count:#?}\ncounts for b: {b_command_count:#?}"
         );
     }
     assert_eq!(a_command_count.len(), b_command_count.len());

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -612,7 +612,6 @@ impl<'h> PytketDecoderContext<'h> {
     pub fn load_parameter_with_type(&mut self, param: &str, typ: ParameterType) -> LoadedParameter {
         self.wire_tracker
             .load_parameter(&mut self.builder, param, Some(typ))
-            .with_type(typ, &mut self.builder)
     }
 }
 

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -426,8 +426,7 @@ impl<'h> PytketDecoderContext<'h> {
     /// The caller must take care of converting the parameter wires to the
     /// required types and units expected by the operation. An error will be
     /// returned if the parameter does not match the expected wire type, but the
-    /// [`ParameterUnit`] (radians or half-turns) cannot be checked
-    /// automatically.
+    /// unit (radians or half-turns) cannot be checked automatically.
     ///
     /// # Arguments
     ///

--- a/tket/src/serialize/pytket/decoder/param.rs
+++ b/tket/src/serialize/pytket/decoder/param.rs
@@ -12,32 +12,26 @@ use hugr::{Hugr, Wire};
 
 use crate::extension::rotation::{rotation_type, RotationOp};
 
-/// The type of a loaded parameter in the Hugr.
+/// The type of a loaded parameter in the Hugr, including its unit.
 #[derive(Debug, derive_more::Display, Clone, Copy, Hash, PartialEq, Eq)]
-pub enum LoadedParameterType {
-    /// A float parameter.
-    Float,
-    /// A rotation parameter.
+pub enum ParameterType {
+    /// A float parameter in radians.
+    FloatRadians,
+    /// A float parameter in half-turns.
+    FloatHalfTurns,
+    /// A rotation parameter in half-turns.
     Rotation,
 }
 
-impl LoadedParameterType {
+impl ParameterType {
     /// Returns the type of the parameter.
-    pub fn from_type(typ: &Type) -> Option<Self> {
-        if typ == &float64_type() {
-            Some(LoadedParameterType::Float)
-        } else if typ == &rotation_type() {
-            Some(LoadedParameterType::Rotation)
-        } else {
-            None
-        }
-    }
-
-    /// Returns the type of the parameter.
-    pub fn to_type(&self) -> Type {
+    pub fn to_type(&self) -> &'static Type {
+        static FLOAT_TYPE: LazyLock<Type> = LazyLock::new(float64_type);
+        static ROTATION_TYPE: LazyLock<Type> = LazyLock::new(rotation_type);
         match self {
-            LoadedParameterType::Float => float64_type(),
-            LoadedParameterType::Rotation => rotation_type(),
+            ParameterType::FloatRadians => &FLOAT_TYPE,
+            ParameterType::FloatHalfTurns => &FLOAT_TYPE,
+            ParameterType::Rotation => &ROTATION_TYPE,
         }
     }
 }
@@ -49,36 +43,60 @@ impl LoadedParameterType {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct LoadedParameter {
     /// The type of the parameter.
-    pub typ: LoadedParameterType,
+    typ: ParameterType,
     /// The wire where the parameter is loaded.
-    pub wire: Wire,
+    wire: Wire,
 }
 
 impl LoadedParameter {
-    /// Returns a `LoadedParameter` for a float param.
-    pub fn float(wire: Wire) -> LoadedParameter {
+    /// Returns a `LoadedParameter` with the given type and unit.
+    pub fn new(typ: ParameterType, wire: Wire) -> LoadedParameter {
+        LoadedParameter { typ, wire }
+    }
+
+    /// Returns the type of the parameter.
+    #[inline]
+    pub fn typ(&self) -> ParameterType {
+        self.typ
+    }
+
+    /// Returns the wire where the parameter is loaded.
+    #[inline]
+    pub fn wire(&self) -> Wire {
+        self.wire
+    }
+
+    /// Returns a `LoadedParameter` for a float param in radians.
+    #[inline]
+    pub fn float_radians(wire: Wire) -> LoadedParameter {
         LoadedParameter {
-            typ: LoadedParameterType::Float,
+            typ: ParameterType::FloatRadians,
             wire,
         }
     }
 
-    /// Returns a `LoadedParameter` for a rotation param.
+    /// Returns a `LoadedParameter` for a float param in half-turns.
+    #[inline]
+    pub fn float_half_turns(wire: Wire) -> LoadedParameter {
+        LoadedParameter {
+            typ: ParameterType::FloatHalfTurns,
+            wire,
+        }
+    }
+
+    /// Returns a `LoadedParameter` for a rotation param in half-turns.
+    #[inline]
     pub fn rotation(wire: Wire) -> LoadedParameter {
         LoadedParameter {
-            typ: LoadedParameterType::Rotation,
+            typ: ParameterType::Rotation,
             wire,
         }
     }
 
     /// Returns the hugr type for the parameter.
-    pub fn wire_type(&self) -> &Type {
-        static FLOAT_TYPE: LazyLock<Type> = LazyLock::new(float64_type);
-        static ROTATION_TYPE: LazyLock<Type> = LazyLock::new(rotation_type);
-        match self.typ {
-            LoadedParameterType::Float => &FLOAT_TYPE,
-            LoadedParameterType::Rotation => &ROTATION_TYPE,
-        }
+    #[inline]
+    pub fn wire_type(&self) -> &'static Type {
+        self.typ.to_type()
     }
 
     /// Convert the parameter into a given type, if necessary.
@@ -87,60 +105,84 @@ impl LoadedParameter {
     ///
     /// See [`LoadedParameter::as_float`] and [`LoadedParameter::as_rotation`]
     /// for more convenient methods.
+    #[inline]
     pub fn with_type<H: AsRef<Hugr> + AsMut<Hugr>>(
         &self,
-        typ: LoadedParameterType,
+        typ: ParameterType,
         hugr: &mut FunctionBuilder<H>,
     ) -> LoadedParameter {
-        match (self.typ, typ) {
-            (LoadedParameterType::Float, LoadedParameterType::Rotation) => {
+        match typ {
+            ParameterType::FloatRadians => self.as_float_radians(hugr),
+            ParameterType::FloatHalfTurns => self.as_float_half_turns(hugr),
+            ParameterType::Rotation => self.as_rotation(hugr),
+        }
+    }
+
+    /// Convert the parameter into a float in radians.
+    ///
+    /// Adds the necessary operations to the Hugr and returns a new wire.
+    pub fn as_float_radians<H: AsRef<Hugr> + AsMut<Hugr>>(
+        &self,
+        hugr: &mut FunctionBuilder<H>,
+    ) -> LoadedParameter {
+        match self.typ {
+            ParameterType::FloatRadians => *self,
+            ParameterType::FloatHalfTurns => {
+                let pi = hugr.add_load_const(Value::from(ConstF64::new(std::f64::consts::PI)));
+                let float_radians = hugr
+                    .add_dataflow_op(FloatOps::fmul, [self.wire(), pi])
+                    .expect("Error converting float to rotation")
+                    .out_wire(0);
+                LoadedParameter::float_radians(float_radians)
+            }
+            ParameterType::Rotation => self.as_float_half_turns(hugr).as_float_radians(hugr),
+        }
+    }
+
+    /// Convert the parameter into a float in half-turns.
+    ///
+    /// Adds the necessary operations to the Hugr and returns a new wire.
+    pub fn as_float_half_turns<H: AsRef<Hugr> + AsMut<Hugr>>(
+        &self,
+        hugr: &mut FunctionBuilder<H>,
+    ) -> LoadedParameter {
+        match self.typ {
+            ParameterType::FloatHalfTurns => *self,
+            ParameterType::FloatRadians => {
                 let pi = hugr.add_load_const(Value::from(ConstF64::new(std::f64::consts::PI)));
                 let float_halfturns = hugr
                     .add_dataflow_op(FloatOps::fdiv, [self.wire, pi])
                     .expect("Error converting float to rotation")
                     .out_wire(0);
+                LoadedParameter::float_half_turns(float_halfturns)
+            }
+            ParameterType::Rotation => {
                 let wire = hugr
-                    .add_dataflow_op(RotationOp::from_halfturns_unchecked, [float_halfturns])
+                    .add_dataflow_op(RotationOp::to_halfturns, [self.wire()])
                     .unwrap()
                     .out_wire(0);
-                LoadedParameter::rotation(wire)
-            }
-            (LoadedParameterType::Rotation, LoadedParameterType::Float) => {
-                let float_halfturns = hugr
-                    .add_dataflow_op(RotationOp::to_halfturns, [self.wire])
-                    .unwrap()
-                    .out_wire(0);
-                let pi = hugr.add_load_const(Value::from(ConstF64::new(std::f64::consts::PI)));
-                let float = hugr
-                    .add_dataflow_op(FloatOps::fmul, [float_halfturns, pi])
-                    .expect("Error converting rotation to float")
-                    .out_wire(0);
-                LoadedParameter::float(float)
-            }
-            _ => {
-                debug_assert_eq!(self.typ, typ, "cannot convert {} to {}", self.typ, typ);
-                *self
+                LoadedParameter::float_half_turns(wire)
             }
         }
     }
 
-    /// Convert the parameter into a float, if necessary.
-    ///
-    /// Adds the necessary operations to the Hugr and returns a new wire.
-    pub fn as_float<H: AsRef<Hugr> + AsMut<Hugr>>(
-        &self,
-        hugr: &mut FunctionBuilder<H>,
-    ) -> LoadedParameter {
-        self.with_type(LoadedParameterType::Float, hugr)
-    }
-
-    /// Convert the parameter into a rotation, if necessary.
+    /// Convert the parameter into a rotation in half-turns.
     ///
     /// Adds the necessary operations to the Hugr and returns a new wire.
     pub fn as_rotation<H: AsRef<Hugr> + AsMut<Hugr>>(
         &self,
         hugr: &mut FunctionBuilder<H>,
     ) -> LoadedParameter {
-        self.with_type(LoadedParameterType::Rotation, hugr)
+        match self.typ {
+            ParameterType::Rotation => *self,
+            ParameterType::FloatHalfTurns => {
+                let wire = hugr
+                    .add_dataflow_op(RotationOp::from_halfturns_unchecked, [self.wire()])
+                    .unwrap()
+                    .out_wire(0);
+                LoadedParameter::rotation(wire)
+            }
+            ParameterType::FloatRadians => self.as_float_half_turns(hugr).as_rotation(hugr),
+        }
     }
 }

--- a/tket/src/serialize/pytket/decoder/param.rs
+++ b/tket/src/serialize/pytket/decoder/param.rs
@@ -103,8 +103,9 @@ impl LoadedParameter {
     ///
     /// Adds the necessary operations to the Hugr and returns a new wire.
     ///
-    /// See [`LoadedParameter::as_float`] and [`LoadedParameter::as_rotation`]
-    /// for more convenient methods.
+    /// See [`LoadedParameter::as_rotation`],
+    /// [`LoadedParameter::as_float_radians`] and
+    /// [`LoadedParameter::as_float_half_turns`] for more convenient methods.
     #[inline]
     pub fn with_type<H: AsRef<Hugr> + AsMut<Hugr>>(
         &self,

--- a/tket/src/serialize/pytket/decoder/param/parser.rs
+++ b/tket/src/serialize/pytket/decoder/param/parser.rs
@@ -12,6 +12,7 @@ use pest::Parser;
 use pest_derive::Parser;
 
 use crate::extension::rotation::RotationOp;
+use crate::serialize::pytket::decoder::ParameterType;
 
 /// The parsed AST for a pytket operation parameter.
 ///
@@ -37,8 +38,12 @@ pub enum PytketParam<'a> {
     /// An operation on some nested expressions.
     #[display("{}({})", op.to_string(), args.iter().map(|a| a.to_string()).join(", "))]
     Operation {
+        /// The HUGR operation used to implement this node.
         op: OpType,
+        /// Input arguments to the operation.
         args: Vec<PytketParam<'a>>,
+        /// The parameter types used for the inputs and outputs of this operation.
+        param_ty: ParameterType,
     },
 }
 
@@ -82,20 +87,23 @@ lazy_static::lazy_static! {
 ///
 /// This takes a sequence of rule matches alternating [`Rule::term`]s and infix operations.
 fn parse_infix_ops(pairs: Pairs<'_, Rule>) -> PytketParam<'_> {
+    use ParameterType::*;
+
     PRATT_PARSER
         .map_primary(|primary| parse_term(primary))
         .map_infix(|lhs, op, rhs| {
-            let op = match op.as_rule() {
-                Rule::add => RotationOp::radd.into(),
-                Rule::subtract => FloatOps::fsub.into(),
-                Rule::multiply => FloatOps::fmul.into(),
-                Rule::divide => FloatOps::fdiv.into(),
-                Rule::power => FloatOps::fpow.into(),
+            let (op, param_ty) = match op.as_rule() {
+                Rule::add => (RotationOp::radd.into(), Rotation),
+                Rule::subtract => (FloatOps::fsub.into(), FloatHalfTurns),
+                Rule::multiply => (FloatOps::fmul.into(), FloatHalfTurns),
+                Rule::divide => (FloatOps::fdiv.into(), FloatHalfTurns),
+                Rule::power => (FloatOps::fpow.into(), FloatHalfTurns),
                 rule => unreachable!("Expr::parse expected infix operation, found {:?}", rule),
             };
             PytketParam::Operation {
                 op,
                 args: vec![lhs, rhs],
+                param_ty,
             }
         })
         .parse(pairs)
@@ -103,6 +111,8 @@ fn parse_infix_ops(pairs: Pairs<'_, Rule>) -> PytketParam<'_> {
 
 /// Parse a match of the silent [`Rule::term`] rule.
 fn parse_term(pair: Pair<'_, Rule>) -> PytketParam<'_> {
+    use ParameterType::*;
+
     match pair.as_rule() {
         Rule::expr => parse_infix_ops(pair.into_inner()),
         Rule::implicit_multiply => {
@@ -112,12 +122,14 @@ fn parse_term(pair: Pair<'_, Rule>) -> PytketParam<'_> {
             PytketParam::Operation {
                 op: FloatOps::fmul.into(),
                 args: vec![lhs, rhs],
+                param_ty: FloatHalfTurns,
             }
         }
         Rule::num => parse_number(pair),
         Rule::unary_minus => PytketParam::Operation {
             op: FloatOps::fneg.into(),
             args: vec![parse_term(pair.into_inner().next().unwrap())],
+            param_ty: FloatHalfTurns,
         },
         Rule::function_call => parse_function_call(pair),
         Rule::ident => PytketParam::InputVariable {
@@ -157,7 +169,11 @@ fn parse_function_call(pair: Pair<'_, Rule>) -> PytketParam<'_> {
     };
 
     let args = args.map(|arg| parse_term(arg)).collect::<Vec<_>>();
-    PytketParam::Operation { op, args }
+    PytketParam::Operation {
+        op,
+        args,
+        param_ty: ParameterType::FloatHalfTurns,
+    }
 }
 
 #[cfg(test)]
@@ -175,37 +191,45 @@ mod test {
     #[case::var("f64", PytketParam::InputVariable{name: "f64"})]
     #[case::add("42 + f64", PytketParam::Operation {
         op: RotationOp::radd.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}],
+        param_ty: ParameterType::Rotation,
     })]
     #[case::sub("42 - 2", PytketParam::Operation {
         op: FloatOps::fsub.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::Constant(2.)]
+        args: vec![PytketParam::Constant(42.), PytketParam::Constant(2.)],
+        param_ty: ParameterType::FloatHalfTurns,
     })]
     #[case::product_implicit("42 f64", PytketParam::Operation {
         op: FloatOps::fmul.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}],
+        param_ty: ParameterType::FloatHalfTurns,
     })]
     #[case::product_implicit2("42f64", PytketParam::Operation {
         op: FloatOps::fmul.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}],
+        param_ty: ParameterType::FloatHalfTurns,
     })]
     #[case::product_implicit3("42 e4", PytketParam::Operation {
         op: FloatOps::fmul.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "e4"}]
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "e4"}],
+        param_ty: ParameterType::FloatHalfTurns,
     })]
     #[case::max("max(42, f64)", PytketParam::Operation {
         op: FloatOps::fmax.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}]
+        args: vec![PytketParam::Constant(42.), PytketParam::InputVariable{name: "f64"}],
+        param_ty: ParameterType::FloatHalfTurns,
     })]
     #[case::minus("-f64", PytketParam::Operation {
         op: FloatOps::fneg.into(),
-        args: vec![PytketParam::InputVariable{name: "f64"}]
+        args: vec![PytketParam::InputVariable{name: "f64"}],
+        param_ty: ParameterType::FloatHalfTurns,
     })]
     #[case::unknown("unknown_op(42, f64)", PytketParam::Sympy("unknown_op(42, f64)"))]
     #[case::unknown_no_params("unknown_op()", PytketParam::Sympy("unknown_op()"))]
     #[case::nested("max(42, unknown_op(37))", PytketParam::Operation {
         op: FloatOps::fmax.into(),
-        args: vec![PytketParam::Constant(42.), PytketParam::Sympy("unknown_op(37)")]
+        args: vec![PytketParam::Constant(42.), PytketParam::Sympy("unknown_op(37)")],
+        param_ty: ParameterType::FloatHalfTurns,
     })]
     #[case::precedence("5-2/3x+4**6", PytketParam::Operation {
         op: RotationOp::radd.into(),
@@ -214,33 +238,50 @@ mod test {
                 op: FloatOps::fsub.into(),
                 args: vec![
                     PytketParam::Constant(5.),
-                    PytketParam::Operation { op: FloatOps::fdiv.into(), args: vec![
-                        PytketParam::Constant(2.),
-                        PytketParam::Operation { op: FloatOps::fmul.into(), args: vec![
-                            PytketParam::Constant(3.),
-                            PytketParam::InputVariable{name: "x"},
-                        ]}
-                    ]}
-                ]
+                    PytketParam::Operation {
+                        op: FloatOps::fdiv.into(),
+                        args: vec![
+                            PytketParam::Constant(2.),
+                            PytketParam::Operation {
+                                op: FloatOps::fmul.into(),
+                                args: vec![
+                                    PytketParam::Constant(3.),
+                                    PytketParam::InputVariable{name: "x"},
+                                ],
+                                param_ty: ParameterType::FloatHalfTurns,
+                            },
+                        ],
+                        param_ty: ParameterType::FloatHalfTurns,
+                    },
+                ],
+                param_ty: ParameterType::FloatHalfTurns,
             },
-            PytketParam::Operation { op: FloatOps::fpow.into(), args: vec![
-                PytketParam::Constant(4.),
-                PytketParam::Constant(6.),
-            ]}
-        ]
+            PytketParam::Operation {
+                op: FloatOps::fpow.into(),
+                args: vec![PytketParam::Constant(4.), PytketParam::Constant(6.)],
+                param_ty: ParameterType::FloatHalfTurns,
+            },
+        ],
+        param_ty: ParameterType::Rotation,
     })]
     #[case::associativity("1-2-3+4", PytketParam::Operation {
         op: RotationOp::radd.into(),
         args: vec![
-            PytketParam::Operation { op: FloatOps::fsub.into(), args: vec![
-                PytketParam::Operation { op: FloatOps::fsub.into(), args: vec![
-                    PytketParam::Constant(1.),
-                    PytketParam::Constant(2.),
-                ]},
-                PytketParam::Constant(3.),
-            ]},
+            PytketParam::Operation {
+                op: FloatOps::fsub.into(),
+                args: vec![
+                    PytketParam::Operation {
+                        op: FloatOps::fsub.into(),
+                        args: vec![PytketParam::Constant(1.), PytketParam::Constant(2.)],
+                        param_ty: ParameterType::FloatHalfTurns,
+                    },
+                    PytketParam::Constant(3.),
+                ],
+                param_ty: ParameterType::FloatHalfTurns,
+            },
             PytketParam::Constant(4.),
-        ]
+        ],
+        param_ty: ParameterType::Rotation,
     })]
     fn parse_param(#[case] param: &str, #[case] expected: PytketParam) {
         let parsed = parse_pytket_param(param);

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -4,8 +4,8 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use hugr::builder::{Dataflow as _, FunctionBuilder};
-use hugr::ops::{OpTrait, Value};
-use hugr::std_extensions::arithmetic::float_types::float64_type;
+use hugr::ops::Value;
+use hugr::std_extensions::arithmetic::float_types::{float64_type, ConstF64};
 use hugr::types::Type;
 use hugr::{Hugr, Wire};
 use indexmap::{IndexMap, IndexSet};
@@ -15,8 +15,8 @@ use tket_json_rs::register::ElementId as PytketRegister;
 use crate::extension::rotation::{rotation_type, ConstRotation};
 use crate::serialize::pytket::decoder::param::parser::{parse_pytket_param, PytketParam};
 use crate::serialize::pytket::decoder::{
-    LoadedParameter, LoadedParameterType, PytketDecoderContext, TrackedBit, TrackedBitId,
-    TrackedQubit, TrackedQubitId,
+    LoadedParameter, ParameterType, PytketDecoderContext, TrackedBit, TrackedBitId, TrackedQubit,
+    TrackedQubitId,
 };
 use crate::serialize::pytket::extension::RegisterCount;
 use crate::serialize::pytket::{
@@ -191,7 +191,7 @@ impl TrackedWires {
     /// Return the tracked parameter wires in this tracked wires.
     #[inline]
     pub fn parameter_wires(&self) -> impl Iterator<Item = Wire> + Clone + '_ {
-        self.parameter_wires.iter().map(|p| p.wire)
+        self.parameter_wires.iter().map(|p| p.wire())
     }
 
     /// Returns the wires in this tracked wires.
@@ -326,7 +326,7 @@ pub(crate) struct WireTracker {
     bit_wires: IndexMap<TrackedBitId, Vec<Wire>>,
     /// An ordered set of parameters found in operation arguments, and added as
     /// new region inputs.
-    parameters: IndexMap<String, Arc<LoadedParameter>>,
+    parameters: IndexMap<String, LoadedParameter>,
     /// A list of input variables added to the hugr.
     ///
     /// Ordered according to their order in the function input.
@@ -623,80 +623,98 @@ impl WireTracker {
         })
     }
 
-    /// Loads the given parameter expression as a [`LoadedParameter`] in the hugr.
+    /// Loads the given parameter expression as a [`LoadedParameter`] in the
+    /// hugr.
     ///
-    /// - If the parameter is a known algebraic operation, adds the required op and recurses on its inputs.
-    /// - If the parameter is a constant, a constant definition is added to the Hugr.
-    /// - If the parameter is a variable, adds a new `rotation` input to the region.
-    /// - If the parameter is a sympy expressions, adds it as a [`SympyOpDef`][crate::extension::sympy::SympyOpDef] black box.
+    /// - If the parameter is a known algebraic operation, adds the required op
+    ///   and recurses on its inputs.
+    /// - If the parameter is a constant, a constant definition is added to the
+    ///   Hugr.
+    /// - If the parameter is a variable, adds a new `rotation` input to the
+    ///   region.
+    /// - If the parameter is a sympy expressions, adds it as a
+    ///   [`SympyOpDef`][crate::extension::sympy::SympyOpDef] black box.
+    ///
+    /// # Arguments
+    ///
+    /// * `hugr` - The hugr to load the parameters to.
+    /// * `param` - The parameter expression to load.
+    /// * `type_hint` - Try to load the parameter with the given type, if
+    ///   possible. The returned parameter is **not** guaranteed to have the
+    ///   requested type.
     pub fn load_parameter(
         &mut self,
         hugr: &mut FunctionBuilder<&mut Hugr>,
         param: &str,
-    ) -> Arc<LoadedParameter> {
+        type_hint: Option<ParameterType>,
+    ) -> LoadedParameter {
         fn process(
             hugr: &mut FunctionBuilder<&mut Hugr>,
-            input_params: &mut IndexMap<String, Arc<LoadedParameter>>,
+            input_params: &mut IndexMap<String, LoadedParameter>,
             param_vars: &mut IndexSet<String>,
             parsed: PytketParam,
             param: &str,
-        ) -> Arc<LoadedParameter> {
+            type_hint: Option<ParameterType>,
+        ) -> LoadedParameter {
             match parsed {
-                PytketParam::Constant(half_turns) => {
-                    let value: Value = ConstRotation::new(half_turns).unwrap().into();
-                    let wire = hugr.add_load_const(value);
-                    Arc::new(LoadedParameter::rotation(wire))
-                }
+                PytketParam::Constant(half_turns) => match type_hint {
+                    Some(ParameterType::FloatHalfTurns) => {
+                        let value: Value = ConstF64::new(half_turns).into();
+                        let wire = hugr.add_load_const(value);
+                        LoadedParameter::float_half_turns(wire)
+                    }
+                    _ => {
+                        let value: Value = ConstRotation::new(half_turns).unwrap().into();
+                        let wire = hugr.add_load_const(value);
+                        LoadedParameter::rotation(wire)
+                    }
+                },
                 PytketParam::Sympy(expr) => {
                     // store string in custom op.
                     let symb_op = symbolic_constant_op(expr.to_string());
                     let wire = hugr.add_dataflow_op(symb_op, []).unwrap().out_wire(0);
-                    Arc::new(LoadedParameter::rotation(wire))
+                    LoadedParameter::rotation(wire)
                 }
                 PytketParam::InputVariable { name } => {
-                    // Special case for the name "pi", inserts a `ConstRotation(PI)` instead.
-                    if name == "pi" {
-                        let value: Value = ConstRotation::new(std::f64::consts::PI).unwrap().into();
-                        let wire = hugr.add_load_const(value);
-                        return Arc::new(LoadedParameter::rotation(wire));
+                    // Special case for the name "pi": inserts a `ConstRotation(PI)` instead.
+                    match (name, type_hint) {
+                        ("pi", Some(ParameterType::FloatHalfTurns)) => {
+                            let value: Value = ConstF64::new(std::f64::consts::PI).into();
+                            let wire = hugr.add_load_const(value);
+                            LoadedParameter::float_half_turns(wire)
+                        }
+                        ("pi", _) => {
+                            let value: Value =
+                                ConstRotation::new(std::f64::consts::PI).unwrap().into();
+                            let wire = hugr.add_load_const(value);
+                            LoadedParameter::rotation(wire)
+                        }
+                        _ => {
+                            // Look it up in the input parameters to the circuit, and add a new float input if needed.
+                            *input_params.entry(name.to_string()).or_insert_with(|| {
+                                param_vars.insert(name.to_string());
+                                let wire = hugr.add_input(rotation_type());
+                                LoadedParameter::rotation(wire)
+                            })
+                        }
                     }
-                    // Look it up in the input parameters to the circuit, and add a new float input if needed.
-                    input_params
-                        .entry(name.to_string())
-                        .or_insert_with(|| {
-                            param_vars.insert(name.to_string());
-                            let wire = hugr.add_input(rotation_type());
-                            Arc::new(LoadedParameter::rotation(wire))
-                        })
-                        .clone()
                 }
-                PytketParam::Operation { op, args } => {
-                    let sig = op
-                        .dataflow_signature()
-                        .expect("Decoded a parameter operation with no signature");
+                PytketParam::Operation { op, args, param_ty } => {
                     // We assume all operations take float inputs.
                     let input_wires = args
                         .into_iter()
-                        .zip(sig.input_types())
-                        .map(|(arg, ty)| {
-                            let param = process(hugr, input_params, param_vars, arg, param);
-                            let expected_type = LoadedParameterType::from_type(ty)
-                                .expect("Invalid decoded op signature");
-                            param.with_type(expected_type, hugr).wire
+                        .map(|arg| {
+                            let param =
+                                process(hugr, input_params, param_vars, arg, param, Some(param_ty));
+                            param.with_type(param_ty, hugr).wire()
                         })
                         .collect_vec();
-                    let out_param_type =
-                        LoadedParameterType::from_type(sig.output_types().first().unwrap())
-                            .unwrap();
                     // If any of the following asserts panics, it means we added invalid ops to the sympy parser.
                     let res = hugr.add_dataflow_op(op, input_wires).unwrap_or_else(|e| {
                         panic!("Error while decoding pytket operation parameter \"{param}\". {e}",)
                     });
                     assert_eq!(res.num_value_outputs(), 1, "An operation decoded from the pytket op parameter \"{param}\" had {} outputs", res.num_value_outputs());
-                    Arc::new(LoadedParameter {
-                        typ: out_param_type,
-                        wire: res.out_wire(0),
-                    })
+                    LoadedParameter::new(param_ty, res.out_wire(0))
                 }
             }
         }
@@ -707,6 +725,7 @@ impl WireTracker {
             &mut self.parameter_vars,
             parse_pytket_param(param),
             param,
+            type_hint,
         )
     }
 
@@ -763,7 +782,7 @@ impl WireTracker {
             }
             .into());
         }
-        entry.insert_entry(Arc::new(LoadedParameter::rotation(wire)));
+        entry.insert_entry(LoadedParameter::rotation(wire));
         Ok(())
     }
 }

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -654,7 +654,7 @@ impl WireTracker {
                     Arc::new(LoadedParameter::rotation(wire))
                 }
                 PytketParam::InputVariable { name } => {
-                    // Special case for the name "pi", inserts a `ConstRotation(1.0)` instead.
+                    // Special case for the name "pi", inserts a `ConstRotation(PI)` instead.
                     if name == "pi" {
                         let value: Value = ConstRotation::new(std::f64::consts::PI).unwrap().into();
                         let wire = hugr.add_load_const(value);

--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -381,7 +381,7 @@ impl<H: HugrView> PytketEncoderContext<H> {
         let args = MakeOperationArgs {
             num_qubits: qubits.len(),
             num_bits: bits.len(),
-            params: &params,
+            params: Cow::Borrowed(&params),
         };
         let op = make_operation(args);
 
@@ -555,7 +555,7 @@ impl<H: HugrView> PytketEncoderContext<H> {
         let args = MakeOperationArgs {
             num_qubits: op_values.qubits.len(),
             num_bits: op_values.bits.len(),
-            params: &input_param_exprs,
+            params: Cow::Borrowed(&input_param_exprs),
         };
         let mut pytket_op = make_tk1_operation(tket_json_rs::OpType::Barrier, args);
         pytket_op.data = Some(payload);
@@ -941,14 +941,14 @@ pub struct OutputParamArgs<'a> {
 ///
 /// This can be passed to [`make_tk1_operation`] to create a pytket
 /// [`circuit_json::Operation`].
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct MakeOperationArgs<'a> {
     /// Number of input qubits.
     pub num_qubits: usize,
     /// Number of input bits.
     pub num_bits: usize,
     /// List of input parameter expressions.
-    pub params: &'a [String],
+    pub params: Cow<'a, [String]>,
 }
 
 /// Cached value for a function encoding.
@@ -983,7 +983,7 @@ pub fn make_tk1_operation(
     op.op_type = pytket_optype;
     op.n_qb = Some(inputs.num_qubits as u32);
     op.params = match inputs.params.is_empty() {
-        false => Some(inputs.params.to_owned()),
+        false => Some(inputs.params.into_owned()),
         true => None,
     };
     op.signature = Some(
@@ -1020,7 +1020,7 @@ pub fn make_tk1_classical_operation(
     let args = MakeOperationArgs {
         num_qubits: 0,
         num_bits: bit_count,
-        params: &[],
+        params: Cow::Borrowed(&[]),
     };
     let mut op = make_tk1_operation(pytket_optype, args);
     op.classical = Some(Box::new(classical));
@@ -1067,7 +1067,7 @@ pub fn make_tk1_classical_expression(
     let args = MakeOperationArgs {
         num_qubits: 0,
         num_bits: bit_count,
-        params: &[],
+        params: Cow::Borrowed(&[]),
     };
     let mut op = make_tk1_operation(tket_json_rs::OpType::ClExpr, args);
     op.classical_expr = Some(clexpr);

--- a/tket/src/serialize/pytket/extension.rs
+++ b/tket/src/serialize/pytket/extension.rs
@@ -123,6 +123,8 @@ pub trait PytketDecoder {
     ///
     /// `op` will always have one of the [`tket_json_rs::OpType`]s specified in
     /// [`PytketDecoder::op_types`].
+    //
+    // TODO: There's no need for `params` to be inside `Arc`s here. They are `Copy`.
     fn op_to_hugr<'h>(
         &self,
         op: &tket_json_rs::circuit_json::Operation,

--- a/tket/src/serialize/pytket/extension/bool.rs
+++ b/tket/src/serialize/pytket/extension/bool.rs
@@ -162,7 +162,12 @@ impl PytketDecoder for BoolEmitter {
             ClOp::BitXor => BoolOp::xor,
             _ => return Ok(DecodeStatus::Unsupported),
         };
-        decoder.add_node_with_wires(op, qubits, bits, params)?;
+
+        if !params.is_empty() {
+            return Ok(DecodeStatus::Unsupported);
+        }
+
+        decoder.add_node_with_wires(op, qubits, bits, &[])?;
 
         Ok(DecodeStatus::Success)
     }

--- a/tket/src/serialize/pytket/extension/float.rs
+++ b/tket/src/serialize/pytket/extension/float.rs
@@ -74,13 +74,13 @@ impl<H: HugrView> PytketEmitter<H> for FloatEmitter {
         // Special cases for pi rotations
         let approx_eq = |a: f64, b: f64| (a - b).abs() < 1e-10;
         const VALS: [(f64, &str); 7] = [
-            (PI, "1"),
-            (PI / 2., "1/2"),
-            (-PI / 2., "-1/2"),
-            (PI / 4., "1/4"),
-            (3. * PI / 4., "3/4"),
-            (-PI / 4., "-1/4"),
-            (-3. * PI / 4., "-3/4"),
+            (PI, "pi"),
+            (PI / 2., "pi/2"),
+            (-PI / 2., "-pi/2"),
+            (PI / 4., "pi/4"),
+            (3. * PI / 4., "3pi/4"),
+            (-PI / 4., "-pi/4"),
+            (-3. * PI / 4., "-3pi/4"),
         ];
         for (val, name) in VALS.iter() {
             if approx_eq(float, *val) {
@@ -89,7 +89,7 @@ impl<H: HugrView> PytketEmitter<H> for FloatEmitter {
             }
         }
 
-        let param = encoder.values.new_param(format!("({float}) / (pi)"));
+        let param = encoder.values.new_param(float.to_string());
         Ok(Some(TrackedValues::new_params([param])))
     }
 }

--- a/tket/src/serialize/pytket/extension/float.rs
+++ b/tket/src/serialize/pytket/extension/float.rs
@@ -126,9 +126,7 @@ impl FloatEmitter {
             FloatOps::fmin => format!("min({}, {})", inputs[0], inputs[1]),
             FloatOps::fabs => format!("abs({})", inputs[0]),
             FloatOps::fdiv => {
-                if inputs[0] == "1" {
-                    format!("({}) / ({})", inputs[0], inputs[1])
-                } else if inputs[1] == "1" {
+                if inputs[1] == "1" {
                     inputs[0].clone()
                 } else {
                     format!("({}) / ({})", inputs[0], inputs[1])

--- a/tket/src/serialize/pytket/extension/float.rs
+++ b/tket/src/serialize/pytket/extension/float.rs
@@ -74,13 +74,13 @@ impl<H: HugrView> PytketEmitter<H> for FloatEmitter {
         // Special cases for pi rotations
         let approx_eq = |a: f64, b: f64| (a - b).abs() < 1e-10;
         const VALS: [(f64, &str); 7] = [
-            (PI, "pi"),
-            (PI / 2., "pi/2"),
-            (-PI / 2., "-pi/2"),
-            (PI / 4., "pi/4"),
-            (3. * PI / 4., "3pi/4"),
-            (-PI / 4., "-pi/4"),
-            (-3. * PI / 4., "-3pi/4"),
+            (PI, "1"),
+            (PI / 2., "1/2"),
+            (-PI / 2., "-1/2"),
+            (PI / 4., "1/4"),
+            (3. * PI / 4., "3/4"),
+            (-PI / 4., "-1/4"),
+            (-3. * PI / 4., "-3/4"),
         ];
         for (val, name) in VALS.iter() {
             if approx_eq(float, *val) {
@@ -89,7 +89,7 @@ impl<H: HugrView> PytketEmitter<H> for FloatEmitter {
             }
         }
 
-        let param = encoder.values.new_param(float.to_string());
+        let param = encoder.values.new_param(format!("({float}) / (pi)"));
         Ok(Some(TrackedValues::new_params([param])))
     }
 }
@@ -118,8 +118,6 @@ impl FloatEmitter {
             FloatOps::fadd => format!("({}) + ({})", inputs[0], inputs[1]),
             FloatOps::fsub => format!("({}) - ({})", inputs[0], inputs[1]),
             FloatOps::fneg => format!("-({})", inputs[0]),
-            FloatOps::fmul => format!("({}) * ({})", inputs[0], inputs[1]),
-            FloatOps::fdiv => format!("({}) / ({})", inputs[0], inputs[1]),
             FloatOps::fpow => format!("({}) ** ({})", inputs[0], inputs[1]),
             FloatOps::ffloor => format!("floor({})", inputs[0]),
             FloatOps::fceil => format!("ceil({})", inputs[0]),
@@ -127,6 +125,24 @@ impl FloatEmitter {
             FloatOps::fmax => format!("max({}, {})", inputs[0], inputs[1]),
             FloatOps::fmin => format!("min({}, {})", inputs[0], inputs[1]),
             FloatOps::fabs => format!("abs({})", inputs[0]),
+            FloatOps::fdiv => {
+                if inputs[0] == "1" {
+                    format!("({}) / ({})", inputs[0], inputs[1])
+                } else if inputs[1] == "1" {
+                    inputs[0].clone()
+                } else {
+                    format!("({}) / ({})", inputs[0], inputs[1])
+                }
+            }
+            FloatOps::fmul => {
+                if inputs[0] == "1" {
+                    inputs[1].clone()
+                } else if inputs[1] == "1" {
+                    inputs[0].clone()
+                } else {
+                    format!("({}) * ({})", inputs[0], inputs[1])
+                }
+            }
             _ => return None,
         };
         Some(s)

--- a/tket/src/serialize/pytket/extension/prelude.rs
+++ b/tket/src/serialize/pytket/extension/prelude.rs
@@ -141,7 +141,10 @@ impl PytketDecoder for PreludeEmitter {
             }
             _ => return Ok(DecodeStatus::Unsupported),
         };
-        decoder.add_node_with_wires(op, qubits, bits, params)?;
+        if !params.is_empty() {
+            return Ok(DecodeStatus::Unsupported);
+        }
+        decoder.add_node_with_wires(op, qubits, bits, &[])?;
 
         Ok(DecodeStatus::Success)
     }

--- a/tket/src/serialize/pytket/extension/tk1.rs
+++ b/tket/src/serialize/pytket/extension/tk1.rs
@@ -100,7 +100,7 @@ pub(crate) fn build_opaque_tket_op<'h>(
     // Ensure all parameter inputs have rotation types rather than float.
     let param_wires = wires
         .iter_parameters()
-        .map(|p| p.as_rotation(&mut decoder.builder).wire)
+        .map(|p| p.as_rotation(&mut decoder.builder).wire())
         .collect_vec();
 
     let opaque_op = decoder

--- a/tket/src/serialize/pytket/extension/tk1.rs
+++ b/tket/src/serialize/pytket/extension/tk1.rs
@@ -65,7 +65,7 @@ impl<H: HugrView> PytketEmitter<H> for Tk1Emitter {
     }
 }
 
-/// Add an [`OpaqueTk1Op`] to the Hugr, representing a pytket operation that could
+/// Add an [`OpaqueTk1Op`] to the Hugr, representing a pytket operation that could not
 /// be decoded by the configured decoders.
 ///
 /// We don't implement [`PytketDecoder`][super::PytketDecoder] for [`Tk1Emitter`] so it doesn't get added

--- a/tket/src/serialize/pytket/extension/tket.rs
+++ b/tket/src/serialize/pytket/extension/tket.rs
@@ -16,6 +16,7 @@ use hugr::extension::simple_op::MakeExtensionOp;
 use hugr::extension::ExtensionId;
 use hugr::ops::ExtensionOp;
 use hugr::{HugrView, Wire};
+use itertools::Itertools as _;
 use tket_json_rs::optype::OpType as PytketOptype;
 
 /// Encoder for [TketOp] operations.
@@ -177,7 +178,14 @@ impl PytketDecoder for TketOpEmitter {
                 return Ok(DecodeStatus::Unsupported);
             }
         };
-        decoder.add_node_with_wires(op, qubits, bits, params)?;
+
+        // We expect all parameters to be rotations in half-turns.
+        let params = params
+            .iter()
+            .map(|p| Arc::new(p.as_rotation(&mut decoder.builder)))
+            .collect_vec();
+
+        decoder.add_node_with_wires(op, qubits, bits, &params)?;
 
         Ok(DecodeStatus::Success)
     }

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -59,6 +59,18 @@ const UNKNOWN_OP: &str = r#"{
         "implicit_permutation": [[["q", [0]], ["q", [0]]], [["q", [1]], ["q", [1]]], [["q", [2]], ["q", [2]]]]
     }"#;
 
+const SMALL_PARAMETERIZED: &str = r#"{
+        "phase": "0.0",
+        "bits": [],
+        "qubits": [["q", [0]]],
+        "commands": [
+            {"args":[["q",[0]]],"op":{"params":["(pi) / (2)"],"type":"Rz"}}
+        ],
+        "created_qubits": [],
+        "discarded_qubits": [],
+        "implicit_permutation": [[["q", [0]], ["q", [0]]]]
+    }"#;
+
 const PARAMETERIZED: &str = r#"{
         "phase": "0.0",
         "bits": [],
@@ -178,7 +190,7 @@ fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
         let count_b = b_command_count.get(a).copied().unwrap_or_default();
         assert_eq!(
             count_a, count_b,
-            "command {a:?} appears {count_a} times in rhs and {count_b} times in lhs"
+            "command {a:?} appears {count_a} times in rhs and {count_b} times in lhs.\ncounts for a: {a_command_count:#?}\ncounts for b: {b_command_count:#?}"
         );
     }
     assert_eq!(a_command_count.len(), b_command_count.len());
@@ -391,6 +403,7 @@ fn circ_complex_angle_computation() -> (Circuit, String) {
 #[case::simple(SIMPLE_JSON, 2, 2)]
 #[case::multi_register(MULTI_REGISTER, 2, 3)]
 #[case::unknown_op(UNKNOWN_OP, 2, 3)]
+#[case::small_parametrized(SMALL_PARAMETERIZED, 1, 1)]
 #[case::parametrized(PARAMETERIZED, 4, 2)]
 #[case::barrier(BARRIER, 3, 3)]
 fn json_roundtrip(#[case] circ_s: &str, #[case] num_commands: usize, #[case] num_qubits: usize) {

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -411,6 +411,7 @@ fn json_roundtrip(#[case] circ_s: &str, #[case] num_commands: usize, #[case] num
     assert_eq!(ser.commands.len(), num_commands);
 
     let circ: Circuit = ser.decode().unwrap();
+    println!("{}", circ.mermaid_string());
 
     assert_eq!(circ.qubit_count(), num_qubits);
 

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -411,8 +411,6 @@ fn json_roundtrip(#[case] circ_s: &str, #[case] num_commands: usize, #[case] num
     assert_eq!(ser.commands.len(), num_commands);
 
     let circ: Circuit = ser.decode().unwrap();
-    println!("{}", circ.mermaid_string());
-
     assert_eq!(circ.qubit_count(), num_qubits);
 
     let reser: SerialCircuit = SerialCircuit::encode(&circ).unwrap();

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [options]
@@ -1096,7 +1096,7 @@ wheels = [
 
 [[package]]
 name = "tket"
-version = "0.13.0"
+version = "0.12.2"
 source = { editable = "tket-py" }
 dependencies = [
     { name = "hugr" },


### PR DESCRIPTION
Fixes inconsistent encoding/decoding parameters. Now we keep them in _half-turns_ most of the time, unless an specific operation requires them to be in radians.

- The `ParameterType` used while decoding now has variants `Rotation | FloatHalfTurns | FloatRadians`.
  Operation decoders must now specify which one they expect for their inputs.
- Decoding a pytket parameter emits float operations over `FloatHalfTurns`, to avoid unnecessary conversions from/to radians.
- The encoder always stores parameters expressions in half-turns, `qsystem` ops must then add a `/ pi` before emitting their command.


BREAKING CHANGE: (pytket decoder) Renamed `LoadedParameterType` to `ParameterType` and changed its variants.
BREAKING CHANGE: (pytket decoder) Made `LoadedParameter` attributes private, and modified its API to support the new type variants.
BREAKING CHANGE: (pytket encoder) Changed `MakeOperationArgs`'s parameter list to a `Cow`.

This is not a breaking change for python;
 
BEGIN_COMMIT_OVERRIDE

fix: Fix erroneous parameters being decoded from pytket for qsystem gates (#1061)

END_COMMIT_OVERRIDE