### PR TITLE
ci: Add contributors list to rust releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,6 +19,17 @@ git_release_name = "{{ package }}: v{{ version }}"
 # To trigger a release manually, merge a PR from a branch starting with `release-plz-`.
 release_always = false
 
+# Include a list of contributors in the release body
+git_release_body = """
+{{ changelog }}
+{% if remote.contributors %}
+### Contributors
+{% for contributor in remote.contributors %}
+* @{{ contributor.username }}
+{% endfor %}
+{% endif %}
+"""
+
 [changelog]
 header = """# Changelog
 


### PR DESCRIPTION
It'd be nice to have a list of _first contributors_, but that's not currently supported.
See [release-plz/release-plz#1907](https://www.github.com/release-plz/release-plz/issues/1907)

See config: https://release-plz.dev/docs/config#the-git_release_body-field