### PR TITLE
fix: ReplaceBoolPass: lower BorrowArray::get

### DIFF
--- a/tket-qsystem/src/replace_bools.rs
+++ b/tket-qsystem/src/replace_bools.rs
@@ -641,9 +641,10 @@ mod test {
     }
 
     #[rstest]
-    #[case(tket_bool_t(), bool_dest())]
-    #[case(usize_t(), usize_t())]
-    fn test_barray_get(#[case] src_ty: Type, #[case] dest_ty: Type) {
+    #[case(Type::new_tuple(vec![tket_bool_t(), usize_t()]), Type::new_tuple(vec![bool_dest(), usize_t()]), true)]
+    #[case(tket_bool_t(), bool_dest(), true)]
+    #[case(usize_t(), usize_t(), false)]
+    fn test_barray_get(#[case] src_ty: Type, #[case] dest_ty: Type, #[case] expect_dup: bool) {
         let arr_ty = borrow_array_type(4, src_ty.clone());
         let mut dfb = DFGBuilder::new(inout_sig(
             vec![arr_ty.clone(), usize_t()],
@@ -678,7 +679,6 @@ mod test {
                 FutureOp::from_op(eop).is_ok_and(|fop| fop.op == FutureOpDef::Dup)
             })
         });
-        // This will do for the cases above, but would be too simple for e.g. nested array of bools:
-        assert_eq!(src_ty == tket_bool_t(), contains_dup);
+        assert_eq!(contains_dup, expect_dup);
     }
 }


### PR DESCRIPTION
Note: follows #1161

(Borrow)Array::get only work for Copyable types.
Since `tket.bool` (Copyable) gets lowered to non-copyable `Sum(bool_t | Future(bool_t))`, (Borrow)Array::get won't work.
Hence, currently guppy avoids generating any Array::gets, and always puts in a workaround (for *any* copyable type):
* For Arrays this was a complex dance of Array::set (swap in a None, unwrap to get the element; copy the element via two Hugr outwires; return one but wrap the other in Some and Array::set it back in then unwrap the None)
* For BorrowArrays, it's a borrow followed by a return, so not as complex, but still more than just `get`.

The right way (TM) to do this is to let guppy generate (Borrow)Array::get, and replace that op with the workaround in ReplaceTypes, so that it only applies when types change from Copyable to Linear. This is the tket side of that, done for BorrowArray only (handling arrays might also be desirable, albeit not important for guppy. Can make an issue for that).

TODO: needs integration testing with guppy
* this'll be first time we'll exercise hugr-llvm lowering of BorrowArray::get
* check I've got the in-range check here the right way around ;-)
* do the linearity changes mess up any other ReplaceTypes pass?