### PR TITLE
feat!: Add original circuit/subgraphs in pytket DecoderCtx

### DIFF
--- a/tket-py/src/circuit/convert.rs
+++ b/tket-py/src/circuit/convert.rs
@@ -70,7 +70,7 @@ where
         Err(_) => (
             SerialCircuit::from_tket1(circ)?
                 .decode(
-                    DecodeOptions::new()
+                    DecodeOptions::new_any()
                         .with_config(tket_qsystem::pytket::qsystem_decoder_config()),
                 )
                 .convert_pyerrs()?,

--- a/tket-qsystem/src/pytket.rs
+++ b/tket-qsystem/src/pytket.rs
@@ -15,7 +15,7 @@ use tket::serialize::pytket::{
 ///
 /// Contains a list of custom decoders that define translations of legacy tket
 /// primitives into HUGR operations.
-pub fn qsystem_decoder_config() -> PytketDecoderConfig {
+pub fn qsystem_decoder_config<H: HugrView>() -> PytketDecoderConfig<H> {
     let mut config = default_decoder_config();
     config.add_decoder(QSystemEmitter);
 

--- a/tket-qsystem/src/pytket/qsystem.rs
+++ b/tket-qsystem/src/pytket/qsystem.rs
@@ -115,7 +115,7 @@ impl QSystemEmitter {
     }
 }
 
-impl PytketDecoder for QSystemEmitter {
+impl<H: HugrView> PytketDecoder<H> for QSystemEmitter {
     fn op_types(&self) -> Vec<PytketOptype> {
         // Process native optypes that are not supported by the `TketOp` emitter.
         vec![
@@ -132,7 +132,7 @@ impl PytketDecoder for QSystemEmitter {
         bits: &[TrackedBit],
         params: &[LoadedParameter],
         _opgroup: Option<&str>,
-        decoder: &mut PytketDecoderContext<'h>,
+        decoder: &mut PytketDecoderContext<'h, H>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
         let op = match op.op_type {
             PytketOptype::PhasedX => QSystemOp::PhasedX,

--- a/tket-qsystem/src/pytket/tests.rs
+++ b/tket-qsystem/src/pytket/tests.rs
@@ -198,7 +198,7 @@ fn json_roundtrip(
     assert_eq!(ser.commands.len(), num_commands);
 
     let circ: Circuit = ser
-        .decode(DecodeOptions::new().with_config(qsystem_decoder_config()))
+        .decode(DecodeOptions::new_any().with_config(qsystem_decoder_config()))
         .unwrap();
     assert_eq!(circ.qubit_count(), num_qubits);
 
@@ -229,7 +229,7 @@ fn circuit_roundtrip(#[case] circ: Circuit, #[case] decoded_sig: Signature) {
     )
     .unwrap();
     let deser: Circuit = ser
-        .decode(DecodeOptions::new().with_config(qsystem_decoder_config()))
+        .decode(DecodeOptions::new_any().with_config(qsystem_decoder_config()))
         .unwrap();
 
     let deser_sig = deser.circuit_signature();

--- a/tket/src/circuit/hash.rs
+++ b/tket/src/circuit/hash.rs
@@ -208,7 +208,7 @@ mod test {
     fn hash_constants() {
         let c_str = r#"{"bits": [], "commands": [{"args": [["q", [0]]], "op": {"params": ["0.5"], "type": "Rz"}}], "created_qubits": [], "discarded_qubits": [], "implicit_permutation": [[["q", [0]], ["q", [0]]]], "phase": "0.0", "qubits": [["q", [0]]]}"#;
         let ser: circuit_json::SerialCircuit = serde_json::from_str(c_str).unwrap();
-        let circ: Circuit = ser.decode(DecodeOptions::new()).unwrap();
+        let circ: Circuit = ser.decode(DecodeOptions::new_any()).unwrap();
         circ.circuit_hash(circ.parent()).unwrap();
     }
 
@@ -220,7 +220,7 @@ mod test {
         let mut all_hashes = Vec::with_capacity(2);
         for c_str in [c_str1, c_str2] {
             let ser: circuit_json::SerialCircuit = serde_json::from_str(c_str).unwrap();
-            let circ: Circuit = ser.decode(DecodeOptions::new()).unwrap();
+            let circ: Circuit = ser.decode(DecodeOptions::new_any()).unwrap();
             all_hashes.push(circ.circuit_hash(circ.parent()).unwrap());
         }
         assert_ne!(all_hashes[0], all_hashes[1]);

--- a/tket/src/serialize/pytket/config.rs
+++ b/tket/src/serialize/pytket/config.rs
@@ -18,7 +18,7 @@ use hugr::HugrView;
 ///
 /// Contains a list of custom decoders that define translations of legacy tket
 /// primitives into HUGR operations.
-pub fn default_decoder_config() -> PytketDecoderConfig {
+pub fn default_decoder_config<H: HugrView>() -> PytketDecoderConfig<H> {
     let mut config = PytketDecoderConfig::new();
     config.add_decoder(CoreDecoder);
     config.add_decoder(PreludeEmitter);

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -7,7 +7,7 @@ use hugr::builder::{DFGBuilder, Dataflow as _};
 use hugr::ops::Value;
 use hugr::std_extensions::arithmetic::float_types::{float64_type, ConstF64};
 use hugr::types::Type;
-use hugr::{Hugr, Wire};
+use hugr::{Hugr, HugrView, Wire};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use tket_json_rs::circuit_json::ImplicitPermutation;
@@ -52,7 +52,7 @@ impl WireData {
     /// The pytket qubit arguments corresponding to this wire.
     pub fn qubits<'d>(
         &'d self,
-        decoder: &'d PytketDecoderContext<'d>,
+        decoder: &'d PytketDecoderContext<'d, impl HugrView>,
     ) -> impl Iterator<Item = TrackedQubit> + 'd {
         self.qubits
             .iter()
@@ -63,7 +63,7 @@ impl WireData {
     /// The pytket bit arguments corresponding to this wire.
     pub fn bits<'d>(
         &'d self,
-        decoder: &'d PytketDecoderContext<'d>,
+        decoder: &'d PytketDecoderContext<'d, impl HugrView>,
     ) -> impl Iterator<Item = TrackedBit> + 'd {
         self.bits
             .iter()
@@ -167,7 +167,7 @@ impl TrackedWires {
     #[inline]
     pub fn qubits<'d>(
         &'d self,
-        decoder: &'d PytketDecoderContext<'d>,
+        decoder: &'d PytketDecoderContext<'d, impl HugrView>,
     ) -> impl Iterator<Item = TrackedQubit> + 'd {
         self.value_wires
             .iter()
@@ -178,7 +178,7 @@ impl TrackedWires {
     #[inline]
     pub fn bits<'d>(
         &'d self,
-        decoder: &'d PytketDecoderContext<'d>,
+        decoder: &'d PytketDecoderContext<'d, impl HugrView>,
     ) -> impl Iterator<Item = TrackedBit> + 'd {
         self.value_wires.iter().flat_map(move |wd| wd.bits(decoder))
     }
@@ -588,7 +588,7 @@ impl WireTracker {
     /// - [`PytketDecodeErrorInner::NoMatchingWire`] if there is no wire with the requested type for the given qubit/bit arguments.
     pub(super) fn find_typed_wires(
         &self,
-        config: &PytketDecoderConfig,
+        config: &PytketDecoderConfig<impl HugrView>,
         types: &[Type],
         qubit_args: &[TrackedQubit],
         bit_args: &[TrackedBit],

--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -218,7 +218,7 @@ impl<H: HugrView> PytketEncoderContext<H> {
     ///
     /// * the final [`SerialCircuit`]
     /// * any parameter expressions at the circuit's output
-    /// * the set of unsupported subgraphs that were referenced (from/inside) pytket barriers.
+    /// * the set of opaque subgraphs that were referenced (from/inside) pytket barriers.
     #[allow(clippy::type_complexity)]
     pub(super) fn finish(
         mut self,
@@ -228,7 +228,7 @@ impl<H: HugrView> PytketEncoderContext<H> {
     {
         // Add any remaining unsupported nodes
         //
-        // TODO: Test that unsupported subgraphs that don't affect any qubit/bit registers
+        // TODO: Test that opaque subgraphs that don't affect any qubit/bit registers
         // are correctly encoded in pytket commands.
         while !self.unsupported.is_empty() {
             let node = self.unsupported.iter().next().unwrap();
@@ -554,7 +554,7 @@ impl<H: HugrView> PytketEncoderContext<H> {
     ///
     /// ## Arguments
     ///
-    /// - `unsupported_nodes`: The list of nodes to encode as an unsupported subgraph.
+    /// - `unsupported_nodes`: The list of nodes to encode as an opaque subgraph.
     fn emit_unsupported(
         &mut self,
         unsupported_nodes: BTreeSet<H::Node>,

--- a/tket/src/serialize/pytket/extension.rs
+++ b/tket/src/serialize/pytket/extension.rs
@@ -105,7 +105,7 @@ pub trait PytketEmitter<H: HugrView> {
 ///
 /// A [decoder configuration](crate::serialize::pytket::PytketDecoderConfig)
 /// contains a list of such decoders.
-pub trait PytketDecoder {
+pub trait PytketDecoder<H: HugrView> {
     /// A list of pytket's [`tket_json_rs::OpType`] supported by this decoder.
     ///
     /// [`PytketDecoder::op_to_hugr`] will only be called for commands
@@ -130,7 +130,7 @@ pub trait PytketDecoder {
         bits: &[TrackedBit],
         params: &[LoadedParameter],
         opgroup: Option<&str>,
-        decoder: &mut PytketDecoderContext<'h>,
+        decoder: &mut PytketDecoderContext<'h, H>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
         let _ = (op, qubits, bits, params, opgroup, decoder);
         Ok(DecodeStatus::Unsupported)

--- a/tket/src/serialize/pytket/extension/bool.rs
+++ b/tket/src/serialize/pytket/extension/bool.rs
@@ -109,7 +109,7 @@ impl PytketTypeTranslator for BoolEmitter {
     }
 }
 
-impl PytketDecoder for BoolEmitter {
+impl<H: HugrView> PytketDecoder<H> for BoolEmitter {
     fn op_types(&self) -> Vec<tket_json_rs::OpType> {
         vec![tket_json_rs::OpType::ClExpr]
     }
@@ -121,7 +121,7 @@ impl PytketDecoder for BoolEmitter {
         bits: &[TrackedBit],
         params: &[LoadedParameter],
         _opgroup: Option<&str>,
-        decoder: &mut PytketDecoderContext<'h>,
+        decoder: &mut PytketDecoderContext<'h, H>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
         let Some(clexpr) = &op.classical_expr else {
             return Ok(DecodeStatus::Unsupported);

--- a/tket/src/serialize/pytket/extension/core.rs
+++ b/tket/src/serialize/pytket/extension/core.rs
@@ -16,6 +16,7 @@ use crate::serialize::TKETDecode;
 use hugr::builder::Container;
 use hugr::extension::prelude::{bool_t, qb_t};
 use hugr::types::{Signature, Type};
+use hugr::HugrView;
 use itertools::Itertools;
 use tket_json_rs::circuit_json::Operation as PytketOperation;
 use tket_json_rs::opbox::OpBox;
@@ -25,7 +26,7 @@ use tket_json_rs::optype::OpType as PytketOptype;
 #[derive(Debug, Clone, Default)]
 pub struct CoreDecoder;
 
-impl PytketDecoder for CoreDecoder {
+impl<H: HugrView> PytketDecoder<H> for CoreDecoder {
     fn op_types(&self) -> Vec<PytketOptype> {
         vec![PytketOptype::Barrier, PytketOptype::CircBox]
     }
@@ -37,7 +38,7 @@ impl PytketDecoder for CoreDecoder {
         bits: &[TrackedBit],
         params: &[LoadedParameter],
         opgroup: Option<&str>,
-        decoder: &mut PytketDecoderContext<'h>,
+        decoder: &mut PytketDecoderContext<'h, H>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
         match &op {
             PytketOperation {

--- a/tket/src/serialize/pytket/extension/prelude.rs
+++ b/tket/src/serialize/pytket/extension/prelude.rs
@@ -113,7 +113,7 @@ impl PreludeEmitter {
     }
 }
 
-impl PytketDecoder for PreludeEmitter {
+impl<H: HugrView> PytketDecoder<H> for PreludeEmitter {
     fn op_types(&self) -> Vec<PytketOptype> {
         vec![PytketOptype::noop, PytketOptype::Barrier]
     }
@@ -125,7 +125,7 @@ impl PytketDecoder for PreludeEmitter {
         bits: &[TrackedBit],
         params: &[LoadedParameter],
         opgroup: Option<&str>,
-        decoder: &mut PytketDecoderContext<'h>,
+        decoder: &mut PytketDecoderContext<'h, H>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
         let op: OpType = match op.op_type {
             PytketOptype::noop => Noop::new(qb_t()).into(),

--- a/tket/src/serialize/pytket/extension/tk1.rs
+++ b/tket/src/serialize/pytket/extension/tk1.rs
@@ -73,13 +73,13 @@ impl<H: HugrView> PytketEmitter<H> for Tk1Emitter {
 /// TODO: This only accepts input/outputs composed of bare qubit, bit, and parameter wires.
 /// We should accept arbitrary wires, but the opaque extension op needs to be modified (or replaced with a new one)
 /// since it currently has a limited signature definition.
-pub(crate) fn build_opaque_tket_op<'h>(
+pub(crate) fn build_opaque_tket_op<'h, H: HugrView>(
     op: &tket_json_rs::circuit_json::Operation,
     qubits: &[TrackedQubit],
     bits: &[TrackedBit],
     params: &[LoadedParameter],
     _opgroup: &Option<String>,
-    decoder: &mut PytketDecoderContext<'h>,
+    decoder: &mut PytketDecoderContext<'h, H>,
 ) -> Result<(), PytketDecodeError> {
     let tk1op: OpType = OpaqueTk1Op::new_from_op(op, qubits.len(), bits.len())
         .as_extension_op()

--- a/tket/src/serialize/pytket/extension/tket.rs
+++ b/tket/src/serialize/pytket/extension/tket.rs
@@ -116,7 +116,7 @@ impl TketOpEmitter {
     }
 }
 
-impl PytketDecoder for TketOpEmitter {
+impl<H: HugrView> PytketDecoder<H> for TketOpEmitter {
     fn op_types(&self) -> Vec<PytketOptype> {
         vec![
             PytketOptype::H,
@@ -149,7 +149,7 @@ impl PytketDecoder for TketOpEmitter {
         bits: &[TrackedBit],
         params: &[LoadedParameter],
         _opgroup: Option<&str>,
-        decoder: &mut PytketDecoderContext<'h>,
+        decoder: &mut PytketDecoderContext<'h, H>,
     ) -> Result<DecodeStatus, PytketDecodeError> {
         let mut num_input_bits = 0;
         let op = match op.op_type {

--- a/tket/src/serialize/pytket/opaque.rs
+++ b/tket/src/serialize/pytket/opaque.rs
@@ -86,7 +86,7 @@ impl<N: HugrNode> OpaqueSubgraphs<N> {
         id
     }
 
-    /// Returns the unsupported subgraph with the given ID.
+    /// Returns the opaque subgraph with the given ID.
     ///
     /// # Panics
     ///

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -567,7 +567,7 @@ fn json_roundtrip(
     let ser: circuit_json::SerialCircuit = serde_json::from_str(circ_s).unwrap();
     assert_eq!(ser.commands.len(), num_commands);
 
-    let circ: Circuit = ser.decode(DecodeOptions::new()).unwrap();
+    let circ: Circuit = ser.decode(DecodeOptions::new_any()).unwrap();
     assert_eq!(circ.qubit_count(), num_qubits);
 
     if !has_tk1_ops {
@@ -585,7 +585,7 @@ fn json_roundtrip(
 fn json_file_roundtrip(#[case] circ: impl AsRef<std::path::Path>) {
     let reader = BufReader::new(std::fs::File::open(circ).unwrap());
     let ser: circuit_json::SerialCircuit = serde_json::from_reader(reader).unwrap();
-    let circ: Circuit = ser.decode(DecodeOptions::new()).unwrap();
+    let circ: Circuit = ser.decode(DecodeOptions::new_any()).unwrap();
 
     check_no_tk1_ops(&circ);
 
@@ -619,7 +619,7 @@ fn circuit_roundtrip(#[case] circ: Circuit, #[case] num_circuits: usize) {
         .extract_standalone()
         .unwrap_or_else(|e| panic!("{e}"));
     let deser: Circuit = ser
-        .decode(DecodeOptions::new().with_signature(circ_signature.clone()))
+        .decode(DecodeOptions::new_any().with_signature(circ_signature.clone()))
         .unwrap_or_else(|e| panic!("{e}"));
 
     let deser_sig = deser.circuit_signature();
@@ -656,7 +656,7 @@ fn test_add_angle_serialise(#[case] circ_add_angles: (Circuit, String)) {
     assert_eq!(ser.commands[0].op.op_type, optype::OpType::Rx);
     assert_eq!(ser.commands[0].op.params, Some(vec![expected]));
 
-    let deser: Circuit = ser.decode(DecodeOptions::new()).unwrap();
+    let deser: Circuit = ser.decode(DecodeOptions::new_any()).unwrap();
     let reser = SerialCircuit::encode(&deser, EncodeOptions::new()).unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
@@ -672,8 +672,8 @@ fn test_inplace_decoding() {
     let func1 = serial
         .decode_inplace(
             builder.hugr_mut(),
-            DecodeInsertionTarget::Function,
-            DecodeOptions::new(),
+            DecodeInsertionTarget::Function { fn_name: None },
+            DecodeOptions::new_any(),
         )
         .unwrap();
     let circ_signature = builder
@@ -694,7 +694,7 @@ fn test_inplace_decoding() {
             .decode_inplace(
                 fn_build.hugr_mut(),
                 DecodeInsertionTarget::Region { parent: fn2_node },
-                DecodeOptions::new(),
+                DecodeOptions::new_any(),
             )
             .unwrap();
 

--- a/tket/tests/badger_termination.rs
+++ b/tket/tests/badger_termination.rs
@@ -51,7 +51,7 @@ fn simple_circ() -> Circuit {
         "qubits": [["q", [0]], ["q", [1]], ["q", [2]]]
     }"#;
     let ser: SerialCircuit = serde_json::from_str(json).unwrap();
-    ser.decode(DecodeOptions::new()).unwrap()
+    ser.decode(DecodeOptions::new_any()).unwrap()
 }
 
 #[rstest]


### PR DESCRIPTION
Adds the `UnsupportedSubgraphs` tracker from that PR to the decoder context, along with a reference to the original Hugr.
This requires adding a `H: HugrView` generic parameter to the decoder, which affects the pytket extension decoder traits so it's a bit noisy.

Depends on
-  #1164

drive-by: Move `fn_name` from `DecodeOptions` into `DecodeInsertionTarget::Function`, since it's ignored in other cases.