### PR TITLE
fix: Add gpu extension to extensions reexposed by tket-py

### DIFF
--- a/tket-py/tket/extensions/__init__.py
+++ b/tket-py/tket/extensions/__init__.py
@@ -4,7 +4,6 @@ from tket_exts import (
     guppy,
     rotation,
     futures,
-    gpu,
     qsystem,
     qsystem_random,
     qsystem_utils,
@@ -16,8 +15,12 @@ from tket_exts import (
 # TODO: Remove once tket no longer supports tket-exts 0.10.*
 try:
     from tket_exts import bool  # type: ignore[attr-defined]
+    from tket_exts import gpu  # noqa: F401
+
+    new_exts = ["gpu"]
 except ImportError:
     bool = opaque_bool  # type: ignore[assignment]
+    new_exts = []
 
 
 # TODO: Remove the deprecated `opaque_bool` export in a breaking change.
@@ -28,11 +31,11 @@ __all__ = [
     "guppy",
     "rotation",
     "futures",
-    "gpu",
     "qsystem",
     "qsystem_random",
     "qsystem_utils",
     "quantum",
     "result",
     "wasm",
+    *new_exts,
 ]


### PR DESCRIPTION
I forgot to reexport the gpu extension in `tket-py` after adding it 🙂 