### PR TITLE
fix: Always load parameter expressions as half turns in the decoder

### DIFF
--- a/tket-qsystem/src/pytket/qsystem.rs
+++ b/tket-qsystem/src/pytket/qsystem.rs
@@ -142,7 +142,7 @@ impl PytketDecoder for QSystemEmitter {
             PytketOptype::ZZMax => {
                 // This is a ZZPhase with a 1/2 angle.
                 let param =
-                    Arc::new(decoder.load_parameter_with_type("pi/2", ParameterType::FloatRadians));
+                    Arc::new(decoder.load_half_turns_with_type("1/2", ParameterType::FloatRadians));
                 decoder.add_node_with_wires(QSystemOp::ZZPhase, qubits, bits, &[param])?;
                 return Ok(DecodeStatus::Success);
             }

--- a/tket-qsystem/src/pytket/tests.rs
+++ b/tket-qsystem/src/pytket/tests.rs
@@ -116,7 +116,7 @@ fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
             // Special case for qsystem ops, where ZZMax does not exist.
             if command.op.op_type == tket_json_rs::OpType::ZZMax {
                 info.op_type = tket_json_rs::OpType::ZZPhase;
-                info.params = vec!["(pi) / (2)".to_string()];
+                info.params = vec!["(1) / (2)".to_string()];
             }
 
             info

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -329,7 +329,7 @@ impl<'h> PytketDecoderContext<'h> {
         let params: Vec<Arc<LoadedParameter>> = match &op.params {
             Some(params) => params
                 .iter()
-                .map(|v| self.load_parameter(v.as_str()))
+                .map(|v| Arc::new(self.load_half_turns(v.as_str())))
                 .collect_vec(),
             None => Vec::new(),
         };
@@ -562,25 +562,50 @@ impl<'h> PytketDecoderContext<'h> {
         Ok(())
     }
 
-    /// Loads the given parameter expression as a [`LoadedParameter`] in the hugr.
+    /// Loads a half-turns expression as a [`LoadedParameter`] in the hugr.
     ///
     /// - If the parameter is a known algebraic operation, adds the required op and recurses on its inputs.
     /// - If the parameter is a constant, a constant definition is added to the Hugr.
     /// - If the parameter is a variable, adds a new `rotation` input to the region.
     /// - If the parameter is a sympy expressions, adds it as a [`SympyOpDef`][crate::extension::sympy::SympyOpDef] black box.
+    pub fn load_half_turns(&mut self, param: &str) -> LoadedParameter {
+        self.wire_tracker
+            .load_half_turns_parameter(&mut self.builder, param, None)
+    }
+
+    /// Loads a half-turns expression as a [`LoadedParameter`] in the hugr, and
+    /// converts them to the required parameter type.
+    ///
+    /// See [`PytketDecoderContext::load_half_turns`] for more details.
+    pub fn load_half_turns_with_type(
+        &mut self,
+        param: &str,
+        typ: ParameterType,
+    ) -> LoadedParameter {
+        self.wire_tracker
+            .load_half_turns_parameter(&mut self.builder, param, Some(typ))
+            .with_type(typ, &mut self.builder)
+    }
+
+    /// Loads a half-turns expression as a [`LoadedParameter`] in the hugr.
+    ///
+    /// - If the parameter is a known algebraic operation, adds the required op and recurses on its inputs.
+    /// - If the parameter is a constant, a constant definition is added to the Hugr.
+    /// - If the parameter is a variable, adds a new `rotation` input to the region.
+    /// - If the parameter is a sympy expressions, adds it as a [`SympyOpDef`][crate::extension::sympy::SympyOpDef] black box.
+    #[deprecated(since = "0.14.1", note = "Renamed to `load_half_turns`")]
     pub fn load_parameter(&mut self, param: &str) -> Arc<LoadedParameter> {
-        Arc::new(
-            self.wire_tracker
-                .load_parameter(&mut self.builder, param, None),
-        )
+        Arc::new(self.load_half_turns(param))
     }
 
     /// Loads the given parameter expression as a [`LoadedParameter`] in the hugr, and converts it to the requested type and unit.
     ///
+    /// The expression is interpreted as a number of half-turns.
+    ///
     /// See [`PytketDecoderContext::load_parameter`] for more details.
+    #[deprecated(since = "0.14.1", note = "Renamed to `load_half_turns`")]
     pub fn load_parameter_with_type(&mut self, param: &str, typ: ParameterType) -> LoadedParameter {
-        self.wire_tracker
-            .load_parameter(&mut self.builder, param, Some(typ))
+        self.load_half_turns_with_type(param, typ)
     }
 }
 

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -668,7 +668,7 @@ impl WireTracker {
         })
     }
 
-    /// Loads the given parameter expression as a [`LoadedParameter`] in the
+    /// Loads the given parameter half-turns expression as a [`LoadedParameter`] in the
     /// hugr.
     ///
     /// - If the parameter is a known algebraic operation, adds the required op
@@ -684,12 +684,14 @@ impl WireTracker {
     ///
     /// * `hugr` - The hugr to load the parameters to.
     /// * `param` - The parameter expression to load.
-    /// * `output_type` - Ensure the loaded parameter has the given type.
-    pub fn load_parameter(
+    /// * `type_hint` - A hint for the type of the parameter we want to load.
+    ///   This lets us decide between using [`ConstRotation`] and [`ConstF64`]
+    ///   for constants. The actual returned type may be different.
+    pub fn load_half_turns_parameter(
         &mut self,
         hugr: &mut FunctionBuilder<&mut Hugr>,
         param: &str,
-        output_type: Option<ParameterType>,
+        type_hint: Option<ParameterType>,
     ) -> LoadedParameter {
         /// Recursive parameter loading.
         ///
@@ -705,7 +707,7 @@ impl WireTracker {
         ) -> LoadedParameter {
             match parsed {
                 PytketParam::Constant(half_turns) => match type_hint {
-                    Some(ParameterType::FloatHalfTurns) => {
+                    Some(ParameterType::FloatHalfTurns) | Some(ParameterType::FloatRadians) => {
                         let value: Value = ConstF64::new(half_turns).into();
                         let wire = hugr.add_load_const(value);
                         LoadedParameter::float_half_turns(wire)
@@ -725,7 +727,8 @@ impl WireTracker {
                 PytketParam::InputVariable { name } => {
                     // Special case for the name "pi": inserts a `ConstRotation(PI)` instead.
                     match (name, type_hint) {
-                        ("pi", Some(ParameterType::FloatHalfTurns)) => {
+                        ("pi", Some(ParameterType::FloatHalfTurns))
+                        | ("pi", Some(ParameterType::FloatRadians)) => {
                             let value: Value = ConstF64::new(std::f64::consts::PI).into();
                             let wire = hugr.add_load_const(value);
                             LoadedParameter::float_half_turns(wire)
@@ -766,19 +769,14 @@ impl WireTracker {
             }
         }
 
-        let loaded = process(
+        process(
             hugr,
             &mut self.parameters,
             &mut self.parameter_vars,
             parse_pytket_param(param),
             param,
-            output_type,
-        );
-
-        match output_type {
-            Some(typ) => loaded.with_type(typ, hugr),
-            None => loaded,
-        }
+            type_hint,
+        )
     }
 
     /// Track a new wire, updating any tracked elements that are present in it.


### PR DESCRIPTION
- Fixes `ZZMax` being lowered as a `ZZPhase(𝛑/2)` instead of `ZZPhase(1/2)`.
- Renames (via deprecation) `PytketDecoder::load_parameter` to `PytketDecoder::load_half_turns` to properly convey it's behaviour.