### PR TITLE
feat: Capture pytket's output permutation explicitly in the hugr connectivity

### DIFF
--- a/tket/src/extension.rs
+++ b/tket/src/extension.rs
@@ -37,6 +37,10 @@ pub const TKET1_EXTENSION_ID: ExtensionId = IdentList::new_unchecked("TKET1");
 pub const TKET1_OP_NAME: SmolStr = SmolStr::new_inline("tk1op");
 
 /// The ID of an opaque TKET1 operation metadata.
+#[deprecated(
+    note = "TKET.tk1op payload is stored as a op parameter, not a metadata field.",
+    since = "0.14.1"
+)]
 pub const TKET1_PAYLOAD_NAME: SmolStr = SmolStr::new_inline("TKET1-json-payload");
 
 /// Current version of the legacy TKET 1 extension
@@ -44,8 +48,11 @@ pub const TKET1_EXTENSION_VERSION: Version = Version::new(0, 2, 0);
 
 lazy_static! {
 /// A custom type for the encoded TKET1 operation
-pub static ref TKET1_OP_PAYLOAD : CustomType =
-    TKET1_EXTENSION.get_type(&TKET1_PAYLOAD_NAME).unwrap().instantiate([]).unwrap();
+
+pub static ref TKET1_OP_PAYLOAD : CustomType = {
+    #[allow(deprecated)]
+    TKET1_EXTENSION.get_type(&TKET1_PAYLOAD_NAME).unwrap().instantiate([]).unwrap()
+};
 
 /// The TKET1 extension, containing the opaque TKET1 operations.
 pub static ref TKET1_EXTENSION: Arc<Extension>  = {

--- a/tket/src/serialize/pytket.rs
+++ b/tket/src/serialize/pytket.rs
@@ -49,17 +49,14 @@ pub const METADATA_PHASE: &str = "TKET1.phase";
 pub const METADATA_Q_REGISTERS: &str = "TKET1.qubit_registers";
 /// The reordered qubit registers in the output, if an implicit permutation was applied.
 #[deprecated(
-    note = "Output registers now always match the input register order.",
+    note = "Qubit permutations are now represented explicitly in DFG output ordering.",
     since = "0.14.1"
 )]
 pub const METADATA_Q_OUTPUT_REGISTERS: &str = "TKET1.qubit_output_registers";
 /// Explicit names for the input bit registers.
 pub const METADATA_B_REGISTERS: &str = "TKET1.bit_registers";
 /// The reordered bit registers in the output, if an implicit permutation was applied.
-#[deprecated(
-    note = "Output registers now always match the input register order.",
-    since = "0.14.1"
-)]
+#[deprecated(note = "Pytket does not allow bit permutations.", since = "0.14.1")]
 pub const METADATA_B_OUTPUT_REGISTERS: &str = "TKET1.bit_output_registers";
 /// A tket1 operation "opgroup" field.
 pub const METADATA_OPGROUP: &str = "TKET1.opgroup";

--- a/tket/src/serialize/pytket.rs
+++ b/tket/src/serialize/pytket.rs
@@ -48,10 +48,18 @@ pub const METADATA_PHASE: &str = "TKET1.phase";
 /// Explicit names for the input qubit registers.
 pub const METADATA_Q_REGISTERS: &str = "TKET1.qubit_registers";
 /// The reordered qubit registers in the output, if an implicit permutation was applied.
+#[deprecated(
+    note = "Output registers now always match the input register order.",
+    since = "0.14.1"
+)]
 pub const METADATA_Q_OUTPUT_REGISTERS: &str = "TKET1.qubit_output_registers";
 /// Explicit names for the input bit registers.
 pub const METADATA_B_REGISTERS: &str = "TKET1.bit_registers";
 /// The reordered bit registers in the output, if an implicit permutation was applied.
