### PR TITLE
ci: Test minimum dependencies in the release checks

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -3,7 +3,7 @@
 # If this fails, it is likely that we either didn't update the dependency version in tket's pyproject,
 # or the latest `tket-exts`/`tket-eccs` packages haven't been published to pypi.
 
-name: 🚚 tket-py release checks
+name: 🚚 Release Checks
 
 on:
   pull_request:
@@ -47,10 +47,13 @@ jobs:
           uv python install ${{ env.PYTHON_HIGHEST }}
           uv python pin ${{ env.PYTHON_HIGHEST }}
       - name: Setup `tket-py` with only pypi deps
+        env:
+          UV_RESOLUTION: ${{ matrix.resolution }}
         run: |
-          uv sync --no-sources --no-install-workspace --resolution ${{ matrix.resolution }}
-          uv pip install --resolution ${{ matrix.resolution }} --no-sources tket-exts
-          uv pip install --resolution ${{ matrix.resolution }} --no-sources tket-eccs
+          uv lock --no-sources -U
+          uv sync --no-sources --no-install-workspace
+          uv pip install --no-sources tket-exts
+          uv pip install --no-sources tket-eccs
           uv run --no-sync maturin develop
           echo "\nDone! Installed dependencies:"
           uv pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dev-dependencies = [
     "conan >= 2.0.0,<3",
     # Required to run `maturin develop`
     "pip >=25",
+    # Pyyaml 0.6.0 makes setuptools fail. This ensures we're using a newer version.
+    "pyyaml >=6.0.2",
 ]
 
 prerelease = "explicit"

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ dev = [
     { name = "pre-commit", specifier = "~=4.3" },
     { name = "pytest", specifier = ">=8.3.2,<9" },
     { name = "pytest-cov", specifier = "~=7.0" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", specifier = ">=0.6.2,<0.7" },
 ]
 


### PR DESCRIPTION
In addition to testing `tket-py` with the latest published dependencies before releasing it,
it also checks that the _minimum_ declared dependencies also work as recommended by the [uv docs](https://docs.astral.sh/uv/concepts/resolution/#resolution-strategy).

This is specially important now that we plan to support multiple versions of `tket-exts` for backwards compat.

[~Test run~](https://github.com/CQCL/tket2/actions/runs/17677623613)
[Test run](https://github.com/CQCL/tket2/actions/runs/17678423897)