### PR TITLE
chore: tket1 passes nix fixes

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -32,6 +32,11 @@ in
 
   env = {
     "LLVM_SYS_${llvmVersion}0_PREFIX" = "${llvmPackages.libllvm.dev}";
+    "LIBCLANG_PATH" = "${pkgs.libclang.lib}/lib";
+    # hardening removed due its impact on tikv-jemalloc-sys build,
+    # as depended upon by tikv-jemalloc-sys
+    # See https://github.com/tikv/jemallocator/issues/108
+    "NIX_HARDENING_ENABLE" = "";
   };
 
   # https://devenv.sh/languages/

--- a/tket1-passes/conan-profiles/linux-x86_64-gcc14
+++ b/tket1-passes/conan-profiles/linux-x86_64-gcc14
@@ -1,0 +1,8 @@
+[settings]
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.cppstd=gnu17
+compiler.libcxx=libstdc++11
+compiler.version=14
+os=Linux


### PR DESCRIPTION
I couldn't get `cargo build --workspace` to work, and it was annoying me.

Here are the changes I needed to make. Merge at your discretion:
- Adding libclang
- Removing Nix Hardening when building inside of the devenv - see https://github.com/tikv/jemallocator/issues/108
- Adding a conan profile for gcc14, which is the one provided by devenv (on linux, at least)