### PR TITLE
ci: Avoid cyclic dependency on release-checks

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -53,7 +53,8 @@ jobs:
           uv sync --no-sources --no-install-workspace
           uv pip install --no-sources tket-exts
           uv pip install --no-sources tket-eccs
-          uv run --package tket-py --no-sync maturin develop
+          uv pip install --no-sources maturin
+          uv run --no-dev --no-sync maturin develop
           echo "\nDone! Installed dependencies:"
           uv pip list
       - name: Type check with mypy

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -50,11 +50,10 @@ jobs:
         env:
           UV_RESOLUTION: ${{ matrix.resolution }}
         run: |
-          uv lock --no-sources -U
           uv sync --no-sources --no-install-workspace
           uv pip install --no-sources tket-exts
           uv pip install --no-sources tket-eccs
-          uv run --no-sync maturin develop
+          uv run --package tket-py --no-sync maturin develop
           echo "\nDone! Installed dependencies:"
           uv pip list
       - name: Type check with mypy


### PR DESCRIPTION
`qis-compiler` added a dev dependency on guppy, which depends on `tket-exts`.

This caused the release-check to fail due to conflicting package resolution
https://github.com/CQCL/tket2/actions/runs/18656728359/job/53187575800?pr=1142

I think removing the `uv lock` line here should work

[Test run](https://github.com/CQCL/tket2/actions/runs/18657807507/job/53191097888)