### PR TITLE
chore: Ensure release-please updates qis-compiler's __version__

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -64,6 +64,7 @@
             "prerelease": false,
             "draft-pull-request": true,
             "extra-files": [
+                "qis-compiler/python/selene_hugr_qis_compiler/__init__.py",
                 {
                     "type": "toml",
                     "path": "uv.lock",


### PR DESCRIPTION
The `__init__.py` is not in a default location, so we must add it explicitly here for `release-please` to detect the `x-release-please-version` annotation and update the package's `__version__` constant