### PR TITLE
feat: Simplify the tuple unpack pass and support some edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "capnp"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def25bdbbc2758b363d79129c7f277520e3347e8b647c404d4823591f837c4ad"
+checksum = "f62fcad97587224e2a1bd12ec1c7c0e95b93cefd285763a174cf1b34048c6437"
 dependencies = [
  "embedded-io",
 ]
@@ -403,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeab6a5cdfc795a05538422012f20a5496f050223c91be4e5420bfd13c641fb1"
+checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
 dependencies = [
  "clap",
  "log",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "duplicate"
@@ -1063,8 +1063,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba34deb9a48603fb1f63a48e00d833f2b51dc7d76efc4d21d1d67bf656fc3284"
+source = "git+https://github.com/CQCL/hugr?rev=e8228a64#e8228a64137436b6db4675154148130155ff5c92"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1075,8 +1074,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d7e9197f6d90f0184ddf5ec60f9099d39dda837c7a94689fa2dfa4b6d807ad"
+source = "git+https://github.com/CQCL/hugr?rev=e8228a64#e8228a64137436b6db4675154148130155ff5c92"
 dependencies = [
  "anyhow",
  "clap",
@@ -1093,8 +1091,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ff3055f61b54110f0db07044298852af252ecf5cf4d0febd024eebd56d4430"
+source = "git+https://github.com/CQCL/hugr?rev=e8228a64#e8228a64137436b6db4675154148130155ff5c92"
 dependencies = [
  "base64",
  "cgmath",
@@ -1105,7 +1102,7 @@ dependencies = [
  "fxhash",
  "html-escape",
  "hugr-model",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "lazy_static",
  "ordered-float",
@@ -1131,8 +1128,7 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedba5a805260a4b2ca73f14af4467d0fece84f4ac56e04b74fbda6d879f628d"
+source = "git+https://github.com/CQCL/hugr?rev=e8228a64#e8228a64137436b6db4675154148130155ff5c92"
 dependencies = [
  "anyhow",
  "delegate 0.13.4",
@@ -1151,15 +1147,14 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f26ab2c3c9ecacd56da27b59f492bf1f24b51ab93e4992fc8ccd6715c3d76d"
+source = "git+https://github.com/CQCL/hugr?rev=e8228a64#e8228a64137436b6db4675154148130155ff5c92"
 dependencies = [
  "base64",
  "bumpalo",
  "capnp",
  "derive_more 1.0.0",
  "fxhash",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "ordered-float",
  "pest",
@@ -1173,8 +1168,7 @@ dependencies = [
 [[package]]
 name = "hugr-passes"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d98acf7df7d21e97bea5cad2e1012dbbe9b29c96c376fa0d59b2defc6f0e4"
+source = "git+https://github.com/CQCL/hugr?rev=e8228a64#e8228a64137436b6db4675154148130155ff5c92"
 dependencies = [
  "ascent",
  "derive_more 1.0.0",
@@ -1237,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1633,7 +1627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
 ]
 
 [[package]]
@@ -1644,7 +1638,7 @@ checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "serde",
 ]
 
@@ -1782,7 +1776,7 @@ checksum = "5676d703dda103cbb035b653a9f11448c0a7216c7926bd35fcb5865475d0c970"
 dependencies = [
  "autocfg",
  "equivalent",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
 ]
 
 [[package]]
@@ -1966,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2202,7 +2196,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -2488,7 +2482,7 @@ dependencies = [
  "fxhash",
  "hugr",
  "hugr-core",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "insta",
  "itertools 0.14.0",
  "lazy_static",
@@ -2559,7 +2553,7 @@ dependencies = [
  "derive_more 2.0.1",
  "hugr",
  "hugr-cli",
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "itertools 0.14.0",
  "lazy_static",
  "petgraph 0.8.2",
@@ -2600,7 +2594,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.1",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-#hugr = { git = "https://github.com/CQCL/hugr", "rev" = "f7cedb4f39b67a77b4c6a55ec00b624b54668eaa" }
-#hugr-core = { git = "https://github.com/CQCL/hugr", "rev" = "f7cedb4f39b67a77b4c6a55ec00b624b54668eaa" }
-#hugr-passes = { git = "https://github.com/CQCL/hugr", "rev" = "f7cedb4f39b67a77b4c6a55ec00b624b54668eaa" }
-#hugr-cli = { git = "https://github.com/CQCL/hugr", "rev" = "f7cedb4f39b67a77b4c6a55ec00b624b54668eaa" }
+hugr = { git = "https://github.com/CQCL/hugr", "rev" = "e8228a64" }
+hugr-core = { git = "https://github.com/CQCL/hugr", "rev" = "e8228a64" }
+hugr-passes = { git = "https://github.com/CQCL/hugr", "rev" = "e8228a64" }
+hugr-cli = { git = "https://github.com/CQCL/hugr", "rev" = "e8228a64" }
 # portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]
@@ -65,7 +65,7 @@ csv = "1.3.1"
 delegate = "0.13.4"
 derive_more = "2.0.1"
 fxhash = "0.2.1"
-indexmap = "2.11.0"
+indexmap = "2.11.1"
 lazy_static = "1.5.0"
 num_cpus = "1.17.0"
 peak_alloc = "0.2.0"


### PR DESCRIPTION
Uses a simple node traversal in the tuple_unpack pass instead of the toposorted commands, and handles edge cases of `UnpackTuple`s on empty tuples that can can be removed.

(This is something we see frequently on guppy-generated hugrs)

- Requires a `hugr 0.22.3` release with this fix: https://github.com/CQCL/hugr/pull/2549