### PR TITLE
revert: Remove modifier resolver pass from qsystem

### DIFF
--- a/tket-qsystem/src/lib.rs
+++ b/tket-qsystem/src/lib.rs
@@ -26,8 +26,6 @@ use hugr::{
 use lower_drops::LowerDropsPass;
 use replace_bools::{ReplaceBoolPass, ReplaceBoolPassError};
 use replace_borrow_arrays::{ReplaceBorrowArrayPass, ReplaceBorrowArrayPassError};
-use tket::modifier::modifier_resolver::ModifierResolverErrors;
-use tket::modifier::ModifierResolverPass;
 use tket::TketOp;
 
 use extension::{
@@ -48,11 +46,6 @@ pub struct QSystemPass {
     monomorphize: bool,
     force_order: bool,
     lazify: bool,
-    /// Resolve function modifiers.
-    //
-    // TODO: This should be in a default Hugr pass rather than here.
-    // We should move it and deprecate once that's defined.
-    modifier: bool,
     lower_borrow_arrays: bool,
 }
 
@@ -63,7 +56,6 @@ impl Default for QSystemPass {
             monomorphize: true,
             force_order: true,
             lazify: true,
-            modifier: true,
             lower_borrow_arrays: true,
         }
     }
@@ -99,8 +91,6 @@ pub enum QSystemPassError<N = Node> {
     /// [Module]: hugr::ops::Module
     #[display("No function named 'main' in module.")]
     NoMain,
-    /// An error from the component [ModifierResolverPass].
-    ModifierResolverError(ModifierResolverErrors<N>),
 }
 
 impl QSystemPass {
@@ -121,11 +111,6 @@ impl QSystemPass {
         } else {
             hugr.entrypoint()
         };
-
-        // experimental modifier support
-        if self.modifier {
-            self.resolve_modifier().run(hugr)?
-        }
 
         // passes that run on whole module
         hugr.set_entrypoint(hugr.module_root());
@@ -238,10 +223,6 @@ impl QSystemPass {
         LinearizeArrayPass::default()
     }
 
-    fn resolve_modifier(&self) -> ModifierResolverPass {
-        ModifierResolverPass
-    }
-
     /// Returns a new `QSystemPass` with constant folding enabled according to
     /// `constant_fold`.
     ///
@@ -281,17 +262,6 @@ impl QSystemPass {
     /// from `tket.qsystem`.
     pub fn with_lazify(mut self, lazify: bool) -> Self {
         self.lazify = lazify;
-        self
-    }
-
-    /// Returns a new `QSystemPass` with modifier resolution enabled according to
-    /// `modifier`.
-    ///
-    /// On by default.
-    ///
-    /// See [`ModifierResolverPass`] for more details.
-    pub fn with_modifier_resolution(mut self, modifier_resolution: bool) -> Self {
-        self.modifier = modifier_resolution;
         self
     }
 }


### PR DESCRIPTION
#1162 defined a `ModifierResolverPass` and added it to the passes run in `QSystemPass`.

This PR removes it from the set of passes ran by qsystem. We've decided to expose as a pass that users must run explicitly python-side when using the experimental modifiers guppy feature.

This will be flagged as a breaking change, but it only modifies unpublished changes from #1162.