### PR TITLE
fix: Avoid loops when encoding recursive fns

### DIFF
--- a/tket/src/serialize/pytket/encoder/value_tracker.rs
+++ b/tket/src/serialize/pytket/encoder/value_tracker.rs
@@ -138,6 +138,18 @@ pub struct TrackedValues {
     pub params: Vec<TrackedParam>,
 }
 
+impl Extend<TrackedValue> for TrackedValues {
+    fn extend<T: IntoIterator<Item = TrackedValue>>(&mut self, iter: T) {
+        for v in iter {
+            match v {
+                TrackedValue::Qubit(qb) => self.qubits.push(qb),
+                TrackedValue::Bit(bit) => self.bits.push(bit),
+                TrackedValue::Param(param) => self.params.push(param),
+            }
+        }
+    }
+}
+
 /// Data associated with a tracked wire in the hugr.
 #[derive(Debug, Clone)]
 struct TrackedWire {

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -10,6 +10,7 @@ use hugr::builder::{
 use hugr::extension::prelude::{bool_t, qb_t};
 
 use hugr::hugr::hugrmut::HugrMut;
+use hugr::ops::handle::FuncID;
 use hugr::ops::OpParent;
 use hugr::std_extensions::arithmetic::float_ops::FloatOps;
 use hugr::types::Signature;
@@ -274,6 +275,21 @@ fn circ_parameterized() -> Circuit {
     hugr.into()
 }
 
+/// A circuit with a recursive function call.
+#[fixture]
+fn circ_recursive() -> Circuit {
+    let input_t = vec![qb_t()];
+    let output_t = vec![qb_t()];
+    let mut h = FunctionBuilder::new("recursive", Signature::new(input_t, output_t)).unwrap();
+    let func: FuncID<true> = h.container_node().into();
+
+    let [q] = h.input_wires_arr();
+    let [q] = h.call(&func, &[], [q]).unwrap().outputs_arr();
+    let hugr = h.finish_hugr_with_outputs([q]).unwrap();
+
+    hugr.into()
+}
+
 /// A simple circuit with ancillae
 #[fixture]
 fn circ_measure_ancilla() -> Circuit {
@@ -523,6 +539,7 @@ fn json_file_roundtrip(#[case] circ: impl AsRef<std::path::Path>) {
 #[case::preset_qubits(circ_preset_qubits())]
 #[case::preset_parameterized(circ_parameterized())]
 #[case::nested_dfgs(circ_nested_dfgs())]
+#[case::recursive(circ_recursive())]
 fn circuit_roundtrip(#[case] circ: Circuit) {
     let circ_signature = circ.circuit_signature().into_owned();
 


### PR DESCRIPTION
Adds an "in encoding stack" state to the function encoding cache, to detect recursive function calls while encoding and produce opaque barriers instead of trying to recurse infinitely.

drive by: Handle untracked input wires when encoding unsupported nodes. This is required for incoming non-local wires (like function references).