+#[deprecated(
+    note = "Output registers now always match the input register order.",
+    since = "0.14.1"
+)]
 pub const METADATA_B_OUTPUT_REGISTERS: &str = "TKET1.bit_output_registers";
 /// A tket1 operation "opgroup" field.
 pub const METADATA_OPGROUP: &str = "TKET1.opgroup";

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -315,11 +315,11 @@ pub(crate) struct WireTracker {
     bits: Vec<TrackedBit>,
     /// A map from pytket register hashes to the latest up-to-date [`TrackedQubit`] referencing it.
     ///
-    /// The map keys are kept in the order we expect to see them at the circuits output.
+    /// The map keys are kept in the order they were defined in the circuit.
     latest_qubit_tracker: IndexMap<RegisterHash, TrackedQubitId>,
     /// A map from pytket register hashes to the latest up-to-date [`TrackedBit`] referencing it.
     ///
-    /// The map keys are kept in the order we expect to see them at the circuits output.
+    /// The map keys are kept in the order they were defined in the circuit.
     latest_bit_tracker: IndexMap<RegisterHash, TrackedBitId>,
     /// For each tracked qubit, the list of wires that contain it.
     qubit_wires: IndexMap<TrackedQubitId, Vec<Wire>>,
@@ -338,10 +338,10 @@ pub(crate) struct WireTracker {
     /// This originates from pytket's `implicit_permutation` field.
     ///
     /// For a circuit with three qubit registers [q0, q1, q2] and an implicit
-    /// permutation {q0 -> q1, q1 -> q2, q2 -> q0}, `output_to_input` will be {1
-    /// -> 0, 2 -> 1, 0 -> 2} and the output order will be [2, 0, 1]. That is,
-    /// at position 0 of the output we'll see the register originally named q2,
-    /// at position 1 the register originally named q0, and so on.
+    /// permutation {q0 -> q1, q1 -> q2, q2 -> q0}, `output_qubit_permutation`
+    /// will be {1 -> 0, 2 -> 1, 0 -> 2} and the output order will be [2, 0, 1].
+    /// That is, at position 0 of the output we'll see the register originally
+    /// named q2, at position 1 the register originally named q0, and so on.
     ///
     /// Registers outside the range of the array are not affected, and will
     /// appear in the same order as they were added to `latest_qubit_tracker`.

--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -27,8 +27,7 @@ use tket_json_rs::circuit_json::{self, SerialCircuit};
 use unsupported_tracker::UnsupportedTracker;
 
 use super::{
-    OpConvertError, PytketEncodeError, METADATA_B_OUTPUT_REGISTERS, METADATA_OPGROUP,
-    METADATA_PHASE, METADATA_Q_OUTPUT_REGISTERS, METADATA_Q_REGISTERS,
+    OpConvertError, PytketEncodeError, METADATA_OPGROUP, METADATA_PHASE, METADATA_Q_REGISTERS,
 };
 use crate::circuit::Circuit;
 use crate::serialize::pytket::config::PytketEncoderConfig;

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -16,9 +16,7 @@ use tket_json_rs::circuit_json::{self, SerialCircuit};
 use tket_json_rs::optype;
 use tket_json_rs::register;
 
-use super::{
-    TKETDecode, METADATA_INPUT_PARAMETERS, METADATA_Q_OUTPUT_REGISTERS, METADATA_Q_REGISTERS,
-};
+use super::{TKETDecode, METADATA_INPUT_PARAMETERS, METADATA_Q_REGISTERS};
 use crate::circuit::Circuit;
 use crate::extension::rotation::{rotation_type, ConstRotation, RotationOp};
 use crate::extension::sympy::SympyOpDef;
@@ -99,6 +97,18 @@ const BARRIER: &str = r#"{
         "created_qubits": [],
         "discarded_qubits": [],
         "implicit_permutation": [[["q", [0]], ["q", [0]]], [["q", [1]], ["q", [1]]], [["q", [2]], ["q", [2]]]]
+    }"#;
+
+const IMPLICIT_PERMUTATION: &str = r#"{
+        "phase": "0.0",
+        "bits": [["c", [0]], ["c", [1]]],
+        "qubits": [["q", [0]], ["q", [1]], ["q", [2]]],
+        "commands": [
+            {"args": [["q", [0]], ["q", [1]]], "op": {"type": "CX"}}
+        ],
+        "created_qubits": [],
+        "discarded_qubits": [],
+        "implicit_permutation": [[["q", [0]], ["q", [1]]], [["q", [1]], ["q", [2]]], [["q", [2]], ["q", [0]]]]
     }"#;
 
 /// Check some properties of the serial circuit.
@@ -219,12 +229,6 @@ fn circ_preset_qubits() -> Circuit {
         hugr.entrypoint(),
         METADATA_Q_REGISTERS,
         serde_json::json!([["q", [2]], ["q", [10]], ["q", [8]]]),
-    );
-    // A preset register for the first qubit output
-    hugr.set_metadata(
-        hugr.entrypoint(),
-        METADATA_Q_OUTPUT_REGISTERS,
-        serde_json::json!([["q", [10]]]),
     );
 
     hugr.into()
@@ -428,6 +432,7 @@ fn check_no_tk1_ops(circ: &Circuit) {
 #[case::small_parametrized(SMALL_PARAMETERIZED, 1, 1, false)]
 #[case::parametrized(PARAMETERIZED, 4, 2, true)] // TK1 op is not supported
 #[case::barrier(BARRIER, 3, 3, false)]
+#[case::implicit_permutation(IMPLICIT_PERMUTATION, 1, 3, false)]
 fn json_roundtrip(
     #[case] circ_s: &str,
     #[case] num_commands: usize,


### PR DESCRIPTION
Now the permutation gets reflected in the wire structure.

A `(circ := Circuit(2).SWAP(0,1)).replace_SWAPs()` now gets encoded directly as
```mermaid
graph LR
    subgraph 0 ["(0) Module"]
        direction LR
        subgraph 1 ["(1) [**FuncDefn: #quot;#quot;**]"]
            direction LR
            style 1 stroke:#832561,stroke-width:3px
            2["(2) Input"]
            3["(3) Output"]
            2--"0:1<br>qubit"-->3
            2--"1:0<br>qubit"-->3
        end
    end
```
Before we only stored the permutation in the circuit's metadata