### PR TITLE
feat!: SerialCircuit::decode_inplace and explicit option structs

### DIFF
--- a/badger-optimiser/src/main.rs
+++ b/badger-optimiser/src/main.rs
@@ -14,6 +14,7 @@ use clap::Parser;
 use tket::optimiser::badger::log::BadgerLogger;
 use tket::optimiser::badger::BadgerOptions;
 use tket::optimiser::{BadgerOptimiser, ECCBadgerOptimiser};
+use tket::serialize::pytket::{DecodeOptions, EncodeOptions};
 use tket::serialize::{load_tk1_json_file, save_tk1_json_file};
 
 #[cfg(feature = "peak_alloc")]
@@ -145,7 +146,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut circ = load_tk1_json_file(
         input_path,
-        Some(tket_qsystem::pytket::qsystem_decoder_config()),
+        DecodeOptions::new().with_config(tket_qsystem::pytket::qsystem_decoder_config()),
     )?;
     if opts.rewrite_tracing {
         circ.enable_rewrite_tracing();
@@ -187,7 +188,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     save_tk1_json_file(
         &opt_circ,
         output_path,
-        Some(tket_qsystem::pytket::qsystem_encoder_config()),
+        EncodeOptions::new().with_config(tket_qsystem::pytket::qsystem_encoder_config()),
     )?;
 
     #[cfg(feature = "peak_alloc")]

--- a/tket-py/src/circuit/convert.rs
+++ b/tket-py/src/circuit/convert.rs
@@ -20,6 +20,7 @@ use hugr::{Hugr, HugrView, Wire};
 use serde::Serialize;
 use tket::circuit::CircuitHash;
 use tket::passes::CircuitChunks;
+use tket::serialize::pytket::{DecodeOptions, EncodeOptions};
 use tket::serialize::TKETDecode;
 use tket::{Circuit, TketOp};
 use tket_json_rs::circuit_json::SerialCircuit;
@@ -43,9 +44,9 @@ impl CircuitType {
     /// Converts a circuit into the format indicated by the flag.
     pub fn convert(self, py: Python, circ: Circuit) -> PyResult<Bound<PyAny>> {
         match self {
-            CircuitType::Tket1 => SerialCircuit::encode_with_config(
+            CircuitType::Tket1 => SerialCircuit::encode(
                 &circ,
-                tket_qsystem::pytket::qsystem_encoder_config(),
+                EncodeOptions::new().with_config(tket_qsystem::pytket::qsystem_encoder_config()),
             )
             .convert_pyerrs()?
             .to_tket1(py),
@@ -68,7 +69,10 @@ where
         // tket1 circuit
         Err(_) => (
             SerialCircuit::from_tket1(circ)?
-                .decode_with_config(tket_qsystem::pytket::qsystem_decoder_config())
+                .decode(
+                    DecodeOptions::new()
+                        .with_config(tket_qsystem::pytket::qsystem_decoder_config()),
+                )
                 .convert_pyerrs()?,
             CircuitType::Tket1,
         ),

--- a/tket-py/src/circuit/tk2circuit.rs
+++ b/tket-py/src/circuit/tk2circuit.rs
@@ -27,6 +27,7 @@ use serde::Serialize;
 use tket::circuit::CircuitHash;
 use tket::passes::pytket::lower_to_pytket;
 use tket::passes::CircuitChunks;
+use tket::serialize::pytket::{DecodeOptions, EncodeOptions};
 use tket::serialize::TKETDecode;
 use tket::{Circuit, TketOp};
 use tket_json_rs::circuit_json::SerialCircuit;
@@ -81,9 +82,12 @@ impl Tk2Circuit {
     /// Convert the [`Tk2Circuit`] to a tket1 circuit.
     pub fn to_tket1<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let circ = lower_to_pytket(&self.circ).convert_pyerrs()?;
-        SerialCircuit::encode_with_config(&circ, tket_qsystem::pytket::qsystem_encoder_config())
-            .convert_pyerrs()?
-            .to_tket1(py)
+        SerialCircuit::encode(
+            &circ,
+            EncodeOptions::new().with_config(tket_qsystem::pytket::qsystem_encoder_config()),
+        )
+        .convert_pyerrs()?
+        .to_tket1(py)
     }
 
     /// Apply a rewrite on the circuit.
@@ -154,9 +158,9 @@ impl Tk2Circuit {
         // Try to simplify tuple pack-unpack pairs, and other operations not supported by pytket.
         let circ = lower_to_pytket(&self.circ).convert_pyerrs()?;
         serde_json::to_string(
-            &SerialCircuit::encode_with_config(
+            &SerialCircuit::encode(
                 &circ,
-                tket_qsystem::pytket::qsystem_encoder_config(),
+                EncodeOptions::new().with_config(tket_qsystem::pytket::qsystem_encoder_config()),
             )
             .convert_pyerrs()?,
         )
@@ -170,7 +174,7 @@ impl Tk2Circuit {
     pub fn from_tket1_json(json: &str) -> PyResult<Self> {
         let circ = tket::serialize::load_tk1_json_str(
             json,
-            Some(tket_qsystem::pytket::qsystem_decoder_config()),
+            DecodeOptions::new().with_config(tket_qsystem::pytket::qsystem_decoder_config()),
         )
         .map_err(|e| {
             PyErr::new::<PyAttributeError, _>(format!("Could not load pytket circuit: {e}"))
@@ -183,9 +187,9 @@ impl Tk2Circuit {
         // Try to simplify tuple pack-unpack pairs, and other operations not supported by pytket.
         let circ = lower_to_pytket(&self.circ).convert_pyerrs()?;
         serde_json::to_vec(
-            &SerialCircuit::encode_with_config(
+            &SerialCircuit::encode(
                 &circ,
-                tket_qsystem::pytket::qsystem_encoder_config(),
+                EncodeOptions::new().with_config(tket_qsystem::pytket::qsystem_encoder_config()),
             )
             .convert_pyerrs()?,
         )
@@ -199,7 +203,7 @@ impl Tk2Circuit {
     pub fn from_tket1_json_bytes(json: &[u8]) -> PyResult<Self> {
         let circ = tket::serialize::load_tk1_json_reader(
             json,
-            Some(tket_qsystem::pytket::qsystem_decoder_config()),
+            DecodeOptions::new().with_config(tket_qsystem::pytket::qsystem_decoder_config()),
         )
         .map_err(|e| {
             PyErr::new::<PyAttributeError, _>(format!("Could not load pytket circuit: {e}"))

--- a/tket-qsystem/src/pytket/tests.rs
+++ b/tket-qsystem/src/pytket/tests.rs
@@ -16,6 +16,7 @@ use tket_json_rs::register;
 
 use tket::circuit::Circuit;
 use tket::serialize::pytket::TKETDecode;
+use tket::serialize::pytket::{DecodeOptions, EncodeOptions};
 
 use crate::extension::futures::FutureOpBuilder;
 use crate::extension::qsystem::QSystemOp;
@@ -196,15 +197,20 @@ fn json_roundtrip(
     let ser: circuit_json::SerialCircuit = serde_json::from_str(circ_s).unwrap();
     assert_eq!(ser.commands.len(), num_commands);
 
-    let circ: Circuit = ser.decode_with_config(qsystem_decoder_config()).unwrap();
+    let circ: Circuit = ser
+        .decode(DecodeOptions::new().with_config(qsystem_decoder_config()))
+        .unwrap();
     assert_eq!(circ.qubit_count(), num_qubits);
 
     if !has_tk1_ops {
         check_no_tk1_ops(&circ);
     }
 
-    let reser: SerialCircuit =
-        SerialCircuit::encode_with_config(&circ, qsystem_encoder_config()).unwrap();
+    let reser: SerialCircuit = SerialCircuit::encode(
+        &circ,
+        EncodeOptions::new().with_config(qsystem_encoder_config()),
+    )
+    .unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
 }
@@ -215,9 +221,16 @@ fn json_roundtrip(
 #[rstest]
 #[case::native_gates(circ_qsystem_native_gates(), Signature::new_endo(vec![qb_t(), qb_t(), bool_t(), bool_t()]))]
 fn circuit_roundtrip(#[case] circ: Circuit, #[case] decoded_sig: Signature) {
-    let ser: SerialCircuit =
-        SerialCircuit::encode_with_config(&circ, qsystem_encoder_config()).unwrap();
-    let deser: Circuit = ser.decode_with_config(qsystem_decoder_config()).unwrap();
+    use tket::serialize::pytket::EncodeOptions;
+
+    let ser: SerialCircuit = SerialCircuit::encode(
+        &circ,
+        EncodeOptions::new().with_config(qsystem_encoder_config()),
+    )
+    .unwrap();
+    let deser: Circuit = ser
+        .decode(DecodeOptions::new().with_config(qsystem_decoder_config()))
+        .unwrap();
 
     let deser_sig = deser.circuit_signature();
     assert_eq!(
@@ -231,7 +244,11 @@ fn circuit_roundtrip(#[case] circ: Circuit, #[case] decoded_sig: Signature) {
         &decoded_sig, &deser_sig
     );
 
-    let reser = SerialCircuit::encode_with_config(&deser, qsystem_encoder_config()).unwrap();
+    let reser = SerialCircuit::encode(
+        &deser,
+        EncodeOptions::new().with_config(qsystem_encoder_config()),
+    )
+    .unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
 }

--- a/tket/src/circuit.rs
+++ b/tket/src/circuit.rs
@@ -666,6 +666,7 @@ mod tests {
     use super::*;
     use crate::extension::rotation::ConstRotation;
     use crate::serialize::load_tk1_json_str;
+    use crate::serialize::pytket::DecodeOptions;
     use crate::utils::build_simple_circuit;
     use crate::TketOp;
 
@@ -684,7 +685,7 @@ mod tests {
             ],
             "implicit_permutation": [[["q", [0]], ["q", [0]]], [["q", [1]], ["q", [1]]]]
         }"#,
-            None,
+            DecodeOptions::new(),
         )
         .unwrap()
     }

--- a/tket/src/circuit/hash.rs
+++ b/tket/src/circuit/hash.rs
@@ -161,6 +161,7 @@ pub enum HashError {
 mod test {
     use tket_json_rs::circuit_json;
 
+    use crate::serialize::pytket::DecodeOptions;
     use crate::serialize::TKETDecode;
     use crate::utils::build_simple_circuit;
     use crate::TketOp;
@@ -207,7 +208,7 @@ mod test {
     fn hash_constants() {
         let c_str = r#"{"bits": [], "commands": [{"args": [["q", [0]]], "op": {"params": ["0.5"], "type": "Rz"}}], "created_qubits": [], "discarded_qubits": [], "implicit_permutation": [[["q", [0]], ["q", [0]]]], "phase": "0.0", "qubits": [["q", [0]]]}"#;
         let ser: circuit_json::SerialCircuit = serde_json::from_str(c_str).unwrap();
-        let circ: Circuit = ser.decode().unwrap();
+        let circ: Circuit = ser.decode(DecodeOptions::new()).unwrap();
         circ.circuit_hash(circ.parent()).unwrap();
     }
 
@@ -219,7 +220,7 @@ mod test {
         let mut all_hashes = Vec::with_capacity(2);
         for c_str in [c_str1, c_str2] {
             let ser: circuit_json::SerialCircuit = serde_json::from_str(c_str).unwrap();
-            let circ: Circuit = ser.decode().unwrap();
+            let circ: Circuit = ser.decode(DecodeOptions::new()).unwrap();
             all_hashes.push(circ.circuit_hash(circ.parent()).unwrap());
         }
         assert_ne!(all_hashes[0], all_hashes[1]);

--- a/tket/src/lib.rs
+++ b/tket/src/lib.rs
@@ -21,10 +21,11 @@
 #![cfg_attr(not(miri), doc = "```")] // this doctest reads from the filesystem, so it fails with miri
 #![cfg_attr(miri, doc = "```ignore")]
 //! use tket::Circuit;
+//! use tket::serialize::pytket::DecodeOptions;
 //! use hugr::HugrView;
 //!
 //! // Load a tket1 circuit.
-//! let mut circ: Circuit = tket::serialize::load_tk1_json_file("../test_files/barenco_tof_5.json", None).unwrap();
+//! let mut circ: Circuit = tket::serialize::load_tk1_json_file("../test_files/barenco_tof_5.json", DecodeOptions::new()).unwrap();
 //!
 //! assert_eq!(circ.qubit_count(), 9);
 //! assert_eq!(circ.num_operations(), 170);

--- a/tket/src/optimiser/badger.rs
+++ b/tket/src/optimiser/badger.rs
@@ -590,6 +590,7 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use crate::serialize::load_tk1_json_str;
+    use crate::serialize::pytket::DecodeOptions;
     use crate::{extension::rotation::rotation_type, optimiser::badger::BadgerOptions};
     use crate::{Circuit, TketOp};
 
@@ -635,7 +636,7 @@ mod tests {
     /// A circuit that would trigger non-composable rewrites, if we applied them blindly from nam_6_3 matches.
     #[fixture]
     fn non_composable_rw_hugr() -> Circuit {
-        load_tk1_json_str(NON_COMPOSABLE, None).unwrap()
+        load_tk1_json_str(NON_COMPOSABLE, DecodeOptions::new()).unwrap()
     }
 
     /// A badger optimiser using a reduced set of rewrite rules.

--- a/tket/src/serialize/pytket.rs
+++ b/tket/src/serialize/pytket.rs
@@ -3,21 +3,22 @@
 mod config;
 pub mod decoder;
 pub mod encoder;
+mod error;
 pub mod extension;
+mod options;
 
 pub use config::{
     default_decoder_config, default_encoder_config, PytketDecoderConfig, PytketEncoderConfig,
     TypeTranslatorSet,
 };
 pub use encoder::PytketEncoderContext;
+pub use error::{OpConvertError, PytketDecodeError, PytketDecodeErrorInner, PytketEncodeError};
 pub use extension::PytketEmitter;
-
-use hugr::core::HugrNode;
+pub use options::{DecodeInsertionTarget, DecodeOptions, EncodeOptions};
 
 use hugr::hugr::hugrmut::HugrMut;
 use hugr::ops::handle::NodeHandle;
-use hugr::{Hugr, Wire};
-use itertools::Itertools;
+use hugr::{Hugr, Node};
 
 #[cfg(test)]
 mod tests;
@@ -25,17 +26,12 @@ mod tests;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
-use std::sync::Arc;
 use std::{fs, io};
 
-use hugr::ops::OpType;
-
-use derive_more::{Display, Error, From};
 use tket_json_rs::circuit_json::SerialCircuit;
 use tket_json_rs::register::{Bit, ElementId, Qubit};
 
 use crate::circuit::Circuit;
-use crate::serialize::pytket::extension::RegisterCount;
 
 use self::decoder::PytketDecoderContext;
 
@@ -64,113 +60,134 @@ pub trait TKETDecode: Sized {
     type EncodeError;
     /// Convert the serialized circuit to a circuit.
     ///
-    /// Uses a default set of extension decoders to translate operations.
-    fn decode(&self) -> Result<Circuit, Self::DecodeError>;
-    /// Convert the serialized circuit to a circuit.
-    fn decode_with_config(
+    /// See [DecodeOptions] to define the options used by the decoder.
+    ///
+    /// # Arguments
+    ///
+    /// - `options`: The options for the decoder.
+    ///
+    /// # Returns
+    ///
+    /// The encoded circuit.
+    fn decode(&self, options: DecodeOptions) -> Result<Circuit, Self::DecodeError>;
+    /// Convert the serialized circuit into a function definition in an existing HUGR.
+    ///
+    /// Does **not** modify the HUGR's entrypoint.
+    ///
+    /// # Arguments
+    ///
+    /// - `hugr`: The HUGR to define the function in.
+    /// - `target`: Where to insert the decoded circuit.
+    /// - `options`: The options for the decoder.
+    ///
+    /// # Returns
+    ///
+    /// The node id of the defined function.
+    fn decode_inplace(
         &self,
-        config: impl Into<Arc<PytketDecoderConfig>>,
-    ) -> Result<Circuit, Self::DecodeError>;
+        // This cannot be a generic HugrMut since it is stored inside the `PytketDecoderContext` that we to be Send+Sync
+        // (so that the extension decoder traits are dyn-compatible).
+        hugr: &mut Hugr,
+        target: DecodeInsertionTarget,
+        options: DecodeOptions,
+    ) -> Result<Node, Self::DecodeError>;
     /// Convert a circuit to a serialized pytket circuit.
     ///
-    /// Uses a default set of emitters to translate operations.
-    /// If the circuit contains non-std operations or types,
-    /// use [`TKETDecode::encode_with_config`] instead.
-    fn encode(circuit: &Circuit) -> Result<Self, Self::EncodeError>;
-    /// Convert a circuit to a serialized pytket circuit.
+    /// See [EncodeOptions] for the options used by the encoder.
     ///
-    /// You may use [`TKETDecode::encode`] if the circuit does not contain
-    /// non-std operations or types.
-    fn encode_with_config(
-        circuit: &Circuit,
-        config: impl Into<Arc<PytketEncoderConfig<Hugr>>>,
-    ) -> Result<Self, Self::EncodeError>;
+    /// # Arguments
+    ///
+    /// - `circuit`: The circuit to encode.
+    /// - `options`: The options for the encoder.
+    ///
+    /// # Returns
+    ///
+    /// A serialized pytket circuit.
+    fn encode(circuit: &Circuit, options: EncodeOptions) -> Result<Self, Self::EncodeError>;
 }
 
 impl TKETDecode for SerialCircuit {
     type DecodeError = PytketDecodeError;
     type EncodeError = PytketEncodeError;
 
-    fn decode(&self) -> Result<Circuit, Self::DecodeError> {
-        let config = default_decoder_config();
-        Self::decode_with_config(self, config)
-    }
-
-    fn decode_with_config(
-        &self,
-        config: impl Into<Arc<PytketDecoderConfig>>,
-    ) -> Result<Circuit, Self::DecodeError> {
+    fn decode(&self, options: DecodeOptions) -> Result<Circuit, Self::DecodeError> {
         let mut hugr = Hugr::new();
-
-        let mut decoder =
-            PytketDecoderContext::new(self, &mut hugr, None, None, Vec::new(), config)?;
-        decoder.run_decoder(&self.commands)?;
-        let main_func = decoder.finish()?;
-        hugr.set_entrypoint(main_func.node());
+        let main_func = self.decode_inplace(&mut hugr, DecodeInsertionTarget::Function, options)?;
+        hugr.set_entrypoint(main_func);
         Ok(hugr.into())
     }
 
-    fn encode(circuit: &Circuit) -> Result<Self, Self::EncodeError> {
-        let config = default_encoder_config();
-        Self::encode_with_config(circuit, config)
+    fn decode_inplace(
+        &self,
+        hugr: &mut Hugr,
+        _target: DecodeInsertionTarget,
+        options: DecodeOptions,
+    ) -> Result<Node, Self::DecodeError> {
+        let config = options
+            .config
+            .unwrap_or_else(|| default_decoder_config().into());
+
+        let mut decoder = PytketDecoderContext::new(
+            self,
+            hugr,
+            options.fn_name,
+            options.signature,
+            options.input_params,
+            config,
+        )?;
+        decoder.run_decoder(&self.commands)?;
+        Ok(decoder.finish()?.node())
     }
 
-    fn encode_with_config(
-        circuit: &Circuit,
-        config: impl Into<Arc<PytketEncoderConfig<Hugr>>>,
-    ) -> Result<Self, Self::EncodeError> {
-        let mut encoder = PytketEncoderContext::new(circuit, circuit.parent(), config)?;
-        encoder.run_encoder(circuit, circuit.parent())?;
-        let (serial, _) = encoder.finish(circuit, circuit.parent())?;
+    fn encode(circuit: &Circuit, options: EncodeOptions) -> Result<Self, Self::EncodeError> {
+        let config = options
+            .config
+            .unwrap_or_else(|| default_encoder_config().into());
+        let region = circuit.parent();
+        let mut encoder = PytketEncoderContext::new(circuit, region, config)?;
+        encoder.run_encoder(circuit, region)?;
+        let (serial, _) = encoder.finish(circuit, region)?;
         Ok(serial)
     }
 }
 
 /// Load a TKET1 circuit from a JSON file.
 ///
-/// If a decoder config is provided, it will be used to decode the circuit.
-/// Otherwise, it defaults to [`default_decoder_config`].
+/// See [DecodeOptions] for the options used by the decoder.
 pub fn load_tk1_json_file(
     path: impl AsRef<Path>,
-    config: Option<PytketDecoderConfig>,
+    options: DecodeOptions,
 ) -> Result<Circuit, PytketDecodeError> {
     let file = fs::File::open(path).map_err(PytketDecodeError::custom)?;
     let reader = io::BufReader::new(file);
-    load_tk1_json_reader(reader, config)
+    load_tk1_json_reader(reader, options)
 }
 
 /// Load a TKET1 circuit from a JSON reader.
 ///
-/// If a decoder config is provided, it will be used to decode the circuit.
-/// Otherwise, it defaults to [`default_decoder_config`].
+/// See [DecodeOptions] for the options used by the decoder.
 pub fn load_tk1_json_reader(
     json: impl io::Read,
-    config: Option<PytketDecoderConfig>,
+    options: DecodeOptions,
 ) -> Result<Circuit, PytketDecodeError> {
-    let config = config.unwrap_or_else(default_decoder_config);
     let ser: SerialCircuit = serde_json::from_reader(json).map_err(PytketDecodeError::custom)?;
-    let circ: Circuit = ser.decode_with_config(config)?;
+    let circ: Circuit = ser.decode(options)?;
     Ok(circ)
 }
 
 /// Load a TKET1 circuit from a JSON string.
 ///
-/// If a decoder config is provided, it will be used to decode the circuit.
-/// Otherwise, it defaults to [`default_decoder_config`].
-pub fn load_tk1_json_str(
-    json: &str,
-    config: Option<PytketDecoderConfig>,
-) -> Result<Circuit, PytketDecodeError> {
+/// See [DecodeOptions] for the options used by the decoder.
+pub fn load_tk1_json_str(json: &str, options: DecodeOptions) -> Result<Circuit, PytketDecodeError> {
     let reader = json.as_bytes();
-    load_tk1_json_reader(reader, config)
+    load_tk1_json_reader(reader, options)
 }
 
 /// Save a circuit to file in TK1 JSON format.
 ///
 /// You may need to normalize the circuit using [`lower_to_pytket`] before saving.
 ///
-/// If an encoder config is provided, it will be used to encode the circuit.
-/// Otherwise, it defaults to [`default_encoder_config`].
+/// See [EncodeOptions] for the options used by the encoder.
 ///
 /// # Errors
 ///
@@ -179,19 +196,18 @@ pub fn load_tk1_json_str(
 pub fn save_tk1_json_file(
     circ: &Circuit,
     path: impl AsRef<Path>,
-    config: Option<PytketEncoderConfig<Hugr>>,
+    options: EncodeOptions,
 ) -> Result<(), PytketEncodeError> {
     let file = fs::File::create(path).map_err(PytketEncodeError::custom)?;
     let writer = io::BufWriter::new(file);
-    save_tk1_json_writer(circ, writer, config)
+    save_tk1_json_writer(circ, writer, options)
 }
 
 /// Save a circuit in TK1 JSON format to a writer.
 ///
 /// You may need to normalize the circuit using [`lower_to_pytket`] before saving.
 ///
-/// If an encoder config is provided, it will be used to encode the circuit.
-/// Otherwise, it defaults to [`default_encoder_config`].
+/// See [EncodeOptions] for the options used by the encoder.
 ///
 /// # Errors
 ///
@@ -200,10 +216,9 @@ pub fn save_tk1_json_file(
 pub fn save_tk1_json_writer(
     circ: &Circuit,
     w: impl io::Write,
-    config: Option<PytketEncoderConfig<Hugr>>,
+    options: EncodeOptions,
 ) -> Result<(), PytketEncodeError> {
-    let config = config.unwrap_or_else(default_encoder_config);
-    let serial_circ = SerialCircuit::encode_with_config(circ, config)?;
+    let serial_circ = SerialCircuit::encode(circ, options)?;
     serde_json::to_writer(w, &serial_circ).map_err(PytketEncodeError::custom)?;
     Ok(())
 }
@@ -212,8 +227,7 @@ pub fn save_tk1_json_writer(
 ///
 /// You may need to normalize the circuit using [`lower_to_pytket`] before saving.
 ///
-/// If an encoder config is provided, it will be used to encode the circuit.
-/// Otherwise, it defaults to [`default_encoder_config`].
+/// See [EncodeOptions] for the options used by the encoder.
 ///
 /// # Errors
 ///
@@ -221,375 +235,12 @@ pub fn save_tk1_json_writer(
 /// supported by pytket.
 pub fn save_tk1_json_str(
     circ: &Circuit,
-    config: Option<PytketEncoderConfig<Hugr>>,
+    options: EncodeOptions,
 ) -> Result<String, PytketEncodeError> {
     let mut buf = io::BufWriter::new(Vec::new());
-    save_tk1_json_writer(circ, &mut buf, config)?;
+    save_tk1_json_writer(circ, &mut buf, options)?;
     let bytes = buf.into_inner().unwrap();
     String::from_utf8(bytes).map_err(PytketEncodeError::custom)
-}
-
-/// Error type for conversion between pytket operations and tket ops.
-#[derive(Display, derive_more::Debug, Error)]
-#[non_exhaustive]
-#[debug(bounds(N: HugrNode))]
-pub enum OpConvertError<N = hugr::Node> {
-    /// Tried to decode a tket1 operation with not enough parameters.
-    #[display(
-        "Operation {} is missing encoded parameters. Expected at least {expected} but only \"{}\" were specified.",
-        optype,
-        params.iter().join(", "),
-    )]
-    MissingSerialisedParams {
-        /// The operation name.
-        optype: OpType,
-        /// The expected number of parameters.
-        expected: usize,
-        /// The given of parameters.
-        params: Vec<String>,
-    },
-    /// Tried to decode a tket1 operation with not enough qubit/bit arguments.
-    #[display(
-        "Operation {} is missing encoded arguments. Expected {expected_qubits} and {expected_bits}, but only \"{args:?}\" were specified.",
-        optype,
-    )]
-    MissingSerialisedArguments {
-        /// The operation name.
-        optype: OpType,
-        /// The expected number of qubits.
-        expected_qubits: usize,
-        /// The expected number of bits.
-        expected_bits: usize,
-        /// The given of parameters.
-        args: Vec<ElementId>,
-    },
-    /// Tried to query the values associated with an unexplored wire.
-    ///
-    /// This reflects a bug in the operation encoding logic of an operation.
-    #[display("Could not find values associated with wire {wire}.")]
-    WireHasNoValues {
-        /// The wire that has no values.
-        wire: Wire<N>,
-    },
-    /// Tried to add values to an already registered wire.
-    ///
-    /// This reflects a bug in the operation encoding logic of an operation.
-    #[display("Tried to register values for wire {wire}, but it already has associated values.")]
-    WireAlreadyHasValues {
-        /// The wire that already has values.
-        wire: Wire<N>,
-    },
-}
-
-/// Error type for conversion between tket ops and pytket operations.
-#[derive(derive_more::Debug, Display, Error, From)]
-#[non_exhaustive]
-#[debug(bounds(N: HugrNode))]
-pub enum PytketEncodeError<N = hugr::Node> {
-    /// Tried to encode a non-dataflow region.
-    #[display("Cannot encode non-dataflow region at {region} with type {optype}.")]
-    NonDataflowRegion {
-        /// The region that is not a dataflow region.
-        region: N,
-        /// The operation type of the region.
-        optype: String,
-    },
-    /// Operation conversion error.
-    #[from]
-    OpConversionError(OpConvertError<N>),
-    /// Custom user-defined error raised while encoding an operation.
-    #[display("Error while encoding operation: {msg}")]
-    CustomError {
-        /// The custom error message
-        msg: String,
-    },
-}
-
-impl<N> PytketEncodeError<N> {
-    /// Create a new error with a custom message.
-    pub fn custom(msg: impl ToString) -> Self {
-        Self::CustomError {
-            msg: msg.to_string(),
-        }
-    }
-}
-
-/// Error type for conversion between tket2 ops and pytket operations.
-#[derive(derive_more::Debug, Display, Error, Clone)]
-#[non_exhaustive]
-#[display(
-    "{inner}{context}",
-    context = {
-        match (pytket_op, hugr_op) {
-            (Some(pytket_op), Some(hugr_op)) => format!(". While decoding a pytket {pytket_op} as a hugr {hugr_op}"),
-            (Some(pytket_op), None) => format!(". While decoding a pytket {pytket_op}"),
-            (None, Some(hugr_op)) => format!(". While decoding a hugr {hugr_op}"),
-            (None, None) => String::new(),
-        }
-    },
-)]
-pub struct PytketDecodeError {
-    /// The kind of error.
-    pub inner: PytketDecodeErrorInner,
-    /// The pytket operation that caused the error, if applicable.
-    pub pytket_op: Option<String>,
-    /// The hugr operation that caused the error, if applicable.
-    pub hugr_op: Option<String>,
-}
-
-impl PytketDecodeError {
-    /// Create a new error with a custom message.
-    pub fn custom(msg: impl ToString) -> Self {
-        PytketDecodeErrorInner::CustomError {
-            msg: msg.to_string(),
-        }
-        .into()
-    }
-
-    /// Create an error for an unknown qubit register.
-    pub fn unknown_qubit_reg(register: &tket_json_rs::register::ElementId) -> Self {
-        PytketDecodeErrorInner::UnknownQubitRegister {
-            register: register.to_string(),
-        }
-        .into()
-    }
-
-    /// Create an error for an unknown bit register.
-    pub fn unknown_bit_reg(register: &tket_json_rs::register::ElementId) -> Self {
-        PytketDecodeErrorInner::UnknownBitRegister {
-            register: register.to_string(),
-        }
-        .into()
-    }
-
-    /// Add the pytket operation name to the error.
-    pub fn pytket_op(mut self, op: &tket_json_rs::OpType) -> Self {
-        self.pytket_op = Some(format!("{op}"));
-        self
-    }
-
-    /// Add the hugr operation name to the error.
-    pub fn hugr_op(mut self, op: impl ToString) -> Self {
-        self.hugr_op = Some(op.to_string());
-        self
-    }
-}
-
-impl From<PytketDecodeErrorInner> for PytketDecodeError {
-    fn from(inner: PytketDecodeErrorInner) -> Self {
-        Self {
-            inner,
-            pytket_op: None,
-            hugr_op: None,
-        }
-    }
-}
-
-/// Error variants of [`PytketDecodeError`], signalling errors during the
-/// conversion between tket2 ops and pytket operations.
-#[derive(derive_more::Debug, Display, Error, Clone)]
-#[non_exhaustive]
-pub enum PytketDecodeErrorInner {
-    /// The pytket circuit uses multi-indexed registers.
-    //
-    // This could be supported in the future, if there is a need for it.
-    #[display("Register {register} in the circuit has multiple indices. Tket2 does not support multi-indexed registers")]
-    MultiIndexedRegister {
-        /// The register name.
-        register: String,
-    },
-    /// Found an unexpected register name.
-    #[display("Found an unknown qubit register name: {register}")]
-    UnknownQubitRegister {
-        /// The unknown register name.
-        register: String,
-    },
-    /// Found an unexpected bit register name.
-    #[display("Found an unknown bit register name: {register}")]
-    UnknownBitRegister {
-        /// The unknown register name.
-        register: String,
-    },
-    /// The given signature to use for the HUGR's input wires is not compatible with the number of qubits and bits in the pytket circuit.
-    ///
-    /// The expected number of qubits and bits may be different depending on the [`PytketTypeTranslator`][extension::PytketTypeTranslator]s used in the decoder config.
-    #[display(
-        "The given input types {input_types} to use for the HUGR's input wires are not compatible with the number of qubits and bits in the pytket circuit. Expected {expected_qubits} qubits and {expected_bits} bits, but found {circ_qubits} qubits and {circ_bits} bits",
-        input_types = input_types.iter().join(", "),
-    )]
-    InvalidInputSignature {
-        /// The given input types.
-        input_types: Vec<String>,
-        /// The expected number of qubits in the signature.
-        expected_qubits: usize,
-        /// The expected number of bits in the signature.
-        expected_bits: usize,
-        /// The number of qubits in the pytket circuit.
-        circ_qubits: usize,
-        /// The number of bits in the pytket circuit.
-        circ_bits: usize,
-    },
-    /// The signature to use for the HUGR's output wires is not compatible with the number of qubits and bits in the pytket circuit.
-    ///
-    /// We don't do any kind of type conversion, so this depends solely on the last operation to update each register.
-    #[display(
-        "The expected output types {expected_types} are not compatible with the actual output types {actual_types}, obtained from decoding the pytket circuit",
-        expected_types = expected_types.iter().join(", "),
-        actual_types = actual_types.iter().join(", "),
-    )]
-    InvalidOutputSignature {
-        /// The expected types of the input wires.
-        expected_types: Vec<String>,
-        /// The actual types of the input wires.
-        actual_types: Vec<String>,
-    },
-    /// A pytket operation had some input registers that couldn't be mapped to hugr wires.
-    //
-    // Some of this errors will be avoided in the future once we are able to decompose complex types automatically.
-    #[display(
-        "Could not find a wire with the required qubit arguments [{qubit_args:?}] and bit arguments [{bit_args:?}]",
-        qubit_args = qubit_args.iter().join(", "),
-        bit_args = bit_args.iter().join(", "),
-    )]
-    ArgumentCouldNotBeMapped {
-        /// The qubit arguments that couldn't be mapped.
-        qubit_args: Vec<String>,
-        /// The bit arguments that couldn't be mapped.
-        bit_args: Vec<String>,
-    },
-    /// Found an unexpected number of input wires when decoding an operation.
-    #[display(
-            "Expected {expected_values} input value wires{expected_types} and {expected_params} input parameters, but found {actual_values} values{actual_types} and {actual_params} parameters",
-            expected_types = match expected_types {
-                None => "".to_string(),
-                Some(tys) => format!(" with types [{}]", tys.iter().join(", ")),
-            },
-            actual_types = match actual_types {
-                None => "".to_string(),
-                Some(tys) => format!(" with types [{}]", tys.iter().join(", ")),
-            },
-        )]
-    UnexpectedInputWires {
-        /// The expected amount of input wires.
-        expected_values: usize,
-        /// The expected amount of input parameters.
-        expected_params: usize,
-        /// The actual amount of input wires.
-        actual_values: usize,
-        /// The actual amount of input parameters.
-        actual_params: usize,
-        /// The expected types of the input wires.
-        expected_types: Option<Vec<String>>,
-        /// The actual types of the input wires.
-        actual_types: Option<Vec<String>>,
-    },
-    /// Found an unexpected input type when decoding an operation.
-    #[display(
-        "Found an unexpected type {unknown_type} in the input wires, in input signature ({all_types})",
-        all_types = all_types.iter().join(", "),
-    )]
-    UnexpectedInputType {
-        /// The unknown type.
-        unknown_type: String,
-        /// All the input types specified for the operation.
-        all_types: Vec<String>,
-    },
-    /// Tried to track the output wires of a node, but the number of tracked elements didn't match the ones in the output wires.
-    #[display(
-        "Tried to track the output wires of a node, but the number of tracked elements didn't match the ones in the output wires. Expected {expected_qubits} qubits and {expected_bits} bits, but found {circ_qubits} qubits and {circ_bits} bits in the node outputs"
-    )]
-    UnexpectedNodeOutput {
-        /// The expected number of qubits.
-        expected_qubits: usize,
-        /// The expected number of bits.
-        expected_bits: usize,
-        /// The number of qubits in HUGR node outputs.
-        circ_qubits: usize,
-        /// The number of bits in HUGR node output.
-        circ_bits: usize,
-    },
-    /// Custom user-defined error raised while encoding an operation.
-    #[display("Error while decoding operation: {msg}")]
-    CustomError {
-        /// The custom error message
-        msg: String,
-    },
-    /// Input parameter was defined multiple times.
-    #[display("Parameter {param} was defined multiple times in the input signature")]
-    DuplicatedParameter {
-        /// The parameter name.
-        param: String,
-    },
-    /// Not enough parameter names given for the input signature.
-    #[display("Tried to initialize a pytket circuit decoder with {num_params_given} given parameter names, but more were required by the input signature")]
-    MissingParametersInInput {
-        /// The number of parameters given.
-        num_params_given: usize,
-    },
-    /// We don't support complex types containing parameters in the input.
-    //
-    // This restriction may be relaxed in the future.
-    #[display("Complex type {ty} contains {num_params} inside it. We only support input parameters in standalone 'float' or 'rotation'-typed wires")]
-    UnsupportedParametersInInput {
-        /// The type that contains the parameters.
-        ty: String,
-        /// The number of parameters in the type.
-        num_params: usize,
-    },
-    /// We couldn't find a wire that contains the required type.
-    #[display(
-        "Could not find a wire with type {ty} that contains {expected_arguments}",
-        expected_arguments = match (qubit_args.is_empty(), bit_args.is_empty()) {
-            (true, true) => "no arguments".to_string(),
-            (true, false) => format!("pytket bit arguments [{}]", bit_args.iter().join(", ")),
-            (false, true) => format!("pytket qubit arguments [{}]", qubit_args.iter().join(", ")),
-            (false, false) => format!("pytket qubit and bit arguments [{}] and [{}]", qubit_args.iter().join(", "), bit_args.iter().join(", ")),
-        },
-    )]
-    NoMatchingWire {
-        /// The type that couldn't be found.
-        ty: String,
-        /// The qubit registers expected in the wire.
-        qubit_args: Vec<String>,
-        /// The bit registers expected in the wire.
-        bit_args: Vec<String>,
-    },
-    /// The number of pytket registers expected for an operation is not enough.
-    ///
-    /// This is usually caused by a mismatch between the input signature and the number of registers in the pytket circuit.
-    ///
-    /// The expected number of registers may be different depending on the [`PytketTypeTranslator`][extension::PytketTypeTranslator]s used in the decoder config.
-    #[display(
-        "Expected {expected_count} to map types ({expected_types}), but only got {actual_count}",
-        expected_types = expected_types.iter().join(", "),
-    )]
-    NotEnoughPytketRegisters {
-        /// The types we tried to get wires for.
-        expected_types: Vec<String>,
-        /// The number of registers required by the types.
-        expected_count: RegisterCount,
-        /// The number of registers we actually got.
-        actual_count: RegisterCount,
-    },
-    /// A qubit was marked as outdated, but was expected to be fresh.
-    #[display("Discarded qubit {qubit} cannot be used as an input")]
-    OutdatedQubit {
-        /// The qubit that was marked as outdated.
-        qubit: String,
-    },
-    /// A bit was marked as outdated, but was expected to be fresh.
-    #[display("Discarded bit {bit} cannot be used as an input")]
-    OutdatedBit {
-        /// The bit that was marked as outdated.
-        bit: String,
-    },
-}
-
-impl PytketDecodeErrorInner {
-    /// Wrap the error in a [`PytketDecodeError`].
-    pub fn wrap(self) -> PytketDecodeError {
-        PytketDecodeError::from(self)
-    }
 }
 
 /// A hashed register, used to identify registers in the [`Tk1Decoder::register_wire`] map,

--- a/tket/src/serialize/pytket/options.rs
+++ b/tket/src/serialize/pytket/options.rs
@@ -1,0 +1,116 @@
+//! Option structs for the [TKETDecode][super::TKETDecode] trait methods.
+
+use std::sync::Arc;
+
+use hugr::types::Signature;
+use hugr::Hugr;
+
+use crate::serialize::pytket::{PytketDecoderConfig, PytketEncoderConfig};
+
+/// Options used when decoding a pytket
+/// [`SerialCircuit`][tket_json_rs::circuit_json::SerialCircuit] into a HUGR.
+///
+/// See [TKETDecode::decode][super::TKETDecode::decode].
+///
+/// In contrast to [PytketDecoderConfig] which is normally statically defined by
+/// a library, these options may vary between calls.
+#[derive(Default, Clone)]
+#[non_exhaustive]
+pub struct DecodeOptions {
+    /// The configuration for the decoder, containing custom
+    /// operation decoders.
+    ///
+    /// When `None`, we will use [`default_decoder_config`][super::default_decoder_config].
+    pub config: Option<Arc<PytketDecoderConfig>>,
+    /// The name of the function to create.
+    ///
+    /// If `None`, we will use the name of the circuit, or "main" if the circuit
+    /// has no name.
+    pub fn_name: Option<String>,
+    /// The signature of the function to create. This should match the number of qubits and bits in the circuit.
+    ///
+    /// If `None`, we will use qubits, bools, and [rotation_type][crate::extension::rotation::rotation_type] parameters.
+    pub signature: Option<Signature>,
+    /// A list of parameter names to add to the function input.
+    ///
+    /// If additional parameters are found in the circuit, they will be added
+    /// after these using generic names.
+    pub input_params: Vec<String>,
+}
+
+impl DecodeOptions {
+    /// Create a new [`DecodeOptions`] with the default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a decoder configuration.
+    pub fn with_config(mut self, config: impl Into<Arc<PytketDecoderConfig>>) -> Self {
+        self.config = Some(config.into());
+        self
+    }
+
+    /// Set the name of the function to create.
+    pub fn with_fn_name(mut self, fn_name: impl ToString) -> Self {
+        self.fn_name = Some(fn_name.to_string());
+        self
+    }
+
+    /// Set the signature of the function to create.
+    pub fn with_signature(mut self, signature: Signature) -> Self {
+        self.signature = Some(signature);
+        self
+    }
+
+    /// Set the input parameter names.
+    pub fn with_input_params(mut self, input_params: impl IntoIterator<Item = String>) -> Self {
+        self.input_params = input_params.into_iter().collect();
+        self
+    }
+}
+
+/// Where to insert the decoded circuit when calling
+/// [`TKETDecode::decode_inplace`][super::TKETDecode::decode_inplace].
+#[derive(Debug, derive_more::Display, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DecodeInsertionTarget {
+    /// Insert the decoded circuit as a new function in the HUGR.
+    #[default]
+    Function,
+    // TODO: To be added in a follow-up PR.
+    // Insert the decoded circuit as a dataflow region in the HUGR under the given parent.
+    //Region {
+    //    /// The parent node that will contain the circuit's decoded DFG.
+    //    parent: Node,
+    //},
+}
+
+/// Options used when encoding a HUGR into a pytket
+/// [`SerialCircuit`][tket_json_rs::circuit_json::SerialCircuit].
+///
+/// See [TKETDecode::encode][super::TKETDecode::encode].
+///
+/// In contrast to [PytketEncoderConfig] which is normally statically defined by
+/// a library, these options may vary between calls.
+#[derive(Default, Clone)]
+#[non_exhaustive]
+pub struct EncodeOptions {
+    /// The configuration for the decoder, containing custom
+    /// operation decoders.
+    ///
+    /// When `None`, we will use [`default_encoder_config`][super::default_encoder_config].
+    pub config: Option<Arc<PytketEncoderConfig<Hugr>>>,
+}
+
+impl EncodeOptions {
+    /// Create a new [`EncodeOptions`] with the default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a encoder configuration.
+    pub fn with_config(mut self, config: impl Into<Arc<PytketEncoderConfig<Hugr>>>) -> Self {
+        self.config = Some(config.into());
+        self
+    }
+}

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -21,6 +21,7 @@ use crate::circuit::Circuit;
 use crate::extension::rotation::{rotation_type, ConstRotation, RotationOp};
 use crate::extension::sympy::SympyOpDef;
 use crate::extension::TKET1_EXTENSION_ID;
+use crate::serialize::pytket::{DecodeOptions, EncodeOptions};
 use crate::TketOp;
 
 const SIMPLE_JSON: &str = r#"{
@@ -442,14 +443,14 @@ fn json_roundtrip(
     let ser: circuit_json::SerialCircuit = serde_json::from_str(circ_s).unwrap();
     assert_eq!(ser.commands.len(), num_commands);
 
-    let circ: Circuit = ser.decode().unwrap();
+    let circ: Circuit = ser.decode(DecodeOptions::new()).unwrap();
     assert_eq!(circ.qubit_count(), num_qubits);
 
     if !has_tk1_ops {
         check_no_tk1_ops(&circ);
     }
 
-    let reser: SerialCircuit = SerialCircuit::encode(&circ).unwrap();
+    let reser: SerialCircuit = SerialCircuit::encode(&circ, EncodeOptions::new()).unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
 }
@@ -460,11 +461,11 @@ fn json_roundtrip(
 fn json_file_roundtrip(#[case] circ: impl AsRef<std::path::Path>) {
     let reader = BufReader::new(std::fs::File::open(circ).unwrap());
     let ser: circuit_json::SerialCircuit = serde_json::from_reader(reader).unwrap();
-    let circ: Circuit = ser.decode().unwrap();
+    let circ: Circuit = ser.decode(DecodeOptions::new()).unwrap();
 
     check_no_tk1_ops(&circ);
 
-    let reser: SerialCircuit = SerialCircuit::encode(&circ).unwrap();
+    let reser: SerialCircuit = SerialCircuit::encode(&circ, EncodeOptions::new()).unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
 }
@@ -477,8 +478,11 @@ fn json_file_roundtrip(#[case] circ: impl AsRef<std::path::Path>) {
 #[case::preset_qubits(circ_preset_qubits(), Signature::new_endo(vec![qb_t(), qb_t(), qb_t()]))]
 #[case::preset_parameterized(circ_parameterized(), Signature::new(vec![qb_t(), rotation_type(), rotation_type(), rotation_type()], vec![qb_t()]))]
 fn circuit_roundtrip(#[case] circ: Circuit, #[case] decoded_sig: Signature) {
-    let ser: SerialCircuit = SerialCircuit::encode(&circ).unwrap();
-    let deser: Circuit = ser.decode().unwrap();
+    let ser: SerialCircuit =
+        SerialCircuit::encode(&circ, EncodeOptions::new()).unwrap_or_else(|e| panic!("{e}"));
+    let deser: Circuit = ser
+        .decode(DecodeOptions::new())
+        .unwrap_or_else(|e| panic!("{e}"));
 
     let deser_sig = deser.circuit_signature();
     assert_eq!(
@@ -492,7 +496,7 @@ fn circuit_roundtrip(#[case] circ: Circuit, #[case] decoded_sig: Signature) {
         &decoded_sig, &deser_sig
     );
 
-    let reser = SerialCircuit::encode(&deser).unwrap();
+    let reser = SerialCircuit::encode(&deser, EncodeOptions::new()).unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
 }
@@ -509,13 +513,13 @@ fn circuit_roundtrip(#[case] circ: Circuit, #[case] decoded_sig: Signature) {
 fn test_add_angle_serialise(#[case] circ_add_angles: (Circuit, String)) {
     let (circ, expected) = circ_add_angles;
 
-    let ser: SerialCircuit = SerialCircuit::encode(&circ).unwrap();
+    let ser: SerialCircuit = SerialCircuit::encode(&circ, EncodeOptions::new()).unwrap();
     assert_eq!(ser.commands.len(), 1);
     assert_eq!(ser.commands[0].op.op_type, optype::OpType::Rx);
     assert_eq!(ser.commands[0].op.params, Some(vec![expected]));
 
-    let deser: Circuit = ser.decode().unwrap();
-    let reser = SerialCircuit::encode(&deser).unwrap();
+    let deser: Circuit = ser.decode(DecodeOptions::new()).unwrap();
+    let reser = SerialCircuit::encode(&deser, EncodeOptions::new()).unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
 }

--- a/tket/tests/badger_termination.rs
+++ b/tket/tests/badger_termination.rs
@@ -4,6 +4,7 @@
 use rstest::{fixture, rstest};
 use tket::optimiser::badger::BadgerOptions;
 use tket::optimiser::{BadgerOptimiser, ECCBadgerOptimiser};
+use tket::serialize::pytket::DecodeOptions;
 use tket::serialize::TKETDecode;
 use tket::Circuit;
 use tket_json_rs::circuit_json::SerialCircuit;
@@ -50,7 +51,7 @@ fn simple_circ() -> Circuit {
         "qubits": [["q", [0]], ["q", [1]], ["q", [2]]]
     }"#;
     let ser: SerialCircuit = serde_json::from_str(json).unwrap();
-    ser.decode().unwrap()
+    ser.decode(DecodeOptions::new()).unwrap()
 }
 
 #[rstest]


### PR DESCRIPTION
- Defines option structs for the pytket encoder/decoder. Now we can set the desired function name, hint the circuit's signature, or provide the order of input parameter names while decoding.

- Adds a `decode_inplace` that takes a HUGR and decodes the circuit inside of it. Currently it always inserts a function, I'll follow up with a (non-breaking) PR that adds the option to insert it directly as a DFG.

- Moves the error definitions into a submodule to avoid bloating `pytket.rs`. No code has been modified there.

BREAKING CHANGE: Changed pytket encode/decode functions to take `DecodeOptions`/`EncodeOptions` structs.

I had to modify some internal calls in `tket-py`, but this is not a breaking change for the python lib.

BEGIN_COMMIT_OVERRIDE

chore: Update pytket decode/encode calls after breaking rust changes

END_COMMIT_OVERRIDE