### PR TITLE
fix(qystem): fix angle bug in CZ decomposition

### DIFF
--- a/tket-qsystem/src/extension/qsystem.rs
+++ b/tket-qsystem/src/extension/qsystem.rs
@@ -410,11 +410,11 @@ pub trait QSystemOpBuilder: Dataflow + UnwrapBuilder + ArrayOpBuilder {
 
     /// Build a CZ gate in terms of QSystem primitives.
     fn build_cz(&mut self, a: Wire, b: Wire) -> Result<[Wire; 2], BuildError> {
-        let pi_2 = pi_mul_f64(self, 0.5);
+        let pi_minus_2 = pi_mul_f64(self, -0.5);
 
         let [a, b] = self.build_zz_max(a, b)?;
-        let b = self.add_rz(b, pi_2)?;
-        let a = self.add_rz(a, pi_2)?;
+        let b = self.add_rz(b, pi_minus_2)?;
+        let a = self.add_rz(a, pi_minus_2)?;
 
         Ok([a, b])
     }


### PR DESCRIPTION
Error due to missing the minus sign in Rz definition in top answer here:
https://quantumcomputing.stackexchange.com/questions/37569/how-do-i-transform-a-zz-interaction-unitary-into-a-textcz-gate