### PR TITLE
fix(pytket-encoder): Correctly encode I/O nodes in nested containers

### DIFF
--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -101,18 +101,12 @@ impl<H: HugrView> PytketEncoderContext<H> {
         region: H::Node,
     ) -> Result<(), PytketEncodeError<H::Node>> {
         let (region, node_map) = circ.hugr().region_portgraph(region);
-        let io_nodes = circ.io_nodes();
-
         // TODO: Use weighted topological sort to try and explore unsupported
         // ops first (that is, ops with no available emitter in `self.config`),
         // to ensure we group them as much as possible.
         let mut topo = petgraph::visit::Topo::new(&region);
         while let Some(pg_node) = topo.next(&region) {
             let node = node_map.from_portgraph(pg_node);
-            if io_nodes.contains(&node) {
-                // I/O nodes are handled by `new` and `finish`.
-                continue;
-            }
             self.try_encode_node(node, circ)?;
         }
         Ok(())
@@ -775,6 +769,10 @@ impl<H: HugrView> PytketEncoderContext<H> {
                     .single_linked_output(node, call.called_function_port())
                     .expect("Function call must be linked to a function");
                 return self.emit_function_call(node, fn_node, circ);
+            }
+            OpType::Input(_) | OpType::Output(_) => {
+                // I/O nodes are handled by the container's encoder.
+                return Ok(EncodeStatus::Success);
             }
             _ => {}
         }


### PR DESCRIPTION
When encoding ops into pytket circuits we were comparing ids against the circuit's I/O nodes.
This ended up producing unsupported ops in the encoding of nested regions (when emitting CircBoxes).

No test here yet, they'll be added with the implementation of #44.