### PR TITLE
feat: Decode pytket circs into DFGs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,8 +1057,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb9c2b19e769863a1e059045595136ac5f6f37e98bc605447a0b728e72fff11"
+source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1069,8 +1068,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7318c8514063e835ef4720babb141dc53c96dd47f204ae584de67afb3fb1f2"
+source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
 dependencies = [
  "anyhow",
  "clap",
@@ -1087,8 +1085,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f1b84868164b0ab995814f8b3f07dbc4a142c3726d6aceae0e95fce047525e"
+source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
 dependencies = [
  "base64",
  "cgmath",
@@ -1125,8 +1122,7 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5228ef837b3bc4cf004798d8aa5aa18131f04c9224c31cbbbf29b8572639066c"
+source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
 dependencies = [
  "anyhow",
  "delegate 0.13.4",
@@ -1145,8 +1141,7 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b426a1907de2375f7afbf92aa79dc41bad805486c40201414707ae72e03dbb80"
+source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1167,8 +1162,7 @@ dependencies = [
 [[package]]
 name = "hugr-passes"
 version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ca4e34988b934e3a3e59c4756605df3eaa8bc62d9d89b33b19d8875170a2f9"
+source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
 dependencies = [
  "ascent",
  "derive_more 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,8 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.22.3"
-source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b0f6da51aacb075c0ca32175d5e94d1faac26a65e724a709e9dda140f5cf6d8"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1067,8 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.22.3"
-source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf6f6ac3e286f2243a473a67fb9bc088adc1dfebc64259a0d7fe7c9aa08a485"
 dependencies = [
  "anyhow",
  "clap",
@@ -1084,8 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.22.3"
-source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02adddac00b90be154a77568c578607d264df37b0d294a82d770a429fb0ec19"
 dependencies = [
  "base64",
  "cgmath",
@@ -1121,8 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-llvm"
-version = "0.22.3"
-source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942dd96ad1d017c039fd4c1625e318373bb5bb28a8fec246992c872cbbb82252"
 dependencies = [
  "anyhow",
  "delegate 0.13.4",
@@ -1140,8 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-model"
-version = "0.22.3"
-source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833f5b5163876e24de1e80df1074cdf22a98142ee4774700059397769ad1be0b"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1161,8 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-passes"
-version = "0.22.3"
-source = "git+https://github.com/CQCL/hugr?rev=2bab2a1b#2bab2a1b1b5ff879c2611381b32c90489e959c84"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd0bb069bc068ac4f705c23767477feb29b108d33ae1846c14823eaf2f1851b"
 dependencies = [
  "ascent",
  "derive_more 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,18 +38,18 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
-hugr-core = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
-hugr-passes = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
-hugr-cli = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
+#hugr = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
+#hugr-core = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
+#hugr-passes = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
+#hugr-cli = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
 # portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]
 
 # Make sure to run `just recompile-eccs` if the hugr serialisation format changes.
-hugr = "0.22.3"
-hugr-core = "0.22.3"
-hugr-cli = "0.22.3"
+hugr = "0.22.4"
+hugr-core = "0.22.4"
+hugr-cli = "0.22.4"
 portgraph = "0.15.2"
 pyo3 = ">= 0.23.4, < 0.27"
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-#hugr = { git = "https://github.com/CQCL/hugr", "rev" = "f7cedb4f39b67a77b4c6a55ec00b624b54668eaa" }
-#hugr-core = { git = "https://github.com/CQCL/hugr", "rev" = "f7cedb4f39b67a77b4c6a55ec00b624b54668eaa" }
-#hugr-passes = { git = "https://github.com/CQCL/hugr", "rev" = "f7cedb4f39b67a77b4c6a55ec00b624b54668eaa" }
-#hugr-cli = { git = "https://github.com/CQCL/hugr", "rev" = "f7cedb4f39b67a77b4c6a55ec00b624b54668eaa" }
+hugr = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
+hugr-core = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
+hugr-passes = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
+hugr-cli = { git = "https://github.com/CQCL/hugr", "rev" = "2bab2a1b" }
 # portgraph = { git = "https://github.com/CQCL/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/tket/src/serialize/pytket.rs
+++ b/tket/src/serialize/pytket.rs
@@ -120,7 +120,7 @@ impl TKETDecode for SerialCircuit {
     fn decode_inplace(
         &self,
         hugr: &mut Hugr,
-        _target: DecodeInsertionTarget,
+        target: DecodeInsertionTarget,
         options: DecodeOptions,
     ) -> Result<Node, Self::DecodeError> {
         let config = options
@@ -130,6 +130,7 @@ impl TKETDecode for SerialCircuit {
         let mut decoder = PytketDecoderContext::new(
             self,
             hugr,
+            target,
             options.fn_name,
             options.signature,
             options.input_params,

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -160,7 +160,12 @@ impl<'h> PytketDecoderContext<'h> {
 
     /// Initialize the wire tracker with the input wires.
     ///
-    /// Utility method for [`PytketDecoderContext::new_arc`].
+    /// Utility method for [`PytketDecoderContext::new`].
+    ///
+    /// # Panics
+    ///
+    /// If the dfg builder does not support adding input wires.
+    /// (That is, we're not building a FuncDefn or a DFG).
     fn init_wire_tracker(
         serialcirc: &SerialCircuit,
         dfg: &mut DFGBuilder<&mut Hugr>,
@@ -232,7 +237,9 @@ impl<'h> PytketDecoderContext<'h> {
 
         // Insert any remaining parameters as new inputs
         for param in input_params {
-            let wire = dfg.add_input(rotation_type()).unwrap();
+            let wire = dfg
+                .add_input(rotation_type())
+                .expect("Must be building a FuncDefn or a DFG");
             wire_tracker.register_input_parameter(wire, param)?;
         }
 

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -4,16 +4,19 @@ mod param;
 mod tracked_elem;
 mod wires;
 
+use hugr::hugr::hugrmut::HugrMut;
 pub use param::{LoadedParameter, ParameterType};
 pub use tracked_elem::{TrackedBit, TrackedQubit};
 pub use wires::TrackedWires;
 
 use std::sync::Arc;
 
-use hugr::builder::{BuildHandle, Container, Dataflow, DataflowSubContainer, FunctionBuilder};
+use hugr::builder::{
+    BuildHandle, Container, DFGBuilder, Dataflow, DataflowSubContainer, FunctionBuilder,
+};
 use hugr::extension::prelude::{bool_t, qb_t};
-use hugr::ops::handle::{DataflowOpID, FuncID, NodeHandle};
-use hugr::ops::{OpParent, OpTrait, OpType};
+use hugr::ops::handle::{DataflowOpID, NodeHandle};
+use hugr::ops::{OpParent, OpTrait, OpType, DFG};
 use hugr::types::{Signature, Type, TypeRow};
 use hugr::{Hugr, HugrView, Node, OutgoingPort, Wire};
 use tracked_elem::{TrackedBitId, TrackedQubitId};
@@ -31,7 +34,7 @@ use crate::extension::rotation::rotation_type;
 use crate::serialize::pytket::config::PytketDecoderConfig;
 use crate::serialize::pytket::decoder::wires::WireTracker;
 use crate::serialize::pytket::extension::{build_opaque_tket_op, RegisterCount};
-use crate::serialize::pytket::PytketDecodeErrorInner;
+use crate::serialize::pytket::{DecodeInsertionTarget, PytketDecodeErrorInner};
 
 /// State of the tket circuit being decoded.
 ///
@@ -39,7 +42,7 @@ use crate::serialize::pytket::PytketDecodeErrorInner;
 #[derive(Debug)]
 pub struct PytketDecoderContext<'h> {
     /// The Hugr being built.
-    pub builder: FunctionBuilder<&'h mut Hugr>,
+    pub builder: DFGBuilder<&'h mut Hugr>,
     /// A tracker keeping track of the generated wires and their corresponding types.
     pub(super) wire_tracker: WireTracker,
     /// Configuration for decoding commands.
@@ -89,15 +92,16 @@ impl<'h> PytketDecoderContext<'h> {
     pub(super) fn new(
         serialcirc: &SerialCircuit,
         hugr: &'h mut Hugr,
+        target: DecodeInsertionTarget,
         fn_name: Option<String>,
         signature: Option<Signature>,
         input_params: impl IntoIterator<Item = String>,
         config: impl Into<Arc<PytketDecoderConfig>>,
     ) -> Result<Self, PytketDecodeError> {
         let config: Arc<PytketDecoderConfig> = config.into();
-        let num_qubits = serialcirc.qubits.len();
-        let num_bits = serialcirc.bits.len();
         let signature = signature.unwrap_or_else(|| {
+            let num_qubits = serialcirc.qubits.len();
+            let num_bits = serialcirc.bits.len();
             let types: TypeRow = [vec![qb_t(); num_qubits], vec![bool_t(); num_bits]]
                 .concat()
                 .into();
@@ -106,8 +110,20 @@ impl<'h> PytketDecoderContext<'h> {
         let name = fn_name
             .or_else(|| serialcirc.name.clone())
             .unwrap_or_default();
-        let mut dfg: FunctionBuilder<&mut Hugr> =
-            FunctionBuilder::with_hugr(hugr, name, signature.clone()).unwrap();
+        let mut dfg: DFGBuilder<&mut Hugr> = match target {
+            DecodeInsertionTarget::Function => {
+                FunctionBuilder::with_hugr(hugr, name, signature.clone())
+                    .unwrap()
+                    .into_dfg_builder()
+            }
+            DecodeInsertionTarget::Region { parent } => {
+                let op = DFG {
+                    signature: signature.clone(),
+                };
+                let dfg = hugr.add_node_with_parent(parent, op);
+                DFGBuilder::create_with_io(hugr, dfg, signature.clone()).unwrap()
+            }
+        };
 
         Self::init_metadata(&mut dfg, serialcirc);
         let wire_tracker = Self::init_wire_tracker(
@@ -134,7 +150,7 @@ impl<'h> PytketDecoderContext<'h> {
 
     /// Store the serialised circuit information as HUGR metadata,
     /// so it can be reused later when re-encoding the circuit.
-    fn init_metadata(dfg: &mut FunctionBuilder<&mut Hugr>, serialcirc: &SerialCircuit) {
+    fn init_metadata(dfg: &mut DFGBuilder<&mut Hugr>, serialcirc: &SerialCircuit) {
         // Metadata. The circuit requires "name", and we store other things that
         // should pass through the serialization roundtrip.
         dfg.set_metadata(METADATA_PHASE, json!(serialcirc.phase));
@@ -147,7 +163,7 @@ impl<'h> PytketDecoderContext<'h> {
     /// Utility method for [`PytketDecoderContext::new_arc`].
     fn init_wire_tracker(
         serialcirc: &SerialCircuit,
-        dfg: &mut FunctionBuilder<&mut Hugr>,
+        dfg: &mut DFGBuilder<&mut Hugr>,
         input_types: &TypeRow,
         input_params: impl IntoIterator<Item = String>,
         config: &PytketDecoderConfig,
@@ -216,7 +232,7 @@ impl<'h> PytketDecoderContext<'h> {
 
         // Insert any remaining parameters as new inputs
         for param in input_params {
-            let wire = dfg.add_input(rotation_type());
+            let wire = dfg.add_input(rotation_type()).unwrap();
             wire_tracker.register_input_parameter(wire, param)?;
         }
 
@@ -243,7 +259,7 @@ impl<'h> PytketDecoderContext<'h> {
     ///
     /// The original Hugr entrypoint is _not_ modified, it must be set by the
     /// caller if required.
-    pub(super) fn finish(mut self) -> Result<BuildHandle<FuncID<true>>, PytketDecodeError> {
+    pub(super) fn finish(mut self) -> Result<Node, PytketDecodeError> {
         // Order the final wires according to the serial circuit register order.
         let qubits = self
             .wire_tracker
@@ -294,9 +310,11 @@ impl<'h> PytketDecoderContext<'h> {
             );
         }
 
-        self.builder
+        Ok(self
+            .builder
             .finish_with_outputs(output_wires)
-            .map_err(PytketDecodeError::custom)
+            .map_err(PytketDecodeError::custom)?
+            .node())
     }
 
     /// Decode a list of pytket commands.
@@ -344,6 +362,11 @@ impl<'h> PytketDecoderContext<'h> {
             }
         }
         Ok(())
+    }
+
+    /// Returns the configuration used by the decoder.
+    pub fn config(&self) -> &Arc<PytketDecoderConfig> {
+        &self.config
     }
 }
 

--- a/tket/src/serialize/pytket/decoder/param.rs
+++ b/tket/src/serialize/pytket/decoder/param.rs
@@ -3,7 +3,7 @@ pub(super) mod parser;
 
 use std::sync::LazyLock;
 
-use hugr::builder::{Dataflow, FunctionBuilder};
+use hugr::builder::{DFGBuilder, Dataflow};
 use hugr::ops::Value;
 use hugr::std_extensions::arithmetic::float_ops::FloatOps;
 use hugr::std_extensions::arithmetic::float_types::{float64_type, ConstF64};
@@ -110,7 +110,7 @@ impl LoadedParameter {
     pub fn with_type<H: AsRef<Hugr> + AsMut<Hugr>>(
         &self,
         typ: ParameterType,
-        hugr: &mut FunctionBuilder<H>,
+        hugr: &mut DFGBuilder<H>,
     ) -> LoadedParameter {
         match typ {
             ParameterType::FloatRadians => self.as_float_radians(hugr),
@@ -124,7 +124,7 @@ impl LoadedParameter {
     /// Adds the necessary operations to the Hugr and returns a new wire.
     pub fn as_float_radians<H: AsRef<Hugr> + AsMut<Hugr>>(
         &self,
-        hugr: &mut FunctionBuilder<H>,
+        hugr: &mut DFGBuilder<H>,
     ) -> LoadedParameter {
         match self.typ {
             ParameterType::FloatRadians => *self,
@@ -145,7 +145,7 @@ impl LoadedParameter {
     /// Adds the necessary operations to the Hugr and returns a new wire.
     pub fn as_float_half_turns<H: AsRef<Hugr> + AsMut<Hugr>>(
         &self,
-        hugr: &mut FunctionBuilder<H>,
+        hugr: &mut DFGBuilder<H>,
     ) -> LoadedParameter {
         match self.typ {
             ParameterType::FloatHalfTurns => *self,
@@ -172,7 +172,7 @@ impl LoadedParameter {
     /// Adds the necessary operations to the Hugr and returns a new wire.
     pub fn as_rotation<H: AsRef<Hugr> + AsMut<Hugr>>(
         &self,
-        hugr: &mut FunctionBuilder<H>,
+        hugr: &mut DFGBuilder<H>,
     ) -> LoadedParameter {
         match self.typ {
             ParameterType::Rotation => *self,

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 
-use hugr::builder::{Dataflow as _, FunctionBuilder};
+use hugr::builder::{DFGBuilder, Dataflow as _};
 use hugr::ops::Value;
 use hugr::std_extensions::arithmetic::float_types::{float64_type, ConstF64};
 use hugr::types::Type;
@@ -689,7 +689,7 @@ impl WireTracker {
     ///   for constants. The actual returned type may be different.
     pub fn load_half_turns_parameter(
         &mut self,
-        hugr: &mut FunctionBuilder<&mut Hugr>,
+        hugr: &mut DFGBuilder<&mut Hugr>,
         param: &str,
         type_hint: Option<ParameterType>,
     ) -> LoadedParameter {
@@ -698,7 +698,7 @@ impl WireTracker {
         /// `type_hint` is a hint for the type of the parameter we want to load.
         /// The actual returned type may be different.
         fn process(
-            hugr: &mut FunctionBuilder<&mut Hugr>,
+            hugr: &mut DFGBuilder<&mut Hugr>,
             input_params: &mut IndexMap<String, LoadedParameter>,
             param_vars: &mut IndexSet<String>,
             parsed: PytketParam,
@@ -743,7 +743,7 @@ impl WireTracker {
                             // Look it up in the input parameters to the circuit, and add a new float input if needed.
                             *input_params.entry(name.to_string()).or_insert_with(|| {
                                 param_vars.insert(name.to_string());
-                                let wire = hugr.add_input(rotation_type());
+                                let wire = hugr.add_input(rotation_type()).unwrap();
                                 LoadedParameter::rotation(wire)
                             })
                         }

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -668,8 +668,8 @@ impl WireTracker {
         })
     }
 
-    /// Loads the given parameter half-turns expression as a [`LoadedParameter`] in the
-    /// hugr.
+    /// Loads the given parameter half-turns expression as a [`LoadedParameter`]
+    /// in the hugr.
     ///
     /// - If the parameter is a known algebraic operation, adds the required op
     ///   and recurses on its inputs.
@@ -687,6 +687,11 @@ impl WireTracker {
     /// * `type_hint` - A hint for the type of the parameter we want to load.
     ///   This lets us decide between using [`ConstRotation`] and [`ConstF64`]
     ///   for constants. The actual returned type may be different.
+    ///
+    /// # Panics
+    ///
+    /// If the hugr builder does not support adding input wires.
+    /// (That is, we're not building a FuncDefn or a DFG).
     pub fn load_half_turns_parameter(
         &mut self,
         hugr: &mut DFGBuilder<&mut Hugr>,
@@ -743,7 +748,9 @@ impl WireTracker {
                             // Look it up in the input parameters to the circuit, and add a new float input if needed.
                             *input_params.entry(name.to_string()).or_insert_with(|| {
                                 param_vars.insert(name.to_string());
-                                let wire = hugr.add_input(rotation_type()).unwrap();
+                                let wire = hugr
+                                    .add_input(rotation_type())
+                                    .expect("Must be building a FuncDefn or a DFG");
                                 LoadedParameter::rotation(wire)
                             })
                         }

--- a/tket/src/serialize/pytket/options.rs
+++ b/tket/src/serialize/pytket/options.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use hugr::types::Signature;
-use hugr::Hugr;
+use hugr::{Hugr, Node};
 
 use crate::serialize::pytket::{PytketDecoderConfig, PytketEncoderConfig};
 
@@ -77,12 +77,11 @@ pub enum DecodeInsertionTarget {
     /// Insert the decoded circuit as a new function in the HUGR.
     #[default]
     Function,
-    // TODO: To be added in a follow-up PR.
-    // Insert the decoded circuit as a dataflow region in the HUGR under the given parent.
-    //Region {
-    //    /// The parent node that will contain the circuit's decoded DFG.
-    //    parent: Node,
-    //},
+    /// Insert the decoded circuit as a dataflow region in the HUGR under the given parent.
+    Region {
+        /// The parent node that will contain the circuit's decoded DFG.
+        parent: Node,
+    },
 }
 
 /// Options used when encoding a HUGR into a pytket


### PR DESCRIPTION
Followup from #1120. Adds the option to decode a pytket circuit into a DFG in the Hugr, rather than a standalone function.

- [x] Requires this patch in hugr: https://github.com/CQCL/hugr/pull/2564