### PR TITLE
feat(pytket-decoder)!: Allow specifying qubit/bit reuse

### DIFF
--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -459,8 +459,10 @@ impl<'h> PytketDecoderContext<'h> {
     ///
     /// # Errors
     ///
-    /// - [`PytketDecodeErrorInner::NotEnoughPytketRegisters`] if the register
-    ///   count required to encode the node does not match the ones provided.
+    /// - [`PytketDecodeErrorInner::NotEnoughInputRegisters`] if the register
+    ///   count required to encode the node inputs does not match the ones provided.
+    /// - [`PytketDecodeErrorInner::NotEnoughOutputRegisters`] if the register
+    ///   count required to encode the node outputs does not match the ones provided.
     /// - [`PytketDecodeErrorInner::OutdatedQubit`] if a qubit in `qubits` was marked as outdated.
     /// - [`PytketDecodeErrorInner::OutdatedBit`] if a bit in `bits` was marked as outdated.
     /// - [`PytketDecodeErrorInner::UnexpectedInputType`] if a type in the node's signature cannot be mapped to a [`RegisterCount`]

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -446,9 +446,16 @@ impl<'h> PytketDecoderContext<'h> {
     /// # Arguments
     ///
     /// - `node`: The node to wire up.
-    /// - `qubits`: The list of tracked qubits to use as input.
-    /// - `bits`: The list of tracked bits to use as input.
-    /// - `params`: The list of parameters to use as input.
+    /// - `input_qubits`: The qubits to use as input.
+    ///   This list must match exactly the number of input qubits required by the operation.
+    /// - `output_qubits`: The qubits to use as output.
+    ///   This list must match exactly the number of output qubits required by the operation.
+    /// - `input_bits`: The bits to use as input.
+    ///   These should match exactly the number of input bits required by the operation.
+    /// - `output_bits`: The bits to use as output.
+    ///   These should match exactly the number of output bits required by the operation.
+    /// - `params`: The parameters to use for the operation inputs.
+    ///   This should match exactly the number of input parameters required by the operation.
     ///
     /// # Errors
     ///
@@ -460,8 +467,10 @@ impl<'h> PytketDecoderContext<'h> {
     pub fn wire_up_node(
         &mut self,
         node: Node,
-        qubits: &[TrackedQubit],
-        bits: &[TrackedBit],
+        input_qubits: &[TrackedQubit],
+        output_qubits: &[TrackedQubit],
+        input_bits: &[TrackedBit],
+        output_bits: &[TrackedBit],
         params: &[LoadedParameter],
     ) -> Result<(), PytketDecodeError> {
         let Some(sig) = self.builder.hugr().signature(node) else {
@@ -472,8 +481,6 @@ impl<'h> PytketDecoderContext<'h> {
 
         // Compute the amount of elements required by the operation,
         // and the amount of elements in the input wires.
-        //
-        // Qubit registers get reused for both input and output, bit registers are not.
         let op_input_count: RegisterCount = sig
             .input_types()
             .iter()
@@ -484,37 +491,51 @@ impl<'h> PytketDecoderContext<'h> {
             .iter()
             .map(|ty| self.config.type_to_pytket(ty).unwrap_or_default())
             .sum();
-        if op_output_count.params > 0 {
-            return Err(PytketDecodeError::custom(format!(
-                "Tried to wire up a node with output parameters. Signature: {sig}"
-            )));
-        }
-        let op_reg_count = RegisterCount::new(
-            op_input_count.qubits.max(op_output_count.qubits),
-            op_input_count.bits + op_output_count.bits,
-            op_input_count.params,
-        );
 
-        // Check that the input wires have the amount of elements required by the operation.
-        if op_reg_count.qubits > qubits.len()
-            || op_reg_count.bits > bits.len()
-            || op_reg_count.params > params.len()
+        // Validate input counts
+        if op_input_count.qubits != input_qubits.len()
+            || op_input_count.bits != input_bits.len()
+            || op_input_count.params != params.len()
         {
             let expected_types = sig
                 .input_types()
                 .iter()
                 .map(ToString::to_string)
                 .collect_vec();
-            return Err(PytketDecodeErrorInner::NotEnoughPytketRegisters {
+            return Err(PytketDecodeErrorInner::NotEnoughInputRegisters {
                 expected_types,
-                expected_count: op_reg_count,
-                actual_count: RegisterCount::new(qubits.len(), bits.len(), params.len()),
+                expected_count: op_input_count,
+                actual_count: RegisterCount::new(
+                    input_qubits.len(),
+                    input_bits.len(),
+                    params.len(),
+                ),
             }
             .wrap());
-        };
+        }
+
+        // Validate output counts
+        // We currently don't allow output parameters
+        if op_output_count.qubits != output_qubits.len()
+            || op_output_count.bits != output_bits.len()
+            || op_output_count.params != 0
+        {
+            let expected_types = sig
+                .output_types()
+                .iter()
+                .map(ToString::to_string)
+                .collect_vec();
+            return Err(PytketDecodeErrorInner::NotEnoughOutputRegisters {
+                expected_types,
+                expected_count: op_output_count,
+                actual_count: RegisterCount::new(output_qubits.len(), output_bits.len(), 0),
+            }
+            .wrap());
+        }
 
         // Gather the input wires, with the types needed by the operation.
-        let input_wires = self.find_typed_wires(sig.input_types(), qubits, bits, params)?;
+        let input_wires =
+            self.find_typed_wires(sig.input_types(), input_qubits, input_bits, params)?;
         debug_assert_eq!(op_input_count, input_wires.register_count());
 
         for (input_idx, wire) in input_wires.wires().enumerate() {
@@ -522,19 +543,13 @@ impl<'h> PytketDecoderContext<'h> {
                 .hugr_mut()
                 .connect(wire.node(), wire.source(), node, input_idx);
         }
+        input_bits.iter().take(op_input_count.bits).for_each(|b| {
+            self.wire_tracker.mark_bit_outdated(b.clone());
+        });
 
         // Register the output wires.
-        // Qubit registers get reused for both input and output.
-        let output_qubits = qubits.iter().take(op_output_count.qubits).cloned();
-        // Bit registers are not reused. The ones present in the input are dropped.
-        let mut output_bits = bits.iter().cloned();
-        output_bits
-            .by_ref()
-            .take(op_input_count.bits)
-            .for_each(|b| {
-                self.wire_tracker.mark_bit_outdated(b);
-            });
-
+        let output_qubits = output_qubits.iter().take(op_output_count.qubits).cloned();
+        let output_bits = output_bits.iter().cloned();
         self.register_node_outputs(node.node(), output_qubits, output_bits)?;
 
         Ok(())
@@ -552,9 +567,16 @@ impl<'h> PytketDecoderContext<'h> {
     /// # Arguments
     ///
     /// - `op`: The operation to add.
-    /// - `qubits`: The list of tracked qubits to use as input.
-    /// - `bits`: The list of tracked bits to use as input.
-    /// - `params`: The list of parameters to use as input.
+    /// - `input_qubits`: The qubits to use as input.
+    ///   This list must match exactly the number of input qubits required by the operation.
+    /// - `output_qubits`: The qubits to use as output.
+    ///   This list must match exactly the number of output qubits required by the operation.
+    /// - `input_bits`: The bits to use as input.
+    ///   These should match exactly the number of input bits required by the operation.
+    /// - `output_bits`: The bits to use as output.
+    ///   These should match exactly the number of output bits required by the operation.
+    /// - `params`: The parameters to use for the operation inputs.
+    ///   This should match exactly the number of input parameters required by the operation.
     ///
     /// # Errors
     ///
@@ -562,8 +584,10 @@ impl<'h> PytketDecoderContext<'h> {
     pub fn add_node_with_wires(
         &mut self,
         op: impl Into<OpType>,
-        qubits: &[TrackedQubit],
-        bits: &[TrackedBit],
+        input_qubits: &[TrackedQubit],
+        output_qubits: &[TrackedQubit],
+        input_bits: &[TrackedBit],
+        output_bits: &[TrackedBit],
         params: &[LoadedParameter],
     ) -> Result<BuildHandle<DataflowOpID>, PytketDecodeError> {
         let op: OpType = op.into();
@@ -576,8 +600,15 @@ impl<'h> PytketDecoderContext<'h> {
         // Add the node to the HUGR.
         let node = self.builder.add_child_node(op);
 
-        self.wire_up_node(node.node(), qubits, bits, params)
-            .map_err(|e| e.hugr_op(&op_name))?;
+        self.wire_up_node(
+            node.node(),
+            input_qubits,
+            output_qubits,
+            input_bits,
+            output_bits,
+            params,
+        )
+        .map_err(|e| e.hugr_op(&op_name))?;
 
         Ok((node, num_outputs).into())
     }

--- a/tket/src/serialize/pytket/error.rs
+++ b/tket/src/serialize/pytket/error.rs
@@ -334,16 +334,29 @@ pub enum PytketDecodeErrorInner {
         /// The bit registers expected in the wire.
         bit_args: Vec<String>,
     },
-    /// The number of pytket registers expected for an operation is not enough.
-    ///
-    /// This is usually caused by a mismatch between the input signature and the number of registers in the pytket circuit.
-    ///
-    /// The expected number of registers may be different depending on the [`PytketTypeTranslator`][super::extension::PytketTypeTranslator]s used in the decoder config.
+    /// The number of pytket registers passed to
+    /// `PytketDecodeContext::wire_up_node` or `add_node_with_wires` does not
+    /// match the number of registers required by the operation.
     #[display(
-        "Expected {expected_count} input wires of the operation with types [{expected_types}], but only got {actual_count}",
+        "The operation input requires {expected_count} registers to cover input wires types [{expected_types}], but only got {actual_count}",
         expected_types = expected_types.iter().join(", "),
     )]
-    NotEnoughPytketRegisters {
+    NotEnoughInputRegisters {
+        /// The types we tried to get wires for.
+        expected_types: Vec<String>,
+        /// The number of registers required by the types.
+        expected_count: RegisterCount,
+        /// The number of registers we actually got.
+        actual_count: RegisterCount,
+    },
+    /// The number of pytket registers passed to
+    /// `PytketDecodeContext::wire_up_node` or `add_node_with_wires` does not
+    /// match the number of registers required by the operation.
+    #[display(
+        "The operation output requires {expected_count} registers to cover output wires types [{expected_types}], but only got {actual_count}",
+           expected_types = expected_types.iter().join(", "),
+       )]
+    NotEnoughOutputRegisters {
         /// The types we tried to get wires for.
         expected_types: Vec<String>,
         /// The number of registers required by the types.

--- a/tket/src/serialize/pytket/extension/core.rs
+++ b/tket/src/serialize/pytket/extension/core.rs
@@ -40,10 +40,8 @@ impl PytketDecoder for CoreDecoder {
         match (op.op_type, &op.op_box) {
             (PytketOptype::CircBox, Some(OpBox::CircBox { id: _id, circuit })) => {
                 // We have no way to distinguish between input and output bits in the circuit box, so we assume all bits are outputs here.
-                //
-                // TODO: Pass the registers both as inputs and outputs once this is implemented
-                // <https://github.com/CQCL/tket2/issues/1124>
                 let circ_inputs: Vec<Type> = itertools::repeat_n(qb_t(), qubits.len())
+                    .chain(itertools::repeat_n(bool_t(), bits.len()))
                     .chain(itertools::repeat_n(rotation_type(), params.len()))
                     .collect_vec();
                 let circ_outputs: Vec<Type> = itertools::repeat_n(qb_t(), qubits.len())
@@ -62,7 +60,7 @@ impl PytketDecoder for CoreDecoder {
                     circuit.decode_inplace(decoder.builder.hugr_mut(), target, options)?;
 
                 decoder
-                    .wire_up_node(internal, qubits, bits, params)
+                    .wire_up_node(internal, qubits, qubits, bits, bits, params)
                     .map_err(|e| e.hugr_op("DFG"))?;
 
                 Ok(DecodeStatus::Success)

--- a/tket/src/serialize/pytket/extension/core.rs
+++ b/tket/src/serialize/pytket/extension/core.rs
@@ -39,7 +39,9 @@ impl PytketDecoder for CoreDecoder {
     ) -> Result<DecodeStatus, PytketDecodeError> {
         match (op.op_type, &op.op_box) {
             (PytketOptype::CircBox, Some(OpBox::CircBox { id: _id, circuit })) => {
-                // We have no way to distinguish between input and output bits in the circuit box, so we assume all bits are outputs here.
+                // We have no way to distinguish between input and output bits
+                // in the circuit box, so we assume all bits are both inputs and
+                // outputs here.
                 let circ_inputs: Vec<Type> = itertools::repeat_n(qb_t(), qubits.len())
                     .chain(itertools::repeat_n(bool_t(), bits.len()))
                     .chain(itertools::repeat_n(rotation_type(), params.len()))

--- a/tket/src/serialize/pytket/extension/prelude.rs
+++ b/tket/src/serialize/pytket/extension/prelude.rs
@@ -5,7 +5,7 @@ use crate::serialize::pytket::config::TypeTranslatorSet;
 use crate::serialize::pytket::decoder::{
     DecodeStatus, LoadedParameter, PytketDecoderContext, TrackedBit, TrackedQubit,
 };
-use crate::serialize::pytket::encoder::{EncodeStatus, PytketEncoderContext};
+use crate::serialize::pytket::encoder::{EmitCommandOptions, EncodeStatus, PytketEncoderContext};
 use crate::serialize::pytket::extension::{PytketDecoder, PytketTypeTranslator, RegisterCount};
 use crate::serialize::pytket::{PytketDecodeError, PytketEncodeError};
 use crate::Circuit;
@@ -37,7 +37,12 @@ impl<H: HugrView> PytketEmitter<H> for PreludeEmitter {
             return self.tuple_op_to_pytket(node, op, &tuple_op, circ, encoder);
         };
         if let Ok(_barrier) = BarrierDef::from_extension_op(op) {
-            encoder.emit_node(PytketOptype::Barrier, node, circ)?;
+            encoder.emit_node(
+                PytketOptype::Barrier,
+                node,
+                circ,
+                EmitCommandOptions::new().reuse_all_bits(),
+            )?;
             return Ok(EncodeStatus::Success);
         };
         Ok(EncodeStatus::Unsupported)
@@ -142,7 +147,7 @@ impl PytketDecoder for PreludeEmitter {
         if !params.is_empty() {
             return Ok(DecodeStatus::Unsupported);
         }
-        decoder.add_node_with_wires(op, qubits, bits, &[])?;
+        decoder.add_node_with_wires(op, qubits, qubits, bits, &[], &[])?;
 
         Ok(DecodeStatus::Success)
     }

--- a/tket/src/serialize/pytket/extension/tk1.rs
+++ b/tket/src/serialize/pytket/extension/tk1.rs
@@ -5,7 +5,7 @@ use crate::extension::{TKET1_EXTENSION, TKET1_EXTENSION_ID, TKET1_OP_NAME};
 use crate::serialize::pytket::decoder::{
     LoadedParameter, PytketDecoderContext, TrackedBit, TrackedQubit,
 };
-use crate::serialize::pytket::encoder::EncodeStatus;
+use crate::serialize::pytket::encoder::{EmitCommandOptions, EncodeStatus};
 use crate::serialize::pytket::{PytketDecodeError, PytketEncodeError, PytketEncoderContext};
 use crate::Circuit;
 
@@ -53,8 +53,7 @@ impl<H: HugrView> PytketEmitter<H> for Tk1Emitter {
         encoder.emit_node_command(
             node,
             circ,
-            // We don't support opaque pytket operations with parameter outputs.
-            |_args| Vec::new(),
+            EmitCommandOptions::new(),
             // Emit the pre-defined pytket operation stored in the metadata.
             move |_| op.serialised_op,
         )?;


### PR DESCRIPTION
Expands support for defining which qubit and bit ids get used for the outputs when encoding and decoding pytket operations.

On the decoder side, splits the `qubits: &[TrackedQubit]` and `bits: &[TrackedBit]`  parameters of the wiring-up operation into `input_` and `output_` lists, so both can be set explicitly.

On the encoder site, since the behaviour is a bit more complex (the input ids are not immediately known without some extra computation) we add a `EmitCommandOptions` struct with functions that mark which ids to reuse, and methods to easily set commonly used options.

Blocked by
- #1120
- #1121 
  - (Requires Hugr `0.22.4` / `0.23` release)
- #1123
- #1122

Closes #1124 

BREAKING CHANGE: `PytketEncoderContext::emit_node` and `PytketDecoderContext::add_node_with_wires` now explicitly control the output bit/qubit ids.