### PR TITLE
chore: add docs link to tket-py README

### DIFF
--- a/tket-py/README.md
+++ b/tket-py/README.md
@@ -32,7 +32,7 @@ See the [Getting Started][getting-started] guide and the other [examples].
   [getting-started]: https://github.com/CQCL/tket2/blob/main/tket-py/examples/1-Getting-Started.ipynb
   [examples]: https://github.com/CQCL/tket2/tree/main/tket-py/examples
 
-API documentation for `tket-py` can be found at https://cqcl.github.io/tket2/.
+The API documentation for `tket-py` can be found at https://cqcl.github.io/tket2/.
 
 ## Development
 


### PR DESCRIPTION
drive by: fix some README links. I think I broke these by accident when removing the notebooks from the sphinx build prior to merging #1087 