### PR TITLE
feat!: Remove unnecessary Arc from PytketDecoder method

### DIFF
--- a/tket-qsystem/src/pytket/qsystem.rs
+++ b/tket-qsystem/src/pytket/qsystem.rs
@@ -1,7 +1,5 @@
 //! Encoder/decoder for [qsystem::EXTENSION][use crate::extension::qsystem::EXTENSION] operations.
 
-use std::sync::Arc;
-
 use hugr::extension::simple_op::MakeExtensionOp;
 use hugr::extension::ExtensionId;
 use hugr::ops::ExtensionOp;
@@ -132,7 +130,7 @@ impl PytketDecoder for QSystemEmitter {
         op: &tket_json_rs::circuit_json::Operation,
         qubits: &[TrackedQubit],
         bits: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
         _opgroup: Option<&str>,
         decoder: &mut PytketDecoderContext<'h>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
@@ -141,8 +139,7 @@ impl PytketDecoder for QSystemEmitter {
             PytketOptype::ZZPhase => QSystemOp::ZZPhase,
             PytketOptype::ZZMax => {
                 // This is a ZZPhase with a 1/2 angle.
-                let param =
-                    Arc::new(decoder.load_half_turns_with_type("0.5", ParameterType::FloatRadians));
+                let param = decoder.load_half_turns_with_type("0.5", ParameterType::FloatRadians);
                 decoder.add_node_with_wires(QSystemOp::ZZPhase, qubits, bits, &[param])?;
                 return Ok(DecodeStatus::Success);
             }
@@ -154,7 +151,7 @@ impl PytketDecoder for QSystemEmitter {
         // We expect all parameters to be floats in radians.
         let params = params
             .iter()
-            .map(|p| Arc::new(p.as_float_radians(&mut decoder.builder)))
+            .map(|p| p.as_float_radians(&mut decoder.builder))
             .collect_vec();
 
         decoder.add_node_with_wires(op, qubits, bits, &params)?;

--- a/tket/src/serialize/pytket/config/decoder_config.rs
+++ b/tket/src/serialize/pytket/config/decoder_config.rs
@@ -7,7 +7,6 @@
 use hugr::types::Type;
 use itertools::Itertools;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::serialize::pytket::decoder::{
     DecodeStatus, LoadedParameter, PytketDecoderContext, TrackedBit, TrackedQubit,
@@ -73,7 +72,7 @@ impl PytketDecoderConfig {
         op: &tket_json_rs::circuit_json::Operation,
         qubits: &[TrackedQubit],
         bits: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
         opgroup: &Option<String>,
         decoder: &mut PytketDecoderContext<'a>,
     ) -> Result<DecodeStatus, PytketDecodeError> {

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -326,10 +326,10 @@ impl<'h> PytketDecoderContext<'h> {
         let (qubits, bits) = self.wire_tracker.pytket_args_to_tracked_elems(args)?;
 
         // Collect the parameters used in the command.
-        let params: Vec<Arc<LoadedParameter>> = match &op.params {
+        let params: Vec<LoadedParameter> = match &op.params {
             Some(params) => params
                 .iter()
-                .map(|v| Arc::new(self.load_half_turns(v.as_str())))
+                .map(|v| self.load_half_turns(v.as_str()))
                 .collect_vec(),
             None => Vec::new(),
         };
@@ -372,7 +372,7 @@ impl<'h> PytketDecoderContext<'h> {
         types: &[Type],
         qubit_args: &[TrackedQubit],
         bit_args: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
     ) -> Result<TrackedWires, PytketDecodeError> {
         self.wire_tracker
             .find_typed_wires(&self.config, types, qubit_args, bit_args, params)
@@ -416,7 +416,7 @@ impl<'h> PytketDecoderContext<'h> {
         op: impl Into<OpType>,
         qubits: &[TrackedQubit],
         bits: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
     ) -> Result<BuildHandle<DataflowOpID>, PytketDecodeError> {
         let op: OpType = op.into();
         let op_name = op.to_string();

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -101,7 +101,7 @@ pub struct TrackedWires {
     /// along with their types.
     value_wires: Vec<WireData>,
     /// List of wires corresponding to the parameters.
-    parameter_wires: Vec<Arc<LoadedParameter>>,
+    parameter_wires: Vec<LoadedParameter>,
 }
 
 impl TrackedWires {
@@ -142,7 +142,7 @@ impl TrackedWires {
     /// Return an iterator over the parameters.
     #[inline]
     pub fn iter_parameters(&self) -> impl Iterator<Item = &'_ LoadedParameter> + Clone + '_ {
-        self.parameter_wires.iter().map(|p| p.as_ref())
+        self.parameter_wires.iter()
     }
 
     /// Returns the types of the value wires.
@@ -580,7 +580,7 @@ impl WireTracker {
         types: &[Type],
         qubit_args: &[TrackedQubit],
         bit_args: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
     ) -> Result<TrackedWires, PytketDecodeError> {
         // We need to return a set of wires that contain all the arguments.
         //

--- a/tket/src/serialize/pytket/extension.rs
+++ b/tket/src/serialize/pytket/extension.rs
@@ -20,8 +20,6 @@ mod rotation;
 mod tk1;
 mod tket;
 
-use std::sync::Arc;
-
 pub use bool::BoolEmitter;
 pub use float::FloatEmitter;
 pub use prelude::PreludeEmitter;
@@ -123,14 +121,12 @@ pub trait PytketDecoder {
     ///
     /// `op` will always have one of the [`tket_json_rs::OpType`]s specified in
     /// [`PytketDecoder::op_types`].
-    //
-    // TODO: There's no need for `params` to be inside `Arc`s here. They are `Copy`.
     fn op_to_hugr<'h>(
         &self,
         op: &tket_json_rs::circuit_json::Operation,
         qubits: &[TrackedQubit],
         bits: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
         opgroup: Option<&str>,
         decoder: &mut PytketDecoderContext<'h>,
     ) -> Result<DecodeStatus, PytketDecodeError> {

--- a/tket/src/serialize/pytket/extension/bool.rs
+++ b/tket/src/serialize/pytket/extension/bool.rs
@@ -1,7 +1,5 @@
 //! Encoder and decoder for the tket.bool extension
 
-use std::sync::Arc;
-
 use super::PytketEmitter;
 use crate::extension::bool::{BoolOp, ConstBool, BOOL_EXTENSION_ID, BOOL_TYPE_NAME};
 use crate::serialize::pytket::config::TypeTranslatorSet;
@@ -121,7 +119,7 @@ impl PytketDecoder for BoolEmitter {
         op: &tket_json_rs::circuit_json::Operation,
         qubits: &[TrackedQubit],
         bits: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
         _opgroup: Option<&str>,
         decoder: &mut PytketDecoderContext<'h>,
     ) -> Result<DecodeStatus, PytketDecodeError> {

--- a/tket/src/serialize/pytket/extension/prelude.rs
+++ b/tket/src/serialize/pytket/extension/prelude.rs
@@ -1,7 +1,5 @@
 //! Encoder and decoder for tket operations with native pytket counterparts.
 
-use std::sync::Arc;
-
 use super::PytketEmitter;
 use crate::serialize::pytket::config::TypeTranslatorSet;
 use crate::serialize::pytket::decoder::{
@@ -120,7 +118,7 @@ impl PytketDecoder for PreludeEmitter {
         op: &tket_json_rs::circuit_json::Operation,
         qubits: &[TrackedQubit],
         bits: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
         opgroup: Option<&str>,
         decoder: &mut PytketDecoderContext<'h>,
     ) -> Result<DecodeStatus, PytketDecodeError> {

--- a/tket/src/serialize/pytket/extension/tk1.rs
+++ b/tket/src/serialize/pytket/extension/tk1.rs
@@ -1,7 +1,5 @@
 //! Encoder for pytket operations that cannot be represented naturally in tket.
 
-use std::sync::Arc;
-
 use crate::extension::rotation::rotation_type;
 use crate::extension::{TKET1_EXTENSION, TKET1_EXTENSION_ID, TKET1_OP_NAME};
 use crate::serialize::pytket::decoder::{
@@ -80,7 +78,7 @@ pub(crate) fn build_opaque_tket_op<'h>(
     op: &tket_json_rs::circuit_json::Operation,
     qubits: &[TrackedQubit],
     bits: &[TrackedBit],
-    params: &[Arc<LoadedParameter>],
+    params: &[LoadedParameter],
     _opgroup: &Option<String>,
     decoder: &mut PytketDecoderContext<'h>,
 ) -> Result<(), PytketDecodeError> {

--- a/tket/src/serialize/pytket/extension/tket.rs
+++ b/tket/src/serialize/pytket/extension/tket.rs
@@ -1,7 +1,5 @@
 //! Encoder and decoder for tket operations with native pytket counterparts.
 
-use std::sync::Arc;
-
 use super::PytketEmitter;
 use crate::extension::sympy::SympyOp;
 use crate::extension::TKET_EXTENSION_ID;
@@ -149,7 +147,7 @@ impl PytketDecoder for TketOpEmitter {
         op: &tket_json_rs::circuit_json::Operation,
         qubits: &[TrackedQubit],
         bits: &[TrackedBit],
-        params: &[Arc<LoadedParameter>],
+        params: &[LoadedParameter],
         _opgroup: Option<&str>,
         decoder: &mut PytketDecoderContext<'h>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
@@ -182,7 +180,7 @@ impl PytketDecoder for TketOpEmitter {
         // We expect all parameters to be rotations in half-turns.
         let params = params
             .iter()
-            .map(|p| Arc::new(p.as_rotation(&mut decoder.builder)))
+            .map(|p| p.as_rotation(&mut decoder.builder))
             .collect_vec();
 
         decoder.add_node_with_wires(op, qubits, bits, &params)?;


### PR DESCRIPTION
`LoadedParameter` is `Copy`, so wrapping them in an Arc in unnecessary bookeeping/indirection.

BREAKING CHANGE: Removed Arc from `PytketDecoder::op_to_hugr` parameters