### PR TITLE
ci: Don't try to deploy docs from PRs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -15,8 +15,23 @@ permissions:
   id-token: write
 
 jobs:
+    # Check if changes were made to the relevant files.
+    # Always returns true if running on the default branch, to ensure all changes are thoroughly checked.
+    changes:
+      name: Check for changes
+      runs-on: ubuntu-latest
+      permissions:
+        pull-requests: read
+      outputs:
+        python: ${{ steps.filter.outputs.python || github.event_name != 'pull_request' }}
+      steps:
+        - uses: actions/checkout@v5
+        - uses: ./.github/actions/check-changes
+          id: filter
     test:
       name: Test sphinx docs build
+      needs: [changes]
+      if: ${{ needs.changes.outputs.python == 'true' }}
       runs-on: ubuntu-latest
       env:
           UV_FROZEN: 1
@@ -44,14 +59,15 @@ jobs:
           with:
             path: ./tket-py/docs/build
 
-            
+
     publish:
       name: Publish docs.
       environment:
           name: github-pages
           url: ${{ steps.deployment.outputs.page_url }}
       runs-on: ubuntu-latest
-      needs: test
+      needs: [test, changes]
+      if: ${{ needs.changes.outputs.python == 'true' && github.event_name == 'push' }}
       steps:
         - name: Setup Pages
           uses: actions/configure-pages@v5


### PR DESCRIPTION
Only deploys the py docs on pushes to main, and only builds the docs on a PR if the python code has changed.

The job currently fails on PRs due to environment protection rules:
https://github.com/CQCL/tket2/actions/runs/17583269189/job/50143465451?pr=1091