### PR TITLE
ci: Use `uv` ecosystem for dependabot python updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
         update-types: ["minor"]
       # Major updates still generate individual PRs
 
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directories: # Location of package manifests
       - "/"
       - "/tket-py"


### PR DESCRIPTION
https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/