### PR TITLE
chore: Test python 3.14 and bump UV version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "--cfg=ci_run"
-  MIRIFLAGS: '-Zmiri-permissive-provenance' # Required due to warnings in bitvec 1.0.1
+  MIRIFLAGS: "-Zmiri-permissive-provenance" # Required due to warnings in bitvec 1.0.1
   CI: true # insta snapshots behave differently on ci
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   # Pinned version for the uv package manager
-  UV_VERSION: "0.8.22"
+  UV_VERSION: "0.9.7"
   UV_FROZEN: 1
   # The highest and lowest supported Python versions, used for testing
-  PYTHON_HIGHEST: "3.13"
+  PYTHON_HIGHEST: "3.14"
   PYTHON_LOWEST: "3.10"
 
   # different strings for install action and feature name
@@ -146,7 +146,7 @@ jobs:
       - id: toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 'stable'
+          toolchain: "stable"
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: taiki-e/install-action@nextest
@@ -196,7 +196,7 @@ jobs:
       matrix:
         # Stable is covered by `tests-stable-no-features` and `tests-stable-all-features`
         # Nightly is covered by `tests-nightly-coverage`
-        rust: ['1.85', beta]
+        rust: ["1.85", beta]
     name: tests (Rust ${{ matrix.rust }})
     steps:
       - uses: actions/checkout@v5
@@ -256,9 +256,9 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests with coverage instrumentation
         run: |
-            cargo llvm-cov clean --workspace
-            cargo llvm-cov --no-report --workspace --no-default-features --doctests
-            cargo llvm-cov --no-report --workspace --all-features --doctests
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --no-report --workspace --no-default-features --doctests
+          cargo llvm-cov --no-report --workspace --all-features --doctests
       - name: Generate coverage report
         run: cargo llvm-cov --all-features report --codecov --output-path coverage.json
       - name: Upload coverage to codecov.io
@@ -373,25 +373,25 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          fetch-depth: 0  # Need full history to compare with main
+          fetch-depth: 0 # Need full history to compare with main
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Check if extension versions are updated
         run: |
-            # Check against latest tag on the target branch
-            # When not on a pull request, base_ref should be empty so we default to HEAD
-            if [ -z "$TARGET_REF" ]; then
-              BASE_SHA="HEAD~1"
-            else
-              BASE_SHA=$(git rev-parse origin/$TARGET_REF)
-            fi
-            echo "Comparing to ref: $BASE_SHA"
+          # Check against latest tag on the target branch
+          # When not on a pull request, base_ref should be empty so we default to HEAD
+          if [ -z "$TARGET_REF" ]; then
+            BASE_SHA="HEAD~1"
+          else
+            BASE_SHA=$(git rev-parse origin/$TARGET_REF)
+          fi
+          echo "Comparing to ref: $BASE_SHA"
 
-            python ./scripts/check_extension_versions.py $BASE_SHA
+          python ./scripts/check_extension_versions.py $BASE_SHA
         env:
           TARGET_REF: ${{ github.base_ref }}
 
@@ -399,7 +399,18 @@ jobs:
   # even if they are skipped due to no changes in the relevant files.
   required-checks:
     name: Required checks 🦀+🐍
-    needs: [changes, check-rs, check-py, tests-rs-stable-no-features, tests-rs-stable-all-features, tests-py, tket-extensions, extension-versions, tests-qis-compiler]
+    needs:
+      [
+        changes,
+        check-rs,
+        check-py,
+        tests-rs-stable-no-features,
+        tests-rs-stable-all-features,
+        tests-py,
+        tket-extensions,
+        extension-versions,
+        tests-qis-compiler,
+      ]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   # Pinned version for the uv package manager
-  UV_VERSION: "0.8.22"
+  UV_VERSION: "0.9.7"
 
 jobs:
   build-publish:
@@ -33,8 +33,8 @@ jobs:
     strategy:
       matrix:
         target:
-          - { dir: tket-eccs, name: tket_eccs}
-          - { dir: tket-exts, name: tket_exts}
+          - { dir: tket-eccs, name: tket_eccs }
+          - { dir: tket-exts, name: tket_exts }
     steps:
       # Check the release tag against the package name
       #

--- a/.github/workflows/python-qis-wheels.yml
+++ b/.github/workflows/python-qis-wheels.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     # check builds work if qis-compiler build config changes
     paths:
-      - 'qis-compiler/pyproject.toml'
+      - "qis-compiler/pyproject.toml"
   workflow_dispatch:
 
 permissions:
@@ -20,7 +20,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CACHE_CARGO: true
-  UV_VERSION: "0.8.22"
+  UV_VERSION: "0.9.7"
 jobs:
   build_qis_compiler_wheels:
     strategy:
@@ -66,7 +66,6 @@ jobs:
       # that wheels are built in an isolated environment. We use
       # /tmp/ci-cache for caching, which is then accessed as
       # /host/tmp/ci-cache within the container.
-
 
       # if the hugr_qis compiler has changed, we build it.
       - name: Build selene-hugr-qis-compiler wheel

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -15,9 +15,9 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   # Pinned version for the uv package manager
-  UV_VERSION: "0.8.22"
+  UV_VERSION: "0.9.7"
   # The highest and lowest supported Python versions, used for testing
-  PYTHON_HIGHEST: "3.13"
+  PYTHON_HIGHEST: "3.14"
   PYTHON_LOWEST: "3.10"
 
 jobs:

--- a/tket-py/pyproject.toml
+++ b/tket-py/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
- Updates CI to test python 3.14 compatibility
- Bumps the UV version. I think this should fix the ["Could not find root package `tket`" errors](https://github.com/CQCL/tket2/actions/runs/19022376992/job/54319640949?pr=1214#step:7:31)