### PR TITLE
chore: Update qis-compiler snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,17 +472,7 @@ jobs:
           echo "Rust: ${{ needs.changes.outputs.rust }}"
           echo "Python: ${{ needs.changes.outputs.python }}"
       - name: Fail if required checks failed
-        # This condition should simply be `if: failure() || cancelled()`,
-        # but there seems to be a bug in the github workflow runner.
-        #
-        # See https://github.com/orgs/community/discussions/80788
-        if: |
-          needs.changes.result == 'failure' || needs.changes.result == 'cancelled' ||
-          needs.check-rs.result == 'failure' || needs.check-rs.result == 'cancelled' ||
-          needs.check-py.result == 'failure' || needs.check-py.result == 'cancelled' ||
-          needs.tests-rs-stable-no-features.result == 'failure' || needs.tests-rs-stable-no-features.result == 'cancelled' ||
-          needs.tests-rs-stable-all-features.result == 'failure' || needs.tests-rs-stable-all-features.result == 'cancelled' ||
-          needs.tests-py.result == 'failure' || needs.tests-py.result == 'cancelled'
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |
           echo "Required checks failed"
           echo "Please check the logs for more information"

--- a/justfile
+++ b/justfile
@@ -79,9 +79,14 @@ recompile-eccs:
 gen-extensions:
     cargo run -p tket-qsystem gen-extensions -o tket-exts/src/tket_exts/data
 
+# Update snapshot tests for both rust and python (requires `cargo-insta`)
+update-snapshots: update-snapshots-rs update-snapshots-py
 # Interactively update snapshot tests (requires `cargo-insta`)
-update-snapshots:
+update-snapshots-rs:
     cargo insta review
+# Update python snapshot tests.
+update-snapshots-py *TEST_ARGS:
+    uv run pytest --snapshot-update {{TEST_ARGS}}
 
 # Build the sphinx API documentation
 build-pydocs:

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/aarch64-apple-darwin/measure_array_aarch64-apple-darwin
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/aarch64-apple-darwin/measure_array_aarch64-apple-darwin
@@ -5,7 +5,6 @@ target triple = "aarch64-apple-darwin"
 
 @"e_Array alre.5A300C2A.0" = private constant [57 x i8] c"8EXIT:INT:Array already contains an element at this index"
 @"e_Array elem.E746B1A3.0" = private constant [43 x i8] c"*EXIT:INT:Array element is already borrowed"
-@"e_Some array.A77EF32E.0" = private constant [48 x i8] c"/EXIT:INT:Some array elements have been borrowed"
 @"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @"e_No more qu.3B2EEBF0.0" = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
 
@@ -39,8 +38,8 @@ entry:
   br label %cond_20_case_1.i
 
 cond_20_case_1.i:                                 ; preds = %cond_exit_20.i, %entry
-  %"15_0.sroa.0.0216.i" = phi i64 [ 0, %entry ], [ %5, %cond_exit_20.i ]
-  %5 = add nuw nsw i64 %"15_0.sroa.0.0216.i", 1
+  %"15_0.sroa.0.0295.i" = phi i64 [ 0, %entry ], [ %5, %cond_exit_20.i ]
+  %5 = add nuw nsw i64 %"15_0.sroa.0.0295.i", 1
   %qalloc.i.i = tail call i64 @___qalloc()
   %not_max.not.i.i = icmp eq i64 %qalloc.i.i, -1
   br i1 %not_max.not.i.i, label %id_bb.i.i, label %reset_bb.i.i
@@ -60,10 +59,10 @@ cond_217_case_0.i.i:                              ; preds = %id_bb.i.i
   unreachable
 
 __barray_check_bounds.exit.i:                     ; preds = %id_bb.i.i
-  %8 = lshr i64 %"15_0.sroa.0.0216.i", 6
+  %8 = lshr i64 %"15_0.sroa.0.0295.i", 6
   %9 = getelementptr inbounds i64, i64* %4, i64 %8
   %10 = load i64, i64* %9, align 4
-  %11 = shl nuw nsw i64 1, %"15_0.sroa.0.0216.i"
+  %11 = shl nuw nsw i64 1, %"15_0.sroa.0.0295.i"
   %12 = and i64 %10, %11
   %.not.i.i = icmp eq i64 %12, 0
   br i1 %.not.i.i, label %panic.i.i, label %cond_exit_20.i
@@ -76,7 +75,7 @@ cond_exit_20.i:                                   ; preds = %__barray_check_boun
   %.fca.1.extract.i.i = extractvalue { i1, i64 } %7, 1
   %13 = xor i64 %10, %11
   store i64 %13, i64* %9, align 4
-  %14 = getelementptr inbounds i64, i64* %2, i64 %"15_0.sroa.0.0216.i"
+  %14 = getelementptr inbounds i64, i64* %2, i64 %"15_0.sroa.0.0295.i"
   store i64 %.fca.1.extract.i.i, i64* %14, align 4
   %exitcond.not.i = icmp eq i64 %5, 10
   br i1 %exitcond.not.i, label %loop_out.i, label %cond_20_case_1.i
@@ -84,10 +83,10 @@ cond_exit_20.i:                                   ; preds = %__barray_check_boun
 loop_out.i:                                       ; preds = %cond_exit_20.i
   %15 = load i64, i64* %4, align 4
   %16 = and i64 %15, 1
-  %.not.i186.i = icmp eq i64 %16, 0
-  br i1 %.not.i186.i, label %__barray_mask_borrow.exit.i, label %panic.i187.i
+  %.not.i259.i = icmp eq i64 %16, 0
+  br i1 %.not.i259.i, label %__barray_mask_borrow.exit.i, label %panic.i260.i
 
-panic.i187.i:                                     ; preds = %loop_out.i
+panic.i260.i:                                     ; preds = %loop_out.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
@@ -98,27 +97,27 @@ __barray_mask_borrow.exit.i:                      ; preds = %loop_out.i
   tail call void @___rxy(i64 %18, double 0x400921FB54442D18, double 0.000000e+00)
   %19 = load i64, i64* %4, align 4
   %20 = and i64 %19, 1
-  %.not.i188.i = icmp eq i64 %20, 0
-  br i1 %.not.i188.i, label %panic.i189.i, label %__barray_mask_return.exit190.i
+  %.not.i261.i = icmp eq i64 %20, 0
+  br i1 %.not.i261.i, label %panic.i262.i, label %__barray_mask_return.exit263.i
 
-panic.i189.i:                                     ; preds = %__barray_mask_borrow.exit.i
+panic.i262.i:                                     ; preds = %__barray_mask_borrow.exit.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit190.i:                   ; preds = %__barray_mask_borrow.exit.i
+__barray_mask_return.exit263.i:                   ; preds = %__barray_mask_borrow.exit.i
   %21 = xor i64 %19, 1
   store i64 %21, i64* %4, align 4
   store i64 %18, i64* %2, align 4
   %22 = load i64, i64* %4, align 4
   %23 = and i64 %22, 4
-  %.not.i191.i = icmp eq i64 %23, 0
-  br i1 %.not.i191.i, label %__barray_mask_borrow.exit193.i, label %panic.i192.i
+  %.not.i264.i = icmp eq i64 %23, 0
+  br i1 %.not.i264.i, label %__barray_mask_borrow.exit266.i, label %panic.i265.i
 
-panic.i192.i:                                     ; preds = %__barray_mask_return.exit190.i
+panic.i265.i:                                     ; preds = %__barray_mask_return.exit263.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit193.i:                   ; preds = %__barray_mask_return.exit190.i
+__barray_mask_borrow.exit266.i:                   ; preds = %__barray_mask_return.exit263.i
   %24 = xor i64 %22, 4
   store i64 %24, i64* %4, align 4
   %25 = getelementptr inbounds i8, i8* %1, i64 16
@@ -127,27 +126,27 @@ __barray_mask_borrow.exit193.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %27, double 0x400921FB54442D18, double 0.000000e+00)
   %28 = load i64, i64* %4, align 4
   %29 = and i64 %28, 4
-  %.not.i194.i = icmp eq i64 %29, 0
-  br i1 %.not.i194.i, label %panic.i195.i, label %__barray_mask_return.exit196.i
+  %.not.i267.i = icmp eq i64 %29, 0
+  br i1 %.not.i267.i, label %panic.i268.i, label %__barray_mask_return.exit269.i
 
-panic.i195.i:                                     ; preds = %__barray_mask_borrow.exit193.i
+panic.i268.i:                                     ; preds = %__barray_mask_borrow.exit266.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit196.i:                   ; preds = %__barray_mask_borrow.exit193.i
+__barray_mask_return.exit269.i:                   ; preds = %__barray_mask_borrow.exit266.i
   %30 = xor i64 %28, 4
   store i64 %30, i64* %4, align 4
   store i64 %27, i64* %26, align 4
   %31 = load i64, i64* %4, align 4
   %32 = and i64 %31, 8
-  %.not.i197.i = icmp eq i64 %32, 0
-  br i1 %.not.i197.i, label %__barray_mask_borrow.exit199.i, label %panic.i198.i
+  %.not.i270.i = icmp eq i64 %32, 0
+  br i1 %.not.i270.i, label %__barray_mask_borrow.exit272.i, label %panic.i271.i
 
-panic.i198.i:                                     ; preds = %__barray_mask_return.exit196.i
+panic.i271.i:                                     ; preds = %__barray_mask_return.exit269.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit199.i:                   ; preds = %__barray_mask_return.exit196.i
+__barray_mask_borrow.exit272.i:                   ; preds = %__barray_mask_return.exit269.i
   %33 = xor i64 %31, 8
   store i64 %33, i64* %4, align 4
   %34 = getelementptr inbounds i8, i8* %1, i64 24
@@ -156,27 +155,27 @@ __barray_mask_borrow.exit199.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %36, double 0x400921FB54442D18, double 0.000000e+00)
   %37 = load i64, i64* %4, align 4
   %38 = and i64 %37, 8
-  %.not.i200.i = icmp eq i64 %38, 0
-  br i1 %.not.i200.i, label %panic.i201.i, label %__barray_mask_return.exit202.i
+  %.not.i273.i = icmp eq i64 %38, 0
+  br i1 %.not.i273.i, label %panic.i274.i, label %__barray_mask_return.exit275.i
 
-panic.i201.i:                                     ; preds = %__barray_mask_borrow.exit199.i
+panic.i274.i:                                     ; preds = %__barray_mask_borrow.exit272.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit202.i:                   ; preds = %__barray_mask_borrow.exit199.i
+__barray_mask_return.exit275.i:                   ; preds = %__barray_mask_borrow.exit272.i
   %39 = xor i64 %37, 8
   store i64 %39, i64* %4, align 4
   store i64 %36, i64* %35, align 4
   %40 = load i64, i64* %4, align 4
   %41 = and i64 %40, 512
-  %.not.i203.i = icmp eq i64 %41, 0
-  br i1 %.not.i203.i, label %__barray_mask_borrow.exit205.i, label %panic.i204.i
+  %.not.i276.i = icmp eq i64 %41, 0
+  br i1 %.not.i276.i, label %__barray_mask_borrow.exit278.i, label %panic.i277.i
 
-panic.i204.i:                                     ; preds = %__barray_mask_return.exit202.i
+panic.i277.i:                                     ; preds = %__barray_mask_return.exit275.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit205.i:                   ; preds = %__barray_mask_return.exit202.i
+__barray_mask_borrow.exit278.i:                   ; preds = %__barray_mask_return.exit275.i
   %42 = xor i64 %40, 512
   store i64 %42, i64* %4, align 4
   %43 = getelementptr inbounds i8, i8* %1, i64 72
@@ -185,14 +184,14 @@ __barray_mask_borrow.exit205.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %45, double 0x400921FB54442D18, double 0.000000e+00)
   %46 = load i64, i64* %4, align 4
   %47 = and i64 %46, 512
-  %.not.i206.i = icmp eq i64 %47, 0
-  br i1 %.not.i206.i, label %panic.i207.i, label %__barray_mask_return.exit208.i
+  %.not.i279.i = icmp eq i64 %47, 0
+  br i1 %.not.i279.i, label %panic.i280.i, label %__barray_mask_return.exit281.i
 
-panic.i207.i:                                     ; preds = %__barray_mask_borrow.exit205.i
+panic.i280.i:                                     ; preds = %__barray_mask_borrow.exit278.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit208.i:                   ; preds = %__barray_mask_borrow.exit205.i
+__barray_mask_return.exit281.i:                   ; preds = %__barray_mask_borrow.exit278.i
   %48 = xor i64 %46, 512
   store i64 %48, i64* %4, align 4
   store i64 %45, i64* %44, align 4
@@ -201,7 +200,7 @@ __barray_mask_return.exit208.i:                   ; preds = %__barray_mask_borro
   %51 = tail call i8* @heap_alloc(i64 8)
   %52 = bitcast i8* %51 to i64*
   store i64 -1, i64* %52, align 1
-  br label %59
+  br label %56
 
 mask_block_ok.i.i.i.i:                            ; preds = %cond_exit_353.i.i
   %53 = load i64, i64* %4, align 4
@@ -213,42 +212,38 @@ mask_block_ok.i.i.i.i:                            ; preds = %cond_exit_353.i.i
 "__hugr__.$measure_array$$n(10).277.exit.i":      ; preds = %mask_block_ok.i.i.i.i
   tail call void @heap_free(i8* nonnull %1)
   tail call void @heap_free(i8* nonnull %3)
-  %56 = load i64, i64* %52, align 4
-  %57 = and i64 %56, 1023
-  store i64 %57, i64* %52, align 4
-  %58 = icmp eq i64 %57, 0
-  br i1 %58, label %__barray_check_none_borrowed.exit.i, label %mask_block_err.i.i
+  br label %__barray_check_bounds.exit284.i
 
 mask_block_err.i.i.i.i:                           ; preds = %mask_block_ok.i.i.i.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-59:                                               ; preds = %cond_exit_353.i.i, %__barray_mask_return.exit208.i
-  %"303_0.sroa.15.0.i218.i" = phi i64 [ 0, %__barray_mask_return.exit208.i ], [ %60, %cond_exit_353.i.i ]
-  %60 = add nuw nsw i64 %"303_0.sroa.15.0.i218.i", 1
-  %61 = lshr i64 %"303_0.sroa.15.0.i218.i", 6
-  %62 = getelementptr inbounds i64, i64* %4, i64 %61
-  %63 = load i64, i64* %62, align 4
-  %64 = shl nuw nsw i64 1, %"303_0.sroa.15.0.i218.i"
-  %65 = and i64 %63, %64
-  %.not.i99.i.i.i = icmp eq i64 %65, 0
+56:                                               ; preds = %cond_exit_353.i.i, %__barray_mask_return.exit281.i
+  %"303_0.sroa.15.0.i297.i" = phi i64 [ 0, %__barray_mask_return.exit281.i ], [ %57, %cond_exit_353.i.i ]
+  %57 = add nuw nsw i64 %"303_0.sroa.15.0.i297.i", 1
+  %58 = lshr i64 %"303_0.sroa.15.0.i297.i", 6
+  %59 = getelementptr inbounds i64, i64* %4, i64 %58
+  %60 = load i64, i64* %59, align 4
+  %61 = shl nuw nsw i64 1, %"303_0.sroa.15.0.i297.i"
+  %62 = and i64 %60, %61
+  %.not.i99.i.i.i = icmp eq i64 %62, 0
   br i1 %.not.i99.i.i.i, label %__barray_check_bounds.exit.i.i, label %panic.i.i.i.i
 
-panic.i.i.i.i:                                    ; preds = %59
+panic.i.i.i.i:                                    ; preds = %56
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit.i.i:                   ; preds = %59
-  %66 = xor i64 %63, %64
-  store i64 %66, i64* %62, align 4
-  %67 = getelementptr inbounds i64, i64* %2, i64 %"303_0.sroa.15.0.i218.i"
-  %68 = load i64, i64* %67, align 4
-  %lazy_measure.i.i = tail call i64 @___lazy_measure(i64 %68)
-  tail call void @___qfree(i64 %68)
-  %69 = getelementptr inbounds i64, i64* %52, i64 %61
-  %70 = load i64, i64* %69, align 4
-  %71 = and i64 %70, %64
-  %.not.i.i.i = icmp eq i64 %71, 0
+__barray_check_bounds.exit.i.i:                   ; preds = %56
+  %63 = xor i64 %60, %61
+  store i64 %63, i64* %59, align 4
+  %64 = getelementptr inbounds i64, i64* %2, i64 %"303_0.sroa.15.0.i297.i"
+  %65 = load i64, i64* %64, align 4
+  %lazy_measure.i.i = tail call i64 @___lazy_measure(i64 %65)
+  tail call void @___qfree(i64 %65)
+  %66 = getelementptr inbounds i64, i64* %52, i64 %58
+  %67 = load i64, i64* %66, align 4
+  %68 = and i64 %67, %61
+  %.not.i.i.i = icmp eq i64 %68, 0
   br i1 %.not.i.i.i, label %panic.i.i.i, label %cond_exit_353.i.i
 
 panic.i.i.i:                                      ; preds = %__barray_check_bounds.exit.i.i
@@ -257,145 +252,57 @@ panic.i.i.i:                                      ; preds = %__barray_check_boun
 
 cond_exit_353.i.i:                                ; preds = %__barray_check_bounds.exit.i.i
   %"367_054.fca.1.insert.i.i" = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %lazy_measure.i.i, 1
-  %72 = xor i64 %70, %64
-  store i64 %72, i64* %69, align 4
-  %73 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"303_0.sroa.15.0.i218.i"
-  store { i1, i64, i1 } %"367_054.fca.1.insert.i.i", { i1, i64, i1 }* %73, align 4
-  %exitcond220.not.i = icmp eq i64 %60, 10
-  br i1 %exitcond220.not.i, label %mask_block_ok.i.i.i.i, label %59
+  %69 = xor i64 %67, %61
+  store i64 %69, i64* %66, align 4
+  %70 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"303_0.sroa.15.0.i297.i"
+  store { i1, i64, i1 } %"367_054.fca.1.insert.i.i", { i1, i64, i1 }* %70, align 4
+  %exitcond298.not.i = icmp eq i64 %57, 10
+  br i1 %exitcond298.not.i, label %mask_block_ok.i.i.i.i, label %56
 
-mask_block_err.i.i:                               ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i"
-  tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
+cond_160_case_0.i:                                ; preds = %cond_exit_160.i
+  %71 = load i64, i64* %52, align 4
+  %72 = or i64 %71, -1024
+  store i64 %72, i64* %52, align 4
+  %73 = icmp eq i64 %72, -1
+  br i1 %73, label %__hugr__.main.1.exit, label %mask_block_err.i.i
+
+mask_block_err.i.i:                               ; preds = %cond_160_case_0.i
+  tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit.i:              ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i"
-  %74 = tail call i8* @heap_alloc(i64 0)
-  %75 = tail call i8* @heap_alloc(i64 8)
-  %76 = bitcast i8* %75 to i64*
-  store i64 0, i64* %76, align 1
-  %77 = load { i1, i64, i1 }, { i1, i64, i1 }* %50, align 4
-  %.fca.0.extract.i209.i = extractvalue { i1, i64, i1 } %77, 0
-  br i1 %.fca.0.extract.i209.i, label %cond_163_case_1.i.i, label %__hugr__.const_fun_169.166.exit.i
+__barray_check_bounds.exit284.i:                  ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i", %cond_exit_160.i
+  %"162_0.0.i1" = phi i64 [ 0, %"__hugr__.$measure_array$$n(10).277.exit.i" ], [ %82, %cond_exit_160.i ]
+  %74 = lshr i64 %"162_0.0.i1", 6
+  %75 = getelementptr inbounds i64, i64* %52, i64 %74
+  %76 = load i64, i64* %75, align 4
+  %77 = shl nuw nsw i64 1, %"162_0.0.i1"
+  %78 = and i64 %76, %77
+  %.not.i = icmp eq i64 %78, 0
+  br i1 %.not.i, label %__barray_mask_borrow.exit289.i, label %cond_exit_160.i
 
-cond_163_case_1.i.i:                              ; preds = %__barray_check_none_borrowed.exit.i
-  %.fca.1.extract.i210.i = extractvalue { i1, i64, i1 } %77, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.i)
-  br label %__hugr__.const_fun_169.166.exit.i
+__barray_mask_borrow.exit289.i:                   ; preds = %__barray_check_bounds.exit284.i
+  %79 = xor i64 %76, %77
+  store i64 %79, i64* %75, align 4
+  %80 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"162_0.0.i1"
+  %81 = load { i1, i64, i1 }, { i1, i64, i1 }* %80, align 4
+  %.fca.0.extract180.i = extractvalue { i1, i64, i1 } %81, 0
+  br i1 %.fca.0.extract180.i, label %cond_85_case_1.i, label %cond_exit_160.i
 
-__hugr__.const_fun_169.166.exit.i:                ; preds = %cond_163_case_1.i.i, %__barray_check_none_borrowed.exit.i
-  %78 = getelementptr inbounds i8, i8* %49, i64 24
-  %79 = bitcast i8* %78 to { i1, i64, i1 }*
-  %80 = load { i1, i64, i1 }, { i1, i64, i1 }* %79, align 4
-  %.fca.0.extract.i209.1.i = extractvalue { i1, i64, i1 } %80, 0
-  br i1 %.fca.0.extract.i209.1.i, label %cond_163_case_1.i.1.i, label %__hugr__.const_fun_169.166.exit.1.i
+cond_exit_160.i:                                  ; preds = %cond_85_case_1.i, %__barray_mask_borrow.exit289.i, %__barray_check_bounds.exit284.i
+  %82 = add nuw nsw i64 %"162_0.0.i1", 1
+  %exitcond.not = icmp eq i64 %82, 10
+  br i1 %exitcond.not, label %cond_160_case_0.i, label %__barray_check_bounds.exit284.i
 
-cond_163_case_1.i.1.i:                            ; preds = %__hugr__.const_fun_169.166.exit.i
-  %.fca.1.extract.i210.1.i = extractvalue { i1, i64, i1 } %80, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.1.i)
-  br label %__hugr__.const_fun_169.166.exit.1.i
+cond_85_case_1.i:                                 ; preds = %__barray_mask_borrow.exit289.i
+  %.fca.1.extract.i = extractvalue { i1, i64, i1 } %81, 1
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i)
+  br label %cond_exit_160.i
 
-__hugr__.const_fun_169.166.exit.1.i:              ; preds = %cond_163_case_1.i.1.i, %__hugr__.const_fun_169.166.exit.i
-  %81 = getelementptr inbounds i8, i8* %49, i64 48
-  %82 = bitcast i8* %81 to { i1, i64, i1 }*
-  %83 = load { i1, i64, i1 }, { i1, i64, i1 }* %82, align 4
-  %.fca.0.extract.i209.2.i = extractvalue { i1, i64, i1 } %83, 0
-  br i1 %.fca.0.extract.i209.2.i, label %cond_163_case_1.i.2.i, label %__hugr__.const_fun_169.166.exit.2.i
-
-cond_163_case_1.i.2.i:                            ; preds = %__hugr__.const_fun_169.166.exit.1.i
-  %.fca.1.extract.i210.2.i = extractvalue { i1, i64, i1 } %83, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.2.i)
-  br label %__hugr__.const_fun_169.166.exit.2.i
-
-__hugr__.const_fun_169.166.exit.2.i:              ; preds = %cond_163_case_1.i.2.i, %__hugr__.const_fun_169.166.exit.1.i
-  %84 = getelementptr inbounds i8, i8* %49, i64 72
-  %85 = bitcast i8* %84 to { i1, i64, i1 }*
-  %86 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
-  %.fca.0.extract.i209.3.i = extractvalue { i1, i64, i1 } %86, 0
-  br i1 %.fca.0.extract.i209.3.i, label %cond_163_case_1.i.3.i, label %__hugr__.const_fun_169.166.exit.3.i
-
-cond_163_case_1.i.3.i:                            ; preds = %__hugr__.const_fun_169.166.exit.2.i
-  %.fca.1.extract.i210.3.i = extractvalue { i1, i64, i1 } %86, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.3.i)
-  br label %__hugr__.const_fun_169.166.exit.3.i
-
-__hugr__.const_fun_169.166.exit.3.i:              ; preds = %cond_163_case_1.i.3.i, %__hugr__.const_fun_169.166.exit.2.i
-  %87 = getelementptr inbounds i8, i8* %49, i64 96
-  %88 = bitcast i8* %87 to { i1, i64, i1 }*
-  %89 = load { i1, i64, i1 }, { i1, i64, i1 }* %88, align 4
-  %.fca.0.extract.i209.4.i = extractvalue { i1, i64, i1 } %89, 0
-  br i1 %.fca.0.extract.i209.4.i, label %cond_163_case_1.i.4.i, label %__hugr__.const_fun_169.166.exit.4.i
-
-cond_163_case_1.i.4.i:                            ; preds = %__hugr__.const_fun_169.166.exit.3.i
-  %.fca.1.extract.i210.4.i = extractvalue { i1, i64, i1 } %89, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.4.i)
-  br label %__hugr__.const_fun_169.166.exit.4.i
-
-__hugr__.const_fun_169.166.exit.4.i:              ; preds = %cond_163_case_1.i.4.i, %__hugr__.const_fun_169.166.exit.3.i
-  %90 = getelementptr inbounds i8, i8* %49, i64 120
-  %91 = bitcast i8* %90 to { i1, i64, i1 }*
-  %92 = load { i1, i64, i1 }, { i1, i64, i1 }* %91, align 4
-  %.fca.0.extract.i209.5.i = extractvalue { i1, i64, i1 } %92, 0
-  br i1 %.fca.0.extract.i209.5.i, label %cond_163_case_1.i.5.i, label %__hugr__.const_fun_169.166.exit.5.i
-
-cond_163_case_1.i.5.i:                            ; preds = %__hugr__.const_fun_169.166.exit.4.i
-  %.fca.1.extract.i210.5.i = extractvalue { i1, i64, i1 } %92, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.5.i)
-  br label %__hugr__.const_fun_169.166.exit.5.i
-
-__hugr__.const_fun_169.166.exit.5.i:              ; preds = %cond_163_case_1.i.5.i, %__hugr__.const_fun_169.166.exit.4.i
-  %93 = getelementptr inbounds i8, i8* %49, i64 144
-  %94 = bitcast i8* %93 to { i1, i64, i1 }*
-  %95 = load { i1, i64, i1 }, { i1, i64, i1 }* %94, align 4
-  %.fca.0.extract.i209.6.i = extractvalue { i1, i64, i1 } %95, 0
-  br i1 %.fca.0.extract.i209.6.i, label %cond_163_case_1.i.6.i, label %__hugr__.const_fun_169.166.exit.6.i
-
-cond_163_case_1.i.6.i:                            ; preds = %__hugr__.const_fun_169.166.exit.5.i
-  %.fca.1.extract.i210.6.i = extractvalue { i1, i64, i1 } %95, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.6.i)
-  br label %__hugr__.const_fun_169.166.exit.6.i
-
-__hugr__.const_fun_169.166.exit.6.i:              ; preds = %cond_163_case_1.i.6.i, %__hugr__.const_fun_169.166.exit.5.i
-  %96 = getelementptr inbounds i8, i8* %49, i64 168
-  %97 = bitcast i8* %96 to { i1, i64, i1 }*
-  %98 = load { i1, i64, i1 }, { i1, i64, i1 }* %97, align 4
-  %.fca.0.extract.i209.7.i = extractvalue { i1, i64, i1 } %98, 0
-  br i1 %.fca.0.extract.i209.7.i, label %cond_163_case_1.i.7.i, label %__hugr__.const_fun_169.166.exit.7.i
-
-cond_163_case_1.i.7.i:                            ; preds = %__hugr__.const_fun_169.166.exit.6.i
-  %.fca.1.extract.i210.7.i = extractvalue { i1, i64, i1 } %98, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.7.i)
-  br label %__hugr__.const_fun_169.166.exit.7.i
-
-__hugr__.const_fun_169.166.exit.7.i:              ; preds = %cond_163_case_1.i.7.i, %__hugr__.const_fun_169.166.exit.6.i
-  %99 = getelementptr inbounds i8, i8* %49, i64 192
-  %100 = bitcast i8* %99 to { i1, i64, i1 }*
-  %101 = load { i1, i64, i1 }, { i1, i64, i1 }* %100, align 4
-  %.fca.0.extract.i209.8.i = extractvalue { i1, i64, i1 } %101, 0
-  br i1 %.fca.0.extract.i209.8.i, label %cond_163_case_1.i.8.i, label %__hugr__.const_fun_169.166.exit.8.i
-
-cond_163_case_1.i.8.i:                            ; preds = %__hugr__.const_fun_169.166.exit.7.i
-  %.fca.1.extract.i210.8.i = extractvalue { i1, i64, i1 } %101, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.8.i)
-  br label %__hugr__.const_fun_169.166.exit.8.i
-
-__hugr__.const_fun_169.166.exit.8.i:              ; preds = %cond_163_case_1.i.8.i, %__hugr__.const_fun_169.166.exit.7.i
-  %102 = getelementptr inbounds i8, i8* %49, i64 216
-  %103 = bitcast i8* %102 to { i1, i64, i1 }*
-  %104 = load { i1, i64, i1 }, { i1, i64, i1 }* %103, align 4
-  %.fca.0.extract.i209.9.i = extractvalue { i1, i64, i1 } %104, 0
-  br i1 %.fca.0.extract.i209.9.i, label %cond_163_case_1.i.9.i, label %__hugr__.main.1.exit
-
-cond_163_case_1.i.9.i:                            ; preds = %__hugr__.const_fun_169.166.exit.8.i
-  %.fca.1.extract.i210.9.i = extractvalue { i1, i64, i1 } %104, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.9.i)
-  br label %__hugr__.main.1.exit
-
-__hugr__.main.1.exit:                             ; preds = %__hugr__.const_fun_169.166.exit.8.i, %cond_163_case_1.i.9.i
-  tail call void @heap_free(i8* nonnull %49)
+__hugr__.main.1.exit:                             ; preds = %cond_160_case_0.i
+  tail call void @heap_free(i8* %49)
   tail call void @heap_free(i8* nonnull %51)
-  tail call void @heap_free(i8* %74)
-  %105 = tail call i64 @teardown()
-  ret i64 %105
+  %83 = tail call i64 @teardown()
+  ret i64 %83
 }
 
 declare void @setup(i64) local_unnamed_addr

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-apple-darwin/measure_array_x86_64-apple-darwin
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-apple-darwin/measure_array_x86_64-apple-darwin
@@ -5,7 +5,6 @@ target triple = "x86_64-apple-darwin"
 
 @"e_Array alre.5A300C2A.0" = private constant [57 x i8] c"8EXIT:INT:Array already contains an element at this index"
 @"e_Array elem.E746B1A3.0" = private constant [43 x i8] c"*EXIT:INT:Array element is already borrowed"
-@"e_Some array.A77EF32E.0" = private constant [48 x i8] c"/EXIT:INT:Some array elements have been borrowed"
 @"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @"e_No more qu.3B2EEBF0.0" = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
 
@@ -39,8 +38,8 @@ entry:
   br label %cond_20_case_1.i
 
 cond_20_case_1.i:                                 ; preds = %cond_exit_20.i, %entry
-  %"15_0.sroa.0.0216.i" = phi i64 [ 0, %entry ], [ %5, %cond_exit_20.i ]
-  %5 = add nuw nsw i64 %"15_0.sroa.0.0216.i", 1
+  %"15_0.sroa.0.0295.i" = phi i64 [ 0, %entry ], [ %5, %cond_exit_20.i ]
+  %5 = add nuw nsw i64 %"15_0.sroa.0.0295.i", 1
   %qalloc.i.i = tail call i64 @___qalloc()
   %not_max.not.i.i = icmp eq i64 %qalloc.i.i, -1
   br i1 %not_max.not.i.i, label %id_bb.i.i, label %reset_bb.i.i
@@ -60,10 +59,10 @@ cond_217_case_0.i.i:                              ; preds = %id_bb.i.i
   unreachable
 
 __barray_check_bounds.exit.i:                     ; preds = %id_bb.i.i
-  %8 = lshr i64 %"15_0.sroa.0.0216.i", 6
+  %8 = lshr i64 %"15_0.sroa.0.0295.i", 6
   %9 = getelementptr inbounds i64, i64* %4, i64 %8
   %10 = load i64, i64* %9, align 4
-  %11 = shl nuw nsw i64 1, %"15_0.sroa.0.0216.i"
+  %11 = shl nuw nsw i64 1, %"15_0.sroa.0.0295.i"
   %12 = and i64 %10, %11
   %.not.i.i = icmp eq i64 %12, 0
   br i1 %.not.i.i, label %panic.i.i, label %cond_exit_20.i
@@ -76,7 +75,7 @@ cond_exit_20.i:                                   ; preds = %__barray_check_boun
   %.fca.1.extract.i.i = extractvalue { i1, i64 } %7, 1
   %13 = xor i64 %10, %11
   store i64 %13, i64* %9, align 4
-  %14 = getelementptr inbounds i64, i64* %2, i64 %"15_0.sroa.0.0216.i"
+  %14 = getelementptr inbounds i64, i64* %2, i64 %"15_0.sroa.0.0295.i"
   store i64 %.fca.1.extract.i.i, i64* %14, align 4
   %exitcond.not.i = icmp eq i64 %5, 10
   br i1 %exitcond.not.i, label %loop_out.i, label %cond_20_case_1.i
@@ -84,10 +83,10 @@ cond_exit_20.i:                                   ; preds = %__barray_check_boun
 loop_out.i:                                       ; preds = %cond_exit_20.i
   %15 = load i64, i64* %4, align 4
   %16 = and i64 %15, 1
-  %.not.i186.i = icmp eq i64 %16, 0
-  br i1 %.not.i186.i, label %__barray_mask_borrow.exit.i, label %panic.i187.i
+  %.not.i259.i = icmp eq i64 %16, 0
+  br i1 %.not.i259.i, label %__barray_mask_borrow.exit.i, label %panic.i260.i
 
-panic.i187.i:                                     ; preds = %loop_out.i
+panic.i260.i:                                     ; preds = %loop_out.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
@@ -98,27 +97,27 @@ __barray_mask_borrow.exit.i:                      ; preds = %loop_out.i
   tail call void @___rxy(i64 %18, double 0x400921FB54442D18, double 0.000000e+00)
   %19 = load i64, i64* %4, align 4
   %20 = and i64 %19, 1
-  %.not.i188.i = icmp eq i64 %20, 0
-  br i1 %.not.i188.i, label %panic.i189.i, label %__barray_mask_return.exit190.i
+  %.not.i261.i = icmp eq i64 %20, 0
+  br i1 %.not.i261.i, label %panic.i262.i, label %__barray_mask_return.exit263.i
 
-panic.i189.i:                                     ; preds = %__barray_mask_borrow.exit.i
+panic.i262.i:                                     ; preds = %__barray_mask_borrow.exit.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit190.i:                   ; preds = %__barray_mask_borrow.exit.i
+__barray_mask_return.exit263.i:                   ; preds = %__barray_mask_borrow.exit.i
   %21 = xor i64 %19, 1
   store i64 %21, i64* %4, align 4
   store i64 %18, i64* %2, align 4
   %22 = load i64, i64* %4, align 4
   %23 = and i64 %22, 4
-  %.not.i191.i = icmp eq i64 %23, 0
-  br i1 %.not.i191.i, label %__barray_mask_borrow.exit193.i, label %panic.i192.i
+  %.not.i264.i = icmp eq i64 %23, 0
+  br i1 %.not.i264.i, label %__barray_mask_borrow.exit266.i, label %panic.i265.i
 
-panic.i192.i:                                     ; preds = %__barray_mask_return.exit190.i
+panic.i265.i:                                     ; preds = %__barray_mask_return.exit263.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit193.i:                   ; preds = %__barray_mask_return.exit190.i
+__barray_mask_borrow.exit266.i:                   ; preds = %__barray_mask_return.exit263.i
   %24 = xor i64 %22, 4
   store i64 %24, i64* %4, align 4
   %25 = getelementptr inbounds i8, i8* %1, i64 16
@@ -127,27 +126,27 @@ __barray_mask_borrow.exit193.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %27, double 0x400921FB54442D18, double 0.000000e+00)
   %28 = load i64, i64* %4, align 4
   %29 = and i64 %28, 4
-  %.not.i194.i = icmp eq i64 %29, 0
-  br i1 %.not.i194.i, label %panic.i195.i, label %__barray_mask_return.exit196.i
+  %.not.i267.i = icmp eq i64 %29, 0
+  br i1 %.not.i267.i, label %panic.i268.i, label %__barray_mask_return.exit269.i
 
-panic.i195.i:                                     ; preds = %__barray_mask_borrow.exit193.i
+panic.i268.i:                                     ; preds = %__barray_mask_borrow.exit266.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit196.i:                   ; preds = %__barray_mask_borrow.exit193.i
+__barray_mask_return.exit269.i:                   ; preds = %__barray_mask_borrow.exit266.i
   %30 = xor i64 %28, 4
   store i64 %30, i64* %4, align 4
   store i64 %27, i64* %26, align 4
   %31 = load i64, i64* %4, align 4
   %32 = and i64 %31, 8
-  %.not.i197.i = icmp eq i64 %32, 0
-  br i1 %.not.i197.i, label %__barray_mask_borrow.exit199.i, label %panic.i198.i
+  %.not.i270.i = icmp eq i64 %32, 0
+  br i1 %.not.i270.i, label %__barray_mask_borrow.exit272.i, label %panic.i271.i
 
-panic.i198.i:                                     ; preds = %__barray_mask_return.exit196.i
+panic.i271.i:                                     ; preds = %__barray_mask_return.exit269.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit199.i:                   ; preds = %__barray_mask_return.exit196.i
+__barray_mask_borrow.exit272.i:                   ; preds = %__barray_mask_return.exit269.i
   %33 = xor i64 %31, 8
   store i64 %33, i64* %4, align 4
   %34 = getelementptr inbounds i8, i8* %1, i64 24
@@ -156,27 +155,27 @@ __barray_mask_borrow.exit199.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %36, double 0x400921FB54442D18, double 0.000000e+00)
   %37 = load i64, i64* %4, align 4
   %38 = and i64 %37, 8
-  %.not.i200.i = icmp eq i64 %38, 0
-  br i1 %.not.i200.i, label %panic.i201.i, label %__barray_mask_return.exit202.i
+  %.not.i273.i = icmp eq i64 %38, 0
+  br i1 %.not.i273.i, label %panic.i274.i, label %__barray_mask_return.exit275.i
 
-panic.i201.i:                                     ; preds = %__barray_mask_borrow.exit199.i
+panic.i274.i:                                     ; preds = %__barray_mask_borrow.exit272.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit202.i:                   ; preds = %__barray_mask_borrow.exit199.i
+__barray_mask_return.exit275.i:                   ; preds = %__barray_mask_borrow.exit272.i
   %39 = xor i64 %37, 8
   store i64 %39, i64* %4, align 4
   store i64 %36, i64* %35, align 4
   %40 = load i64, i64* %4, align 4
   %41 = and i64 %40, 512
-  %.not.i203.i = icmp eq i64 %41, 0
-  br i1 %.not.i203.i, label %__barray_mask_borrow.exit205.i, label %panic.i204.i
+  %.not.i276.i = icmp eq i64 %41, 0
+  br i1 %.not.i276.i, label %__barray_mask_borrow.exit278.i, label %panic.i277.i
 
-panic.i204.i:                                     ; preds = %__barray_mask_return.exit202.i
+panic.i277.i:                                     ; preds = %__barray_mask_return.exit275.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit205.i:                   ; preds = %__barray_mask_return.exit202.i
+__barray_mask_borrow.exit278.i:                   ; preds = %__barray_mask_return.exit275.i
   %42 = xor i64 %40, 512
   store i64 %42, i64* %4, align 4
   %43 = getelementptr inbounds i8, i8* %1, i64 72
@@ -185,14 +184,14 @@ __barray_mask_borrow.exit205.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %45, double 0x400921FB54442D18, double 0.000000e+00)
   %46 = load i64, i64* %4, align 4
   %47 = and i64 %46, 512
-  %.not.i206.i = icmp eq i64 %47, 0
-  br i1 %.not.i206.i, label %panic.i207.i, label %__barray_mask_return.exit208.i
+  %.not.i279.i = icmp eq i64 %47, 0
+  br i1 %.not.i279.i, label %panic.i280.i, label %__barray_mask_return.exit281.i
 
-panic.i207.i:                                     ; preds = %__barray_mask_borrow.exit205.i
+panic.i280.i:                                     ; preds = %__barray_mask_borrow.exit278.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit208.i:                   ; preds = %__barray_mask_borrow.exit205.i
+__barray_mask_return.exit281.i:                   ; preds = %__barray_mask_borrow.exit278.i
   %48 = xor i64 %46, 512
   store i64 %48, i64* %4, align 4
   store i64 %45, i64* %44, align 4
@@ -201,7 +200,7 @@ __barray_mask_return.exit208.i:                   ; preds = %__barray_mask_borro
   %51 = tail call i8* @heap_alloc(i64 8)
   %52 = bitcast i8* %51 to i64*
   store i64 -1, i64* %52, align 1
-  br label %59
+  br label %56
 
 mask_block_ok.i.i.i.i:                            ; preds = %cond_exit_353.i.i
   %53 = load i64, i64* %4, align 4
@@ -213,42 +212,38 @@ mask_block_ok.i.i.i.i:                            ; preds = %cond_exit_353.i.i
 "__hugr__.$measure_array$$n(10).277.exit.i":      ; preds = %mask_block_ok.i.i.i.i
   tail call void @heap_free(i8* nonnull %1)
   tail call void @heap_free(i8* nonnull %3)
-  %56 = load i64, i64* %52, align 4
-  %57 = and i64 %56, 1023
-  store i64 %57, i64* %52, align 4
-  %58 = icmp eq i64 %57, 0
-  br i1 %58, label %__barray_check_none_borrowed.exit.i, label %mask_block_err.i.i
+  br label %__barray_check_bounds.exit284.i
 
 mask_block_err.i.i.i.i:                           ; preds = %mask_block_ok.i.i.i.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-59:                                               ; preds = %cond_exit_353.i.i, %__barray_mask_return.exit208.i
-  %"303_0.sroa.15.0.i218.i" = phi i64 [ 0, %__barray_mask_return.exit208.i ], [ %60, %cond_exit_353.i.i ]
-  %60 = add nuw nsw i64 %"303_0.sroa.15.0.i218.i", 1
-  %61 = lshr i64 %"303_0.sroa.15.0.i218.i", 6
-  %62 = getelementptr inbounds i64, i64* %4, i64 %61
-  %63 = load i64, i64* %62, align 4
-  %64 = shl nuw nsw i64 1, %"303_0.sroa.15.0.i218.i"
-  %65 = and i64 %63, %64
-  %.not.i99.i.i.i = icmp eq i64 %65, 0
+56:                                               ; preds = %cond_exit_353.i.i, %__barray_mask_return.exit281.i
+  %"303_0.sroa.15.0.i297.i" = phi i64 [ 0, %__barray_mask_return.exit281.i ], [ %57, %cond_exit_353.i.i ]
+  %57 = add nuw nsw i64 %"303_0.sroa.15.0.i297.i", 1
+  %58 = lshr i64 %"303_0.sroa.15.0.i297.i", 6
+  %59 = getelementptr inbounds i64, i64* %4, i64 %58
+  %60 = load i64, i64* %59, align 4
+  %61 = shl nuw nsw i64 1, %"303_0.sroa.15.0.i297.i"
+  %62 = and i64 %60, %61
+  %.not.i99.i.i.i = icmp eq i64 %62, 0
   br i1 %.not.i99.i.i.i, label %__barray_check_bounds.exit.i.i, label %panic.i.i.i.i
 
-panic.i.i.i.i:                                    ; preds = %59
+panic.i.i.i.i:                                    ; preds = %56
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit.i.i:                   ; preds = %59
-  %66 = xor i64 %63, %64
-  store i64 %66, i64* %62, align 4
-  %67 = getelementptr inbounds i64, i64* %2, i64 %"303_0.sroa.15.0.i218.i"
-  %68 = load i64, i64* %67, align 4
-  %lazy_measure.i.i = tail call i64 @___lazy_measure(i64 %68)
-  tail call void @___qfree(i64 %68)
-  %69 = getelementptr inbounds i64, i64* %52, i64 %61
-  %70 = load i64, i64* %69, align 4
-  %71 = and i64 %70, %64
-  %.not.i.i.i = icmp eq i64 %71, 0
+__barray_check_bounds.exit.i.i:                   ; preds = %56
+  %63 = xor i64 %60, %61
+  store i64 %63, i64* %59, align 4
+  %64 = getelementptr inbounds i64, i64* %2, i64 %"303_0.sroa.15.0.i297.i"
+  %65 = load i64, i64* %64, align 4
+  %lazy_measure.i.i = tail call i64 @___lazy_measure(i64 %65)
+  tail call void @___qfree(i64 %65)
+  %66 = getelementptr inbounds i64, i64* %52, i64 %58
+  %67 = load i64, i64* %66, align 4
+  %68 = and i64 %67, %61
+  %.not.i.i.i = icmp eq i64 %68, 0
   br i1 %.not.i.i.i, label %panic.i.i.i, label %cond_exit_353.i.i
 
 panic.i.i.i:                                      ; preds = %__barray_check_bounds.exit.i.i
@@ -257,145 +252,57 @@ panic.i.i.i:                                      ; preds = %__barray_check_boun
 
 cond_exit_353.i.i:                                ; preds = %__barray_check_bounds.exit.i.i
   %"367_054.fca.1.insert.i.i" = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %lazy_measure.i.i, 1
-  %72 = xor i64 %70, %64
-  store i64 %72, i64* %69, align 4
-  %73 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"303_0.sroa.15.0.i218.i"
-  store { i1, i64, i1 } %"367_054.fca.1.insert.i.i", { i1, i64, i1 }* %73, align 4
-  %exitcond220.not.i = icmp eq i64 %60, 10
-  br i1 %exitcond220.not.i, label %mask_block_ok.i.i.i.i, label %59
+  %69 = xor i64 %67, %61
+  store i64 %69, i64* %66, align 4
+  %70 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"303_0.sroa.15.0.i297.i"
+  store { i1, i64, i1 } %"367_054.fca.1.insert.i.i", { i1, i64, i1 }* %70, align 4
+  %exitcond298.not.i = icmp eq i64 %57, 10
+  br i1 %exitcond298.not.i, label %mask_block_ok.i.i.i.i, label %56
 
-mask_block_err.i.i:                               ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i"
-  tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
+cond_160_case_0.i:                                ; preds = %cond_exit_160.i
+  %71 = load i64, i64* %52, align 4
+  %72 = or i64 %71, -1024
+  store i64 %72, i64* %52, align 4
+  %73 = icmp eq i64 %72, -1
+  br i1 %73, label %__hugr__.main.1.exit, label %mask_block_err.i.i
+
+mask_block_err.i.i:                               ; preds = %cond_160_case_0.i
+  tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit.i:              ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i"
-  %74 = tail call i8* @heap_alloc(i64 0)
-  %75 = tail call i8* @heap_alloc(i64 8)
-  %76 = bitcast i8* %75 to i64*
-  store i64 0, i64* %76, align 1
-  %77 = load { i1, i64, i1 }, { i1, i64, i1 }* %50, align 4
-  %.fca.0.extract.i209.i = extractvalue { i1, i64, i1 } %77, 0
-  br i1 %.fca.0.extract.i209.i, label %cond_163_case_1.i.i, label %__hugr__.const_fun_169.166.exit.i
+__barray_check_bounds.exit284.i:                  ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i", %cond_exit_160.i
+  %"162_0.0.i1" = phi i64 [ 0, %"__hugr__.$measure_array$$n(10).277.exit.i" ], [ %82, %cond_exit_160.i ]
+  %74 = lshr i64 %"162_0.0.i1", 6
+  %75 = getelementptr inbounds i64, i64* %52, i64 %74
+  %76 = load i64, i64* %75, align 4
+  %77 = shl nuw nsw i64 1, %"162_0.0.i1"
+  %78 = and i64 %76, %77
+  %.not.i = icmp eq i64 %78, 0
+  br i1 %.not.i, label %__barray_mask_borrow.exit289.i, label %cond_exit_160.i
 
-cond_163_case_1.i.i:                              ; preds = %__barray_check_none_borrowed.exit.i
-  %.fca.1.extract.i210.i = extractvalue { i1, i64, i1 } %77, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.i)
-  br label %__hugr__.const_fun_169.166.exit.i
+__barray_mask_borrow.exit289.i:                   ; preds = %__barray_check_bounds.exit284.i
+  %79 = xor i64 %76, %77
+  store i64 %79, i64* %75, align 4
+  %80 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"162_0.0.i1"
+  %81 = load { i1, i64, i1 }, { i1, i64, i1 }* %80, align 4
+  %.fca.0.extract180.i = extractvalue { i1, i64, i1 } %81, 0
+  br i1 %.fca.0.extract180.i, label %cond_85_case_1.i, label %cond_exit_160.i
 
-__hugr__.const_fun_169.166.exit.i:                ; preds = %cond_163_case_1.i.i, %__barray_check_none_borrowed.exit.i
-  %78 = getelementptr inbounds i8, i8* %49, i64 24
-  %79 = bitcast i8* %78 to { i1, i64, i1 }*
-  %80 = load { i1, i64, i1 }, { i1, i64, i1 }* %79, align 4
-  %.fca.0.extract.i209.1.i = extractvalue { i1, i64, i1 } %80, 0
-  br i1 %.fca.0.extract.i209.1.i, label %cond_163_case_1.i.1.i, label %__hugr__.const_fun_169.166.exit.1.i
+cond_exit_160.i:                                  ; preds = %cond_85_case_1.i, %__barray_mask_borrow.exit289.i, %__barray_check_bounds.exit284.i
+  %82 = add nuw nsw i64 %"162_0.0.i1", 1
+  %exitcond.not = icmp eq i64 %82, 10
+  br i1 %exitcond.not, label %cond_160_case_0.i, label %__barray_check_bounds.exit284.i
 
-cond_163_case_1.i.1.i:                            ; preds = %__hugr__.const_fun_169.166.exit.i
-  %.fca.1.extract.i210.1.i = extractvalue { i1, i64, i1 } %80, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.1.i)
-  br label %__hugr__.const_fun_169.166.exit.1.i
+cond_85_case_1.i:                                 ; preds = %__barray_mask_borrow.exit289.i
+  %.fca.1.extract.i = extractvalue { i1, i64, i1 } %81, 1
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i)
+  br label %cond_exit_160.i
 
-__hugr__.const_fun_169.166.exit.1.i:              ; preds = %cond_163_case_1.i.1.i, %__hugr__.const_fun_169.166.exit.i
-  %81 = getelementptr inbounds i8, i8* %49, i64 48
-  %82 = bitcast i8* %81 to { i1, i64, i1 }*
-  %83 = load { i1, i64, i1 }, { i1, i64, i1 }* %82, align 4
-  %.fca.0.extract.i209.2.i = extractvalue { i1, i64, i1 } %83, 0
-  br i1 %.fca.0.extract.i209.2.i, label %cond_163_case_1.i.2.i, label %__hugr__.const_fun_169.166.exit.2.i
-
-cond_163_case_1.i.2.i:                            ; preds = %__hugr__.const_fun_169.166.exit.1.i
-  %.fca.1.extract.i210.2.i = extractvalue { i1, i64, i1 } %83, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.2.i)
-  br label %__hugr__.const_fun_169.166.exit.2.i
-
-__hugr__.const_fun_169.166.exit.2.i:              ; preds = %cond_163_case_1.i.2.i, %__hugr__.const_fun_169.166.exit.1.i
-  %84 = getelementptr inbounds i8, i8* %49, i64 72
-  %85 = bitcast i8* %84 to { i1, i64, i1 }*
-  %86 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
-  %.fca.0.extract.i209.3.i = extractvalue { i1, i64, i1 } %86, 0
-  br i1 %.fca.0.extract.i209.3.i, label %cond_163_case_1.i.3.i, label %__hugr__.const_fun_169.166.exit.3.i
-
-cond_163_case_1.i.3.i:                            ; preds = %__hugr__.const_fun_169.166.exit.2.i
-  %.fca.1.extract.i210.3.i = extractvalue { i1, i64, i1 } %86, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.3.i)
-  br label %__hugr__.const_fun_169.166.exit.3.i
-
-__hugr__.const_fun_169.166.exit.3.i:              ; preds = %cond_163_case_1.i.3.i, %__hugr__.const_fun_169.166.exit.2.i
-  %87 = getelementptr inbounds i8, i8* %49, i64 96
-  %88 = bitcast i8* %87 to { i1, i64, i1 }*
-  %89 = load { i1, i64, i1 }, { i1, i64, i1 }* %88, align 4
-  %.fca.0.extract.i209.4.i = extractvalue { i1, i64, i1 } %89, 0
-  br i1 %.fca.0.extract.i209.4.i, label %cond_163_case_1.i.4.i, label %__hugr__.const_fun_169.166.exit.4.i
-
-cond_163_case_1.i.4.i:                            ; preds = %__hugr__.const_fun_169.166.exit.3.i
-  %.fca.1.extract.i210.4.i = extractvalue { i1, i64, i1 } %89, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.4.i)
-  br label %__hugr__.const_fun_169.166.exit.4.i
-
-__hugr__.const_fun_169.166.exit.4.i:              ; preds = %cond_163_case_1.i.4.i, %__hugr__.const_fun_169.166.exit.3.i
-  %90 = getelementptr inbounds i8, i8* %49, i64 120
-  %91 = bitcast i8* %90 to { i1, i64, i1 }*
-  %92 = load { i1, i64, i1 }, { i1, i64, i1 }* %91, align 4
-  %.fca.0.extract.i209.5.i = extractvalue { i1, i64, i1 } %92, 0
-  br i1 %.fca.0.extract.i209.5.i, label %cond_163_case_1.i.5.i, label %__hugr__.const_fun_169.166.exit.5.i
-
-cond_163_case_1.i.5.i:                            ; preds = %__hugr__.const_fun_169.166.exit.4.i
-  %.fca.1.extract.i210.5.i = extractvalue { i1, i64, i1 } %92, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.5.i)
-  br label %__hugr__.const_fun_169.166.exit.5.i
-
-__hugr__.const_fun_169.166.exit.5.i:              ; preds = %cond_163_case_1.i.5.i, %__hugr__.const_fun_169.166.exit.4.i
-  %93 = getelementptr inbounds i8, i8* %49, i64 144
-  %94 = bitcast i8* %93 to { i1, i64, i1 }*
-  %95 = load { i1, i64, i1 }, { i1, i64, i1 }* %94, align 4
-  %.fca.0.extract.i209.6.i = extractvalue { i1, i64, i1 } %95, 0
-  br i1 %.fca.0.extract.i209.6.i, label %cond_163_case_1.i.6.i, label %__hugr__.const_fun_169.166.exit.6.i
-
-cond_163_case_1.i.6.i:                            ; preds = %__hugr__.const_fun_169.166.exit.5.i
-  %.fca.1.extract.i210.6.i = extractvalue { i1, i64, i1 } %95, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.6.i)
-  br label %__hugr__.const_fun_169.166.exit.6.i
-
-__hugr__.const_fun_169.166.exit.6.i:              ; preds = %cond_163_case_1.i.6.i, %__hugr__.const_fun_169.166.exit.5.i
-  %96 = getelementptr inbounds i8, i8* %49, i64 168
-  %97 = bitcast i8* %96 to { i1, i64, i1 }*
-  %98 = load { i1, i64, i1 }, { i1, i64, i1 }* %97, align 4
-  %.fca.0.extract.i209.7.i = extractvalue { i1, i64, i1 } %98, 0
-  br i1 %.fca.0.extract.i209.7.i, label %cond_163_case_1.i.7.i, label %__hugr__.const_fun_169.166.exit.7.i
-
-cond_163_case_1.i.7.i:                            ; preds = %__hugr__.const_fun_169.166.exit.6.i
-  %.fca.1.extract.i210.7.i = extractvalue { i1, i64, i1 } %98, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.7.i)
-  br label %__hugr__.const_fun_169.166.exit.7.i
-
-__hugr__.const_fun_169.166.exit.7.i:              ; preds = %cond_163_case_1.i.7.i, %__hugr__.const_fun_169.166.exit.6.i
-  %99 = getelementptr inbounds i8, i8* %49, i64 192
-  %100 = bitcast i8* %99 to { i1, i64, i1 }*
-  %101 = load { i1, i64, i1 }, { i1, i64, i1 }* %100, align 4
-  %.fca.0.extract.i209.8.i = extractvalue { i1, i64, i1 } %101, 0
-  br i1 %.fca.0.extract.i209.8.i, label %cond_163_case_1.i.8.i, label %__hugr__.const_fun_169.166.exit.8.i
-
-cond_163_case_1.i.8.i:                            ; preds = %__hugr__.const_fun_169.166.exit.7.i
-  %.fca.1.extract.i210.8.i = extractvalue { i1, i64, i1 } %101, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.8.i)
-  br label %__hugr__.const_fun_169.166.exit.8.i
-
-__hugr__.const_fun_169.166.exit.8.i:              ; preds = %cond_163_case_1.i.8.i, %__hugr__.const_fun_169.166.exit.7.i
-  %102 = getelementptr inbounds i8, i8* %49, i64 216
-  %103 = bitcast i8* %102 to { i1, i64, i1 }*
-  %104 = load { i1, i64, i1 }, { i1, i64, i1 }* %103, align 4
-  %.fca.0.extract.i209.9.i = extractvalue { i1, i64, i1 } %104, 0
-  br i1 %.fca.0.extract.i209.9.i, label %cond_163_case_1.i.9.i, label %__hugr__.main.1.exit
-
-cond_163_case_1.i.9.i:                            ; preds = %__hugr__.const_fun_169.166.exit.8.i
-  %.fca.1.extract.i210.9.i = extractvalue { i1, i64, i1 } %104, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.9.i)
-  br label %__hugr__.main.1.exit
-
-__hugr__.main.1.exit:                             ; preds = %__hugr__.const_fun_169.166.exit.8.i, %cond_163_case_1.i.9.i
-  tail call void @heap_free(i8* nonnull %49)
+__hugr__.main.1.exit:                             ; preds = %cond_160_case_0.i
+  tail call void @heap_free(i8* %49)
   tail call void @heap_free(i8* nonnull %51)
-  tail call void @heap_free(i8* %74)
-  %105 = tail call i64 @teardown()
-  ret i64 %105
+  %83 = tail call i64 @teardown()
+  ret i64 %83
 }
 
 declare void @setup(i64) local_unnamed_addr

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-unknown-linux-gnu/measure_array_x86_64-unknown-linux-gnu
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-unknown-linux-gnu/measure_array_x86_64-unknown-linux-gnu
@@ -5,7 +5,6 @@ target triple = "x86_64-unknown-linux-gnu"
 
 @"e_Array alre.5A300C2A.0" = private constant [57 x i8] c"8EXIT:INT:Array already contains an element at this index"
 @"e_Array elem.E746B1A3.0" = private constant [43 x i8] c"*EXIT:INT:Array element is already borrowed"
-@"e_Some array.A77EF32E.0" = private constant [48 x i8] c"/EXIT:INT:Some array elements have been borrowed"
 @"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @"e_No more qu.3B2EEBF0.0" = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
 
@@ -39,8 +38,8 @@ entry:
   br label %cond_20_case_1.i
 
 cond_20_case_1.i:                                 ; preds = %cond_exit_20.i, %entry
-  %"15_0.sroa.0.0216.i" = phi i64 [ 0, %entry ], [ %5, %cond_exit_20.i ]
-  %5 = add nuw nsw i64 %"15_0.sroa.0.0216.i", 1
+  %"15_0.sroa.0.0295.i" = phi i64 [ 0, %entry ], [ %5, %cond_exit_20.i ]
+  %5 = add nuw nsw i64 %"15_0.sroa.0.0295.i", 1
   %qalloc.i.i = tail call i64 @___qalloc()
   %not_max.not.i.i = icmp eq i64 %qalloc.i.i, -1
   br i1 %not_max.not.i.i, label %id_bb.i.i, label %reset_bb.i.i
@@ -60,10 +59,10 @@ cond_217_case_0.i.i:                              ; preds = %id_bb.i.i
   unreachable
 
 __barray_check_bounds.exit.i:                     ; preds = %id_bb.i.i
-  %8 = lshr i64 %"15_0.sroa.0.0216.i", 6
+  %8 = lshr i64 %"15_0.sroa.0.0295.i", 6
   %9 = getelementptr inbounds i64, i64* %4, i64 %8
   %10 = load i64, i64* %9, align 4
-  %11 = shl nuw nsw i64 1, %"15_0.sroa.0.0216.i"
+  %11 = shl nuw nsw i64 1, %"15_0.sroa.0.0295.i"
   %12 = and i64 %10, %11
   %.not.i.i = icmp eq i64 %12, 0
   br i1 %.not.i.i, label %panic.i.i, label %cond_exit_20.i
@@ -76,7 +75,7 @@ cond_exit_20.i:                                   ; preds = %__barray_check_boun
   %.fca.1.extract.i.i = extractvalue { i1, i64 } %7, 1
   %13 = xor i64 %10, %11
   store i64 %13, i64* %9, align 4
-  %14 = getelementptr inbounds i64, i64* %2, i64 %"15_0.sroa.0.0216.i"
+  %14 = getelementptr inbounds i64, i64* %2, i64 %"15_0.sroa.0.0295.i"
   store i64 %.fca.1.extract.i.i, i64* %14, align 4
   %exitcond.not.i = icmp eq i64 %5, 10
   br i1 %exitcond.not.i, label %loop_out.i, label %cond_20_case_1.i
@@ -84,10 +83,10 @@ cond_exit_20.i:                                   ; preds = %__barray_check_boun
 loop_out.i:                                       ; preds = %cond_exit_20.i
   %15 = load i64, i64* %4, align 4
   %16 = and i64 %15, 1
-  %.not.i186.i = icmp eq i64 %16, 0
-  br i1 %.not.i186.i, label %__barray_mask_borrow.exit.i, label %panic.i187.i
+  %.not.i259.i = icmp eq i64 %16, 0
+  br i1 %.not.i259.i, label %__barray_mask_borrow.exit.i, label %panic.i260.i
 
-panic.i187.i:                                     ; preds = %loop_out.i
+panic.i260.i:                                     ; preds = %loop_out.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
@@ -98,27 +97,27 @@ __barray_mask_borrow.exit.i:                      ; preds = %loop_out.i
   tail call void @___rxy(i64 %18, double 0x400921FB54442D18, double 0.000000e+00)
   %19 = load i64, i64* %4, align 4
   %20 = and i64 %19, 1
-  %.not.i188.i = icmp eq i64 %20, 0
-  br i1 %.not.i188.i, label %panic.i189.i, label %__barray_mask_return.exit190.i
+  %.not.i261.i = icmp eq i64 %20, 0
+  br i1 %.not.i261.i, label %panic.i262.i, label %__barray_mask_return.exit263.i
 
-panic.i189.i:                                     ; preds = %__barray_mask_borrow.exit.i
+panic.i262.i:                                     ; preds = %__barray_mask_borrow.exit.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit190.i:                   ; preds = %__barray_mask_borrow.exit.i
+__barray_mask_return.exit263.i:                   ; preds = %__barray_mask_borrow.exit.i
   %21 = xor i64 %19, 1
   store i64 %21, i64* %4, align 4
   store i64 %18, i64* %2, align 4
   %22 = load i64, i64* %4, align 4
   %23 = and i64 %22, 4
-  %.not.i191.i = icmp eq i64 %23, 0
-  br i1 %.not.i191.i, label %__barray_mask_borrow.exit193.i, label %panic.i192.i
+  %.not.i264.i = icmp eq i64 %23, 0
+  br i1 %.not.i264.i, label %__barray_mask_borrow.exit266.i, label %panic.i265.i
 
-panic.i192.i:                                     ; preds = %__barray_mask_return.exit190.i
+panic.i265.i:                                     ; preds = %__barray_mask_return.exit263.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit193.i:                   ; preds = %__barray_mask_return.exit190.i
+__barray_mask_borrow.exit266.i:                   ; preds = %__barray_mask_return.exit263.i
   %24 = xor i64 %22, 4
   store i64 %24, i64* %4, align 4
   %25 = getelementptr inbounds i8, i8* %1, i64 16
@@ -127,27 +126,27 @@ __barray_mask_borrow.exit193.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %27, double 0x400921FB54442D18, double 0.000000e+00)
   %28 = load i64, i64* %4, align 4
   %29 = and i64 %28, 4
-  %.not.i194.i = icmp eq i64 %29, 0
-  br i1 %.not.i194.i, label %panic.i195.i, label %__barray_mask_return.exit196.i
+  %.not.i267.i = icmp eq i64 %29, 0
+  br i1 %.not.i267.i, label %panic.i268.i, label %__barray_mask_return.exit269.i
 
-panic.i195.i:                                     ; preds = %__barray_mask_borrow.exit193.i
+panic.i268.i:                                     ; preds = %__barray_mask_borrow.exit266.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit196.i:                   ; preds = %__barray_mask_borrow.exit193.i
+__barray_mask_return.exit269.i:                   ; preds = %__barray_mask_borrow.exit266.i
   %30 = xor i64 %28, 4
   store i64 %30, i64* %4, align 4
   store i64 %27, i64* %26, align 4
   %31 = load i64, i64* %4, align 4
   %32 = and i64 %31, 8
-  %.not.i197.i = icmp eq i64 %32, 0
-  br i1 %.not.i197.i, label %__barray_mask_borrow.exit199.i, label %panic.i198.i
+  %.not.i270.i = icmp eq i64 %32, 0
+  br i1 %.not.i270.i, label %__barray_mask_borrow.exit272.i, label %panic.i271.i
 
-panic.i198.i:                                     ; preds = %__barray_mask_return.exit196.i
+panic.i271.i:                                     ; preds = %__barray_mask_return.exit269.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit199.i:                   ; preds = %__barray_mask_return.exit196.i
+__barray_mask_borrow.exit272.i:                   ; preds = %__barray_mask_return.exit269.i
   %33 = xor i64 %31, 8
   store i64 %33, i64* %4, align 4
   %34 = getelementptr inbounds i8, i8* %1, i64 24
@@ -156,27 +155,27 @@ __barray_mask_borrow.exit199.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %36, double 0x400921FB54442D18, double 0.000000e+00)
   %37 = load i64, i64* %4, align 4
   %38 = and i64 %37, 8
-  %.not.i200.i = icmp eq i64 %38, 0
-  br i1 %.not.i200.i, label %panic.i201.i, label %__barray_mask_return.exit202.i
+  %.not.i273.i = icmp eq i64 %38, 0
+  br i1 %.not.i273.i, label %panic.i274.i, label %__barray_mask_return.exit275.i
 
-panic.i201.i:                                     ; preds = %__barray_mask_borrow.exit199.i
+panic.i274.i:                                     ; preds = %__barray_mask_borrow.exit272.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit202.i:                   ; preds = %__barray_mask_borrow.exit199.i
+__barray_mask_return.exit275.i:                   ; preds = %__barray_mask_borrow.exit272.i
   %39 = xor i64 %37, 8
   store i64 %39, i64* %4, align 4
   store i64 %36, i64* %35, align 4
   %40 = load i64, i64* %4, align 4
   %41 = and i64 %40, 512
-  %.not.i203.i = icmp eq i64 %41, 0
-  br i1 %.not.i203.i, label %__barray_mask_borrow.exit205.i, label %panic.i204.i
+  %.not.i276.i = icmp eq i64 %41, 0
+  br i1 %.not.i276.i, label %__barray_mask_borrow.exit278.i, label %panic.i277.i
 
-panic.i204.i:                                     ; preds = %__barray_mask_return.exit202.i
+panic.i277.i:                                     ; preds = %__barray_mask_return.exit275.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit205.i:                   ; preds = %__barray_mask_return.exit202.i
+__barray_mask_borrow.exit278.i:                   ; preds = %__barray_mask_return.exit275.i
   %42 = xor i64 %40, 512
   store i64 %42, i64* %4, align 4
   %43 = getelementptr inbounds i8, i8* %1, i64 72
@@ -185,14 +184,14 @@ __barray_mask_borrow.exit205.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %45, double 0x400921FB54442D18, double 0.000000e+00)
   %46 = load i64, i64* %4, align 4
   %47 = and i64 %46, 512
-  %.not.i206.i = icmp eq i64 %47, 0
-  br i1 %.not.i206.i, label %panic.i207.i, label %__barray_mask_return.exit208.i
+  %.not.i279.i = icmp eq i64 %47, 0
+  br i1 %.not.i279.i, label %panic.i280.i, label %__barray_mask_return.exit281.i
 
-panic.i207.i:                                     ; preds = %__barray_mask_borrow.exit205.i
+panic.i280.i:                                     ; preds = %__barray_mask_borrow.exit278.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit208.i:                   ; preds = %__barray_mask_borrow.exit205.i
+__barray_mask_return.exit281.i:                   ; preds = %__barray_mask_borrow.exit278.i
   %48 = xor i64 %46, 512
   store i64 %48, i64* %4, align 4
   store i64 %45, i64* %44, align 4
@@ -201,7 +200,7 @@ __barray_mask_return.exit208.i:                   ; preds = %__barray_mask_borro
   %51 = tail call i8* @heap_alloc(i64 8)
   %52 = bitcast i8* %51 to i64*
   store i64 -1, i64* %52, align 1
-  br label %59
+  br label %56
 
 mask_block_ok.i.i.i.i:                            ; preds = %cond_exit_353.i.i
   %53 = load i64, i64* %4, align 4
@@ -213,42 +212,38 @@ mask_block_ok.i.i.i.i:                            ; preds = %cond_exit_353.i.i
 "__hugr__.$measure_array$$n(10).277.exit.i":      ; preds = %mask_block_ok.i.i.i.i
   tail call void @heap_free(i8* nonnull %1)
   tail call void @heap_free(i8* nonnull %3)
-  %56 = load i64, i64* %52, align 4
-  %57 = and i64 %56, 1023
-  store i64 %57, i64* %52, align 4
-  %58 = icmp eq i64 %57, 0
-  br i1 %58, label %__barray_check_none_borrowed.exit.i, label %mask_block_err.i.i
+  br label %__barray_check_bounds.exit284.i
 
 mask_block_err.i.i.i.i:                           ; preds = %mask_block_ok.i.i.i.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-59:                                               ; preds = %cond_exit_353.i.i, %__barray_mask_return.exit208.i
-  %"303_0.sroa.15.0.i218.i" = phi i64 [ 0, %__barray_mask_return.exit208.i ], [ %60, %cond_exit_353.i.i ]
-  %60 = add nuw nsw i64 %"303_0.sroa.15.0.i218.i", 1
-  %61 = lshr i64 %"303_0.sroa.15.0.i218.i", 6
-  %62 = getelementptr inbounds i64, i64* %4, i64 %61
-  %63 = load i64, i64* %62, align 4
-  %64 = shl nuw nsw i64 1, %"303_0.sroa.15.0.i218.i"
-  %65 = and i64 %63, %64
-  %.not.i99.i.i.i = icmp eq i64 %65, 0
+56:                                               ; preds = %cond_exit_353.i.i, %__barray_mask_return.exit281.i
+  %"303_0.sroa.15.0.i297.i" = phi i64 [ 0, %__barray_mask_return.exit281.i ], [ %57, %cond_exit_353.i.i ]
+  %57 = add nuw nsw i64 %"303_0.sroa.15.0.i297.i", 1
+  %58 = lshr i64 %"303_0.sroa.15.0.i297.i", 6
+  %59 = getelementptr inbounds i64, i64* %4, i64 %58
+  %60 = load i64, i64* %59, align 4
+  %61 = shl nuw nsw i64 1, %"303_0.sroa.15.0.i297.i"
+  %62 = and i64 %60, %61
+  %.not.i99.i.i.i = icmp eq i64 %62, 0
   br i1 %.not.i99.i.i.i, label %__barray_check_bounds.exit.i.i, label %panic.i.i.i.i
 
-panic.i.i.i.i:                                    ; preds = %59
+panic.i.i.i.i:                                    ; preds = %56
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit.i.i:                   ; preds = %59
-  %66 = xor i64 %63, %64
-  store i64 %66, i64* %62, align 4
-  %67 = getelementptr inbounds i64, i64* %2, i64 %"303_0.sroa.15.0.i218.i"
-  %68 = load i64, i64* %67, align 4
-  %lazy_measure.i.i = tail call i64 @___lazy_measure(i64 %68)
-  tail call void @___qfree(i64 %68)
-  %69 = getelementptr inbounds i64, i64* %52, i64 %61
-  %70 = load i64, i64* %69, align 4
-  %71 = and i64 %70, %64
-  %.not.i.i.i = icmp eq i64 %71, 0
+__barray_check_bounds.exit.i.i:                   ; preds = %56
+  %63 = xor i64 %60, %61
+  store i64 %63, i64* %59, align 4
+  %64 = getelementptr inbounds i64, i64* %2, i64 %"303_0.sroa.15.0.i297.i"
+  %65 = load i64, i64* %64, align 4
+  %lazy_measure.i.i = tail call i64 @___lazy_measure(i64 %65)
+  tail call void @___qfree(i64 %65)
+  %66 = getelementptr inbounds i64, i64* %52, i64 %58
+  %67 = load i64, i64* %66, align 4
+  %68 = and i64 %67, %61
+  %.not.i.i.i = icmp eq i64 %68, 0
   br i1 %.not.i.i.i, label %panic.i.i.i, label %cond_exit_353.i.i
 
 panic.i.i.i:                                      ; preds = %__barray_check_bounds.exit.i.i
@@ -257,145 +252,57 @@ panic.i.i.i:                                      ; preds = %__barray_check_boun
 
 cond_exit_353.i.i:                                ; preds = %__barray_check_bounds.exit.i.i
   %"367_054.fca.1.insert.i.i" = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %lazy_measure.i.i, 1
-  %72 = xor i64 %70, %64
-  store i64 %72, i64* %69, align 4
-  %73 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"303_0.sroa.15.0.i218.i"
-  store { i1, i64, i1 } %"367_054.fca.1.insert.i.i", { i1, i64, i1 }* %73, align 4
-  %exitcond220.not.i = icmp eq i64 %60, 10
-  br i1 %exitcond220.not.i, label %mask_block_ok.i.i.i.i, label %59
+  %69 = xor i64 %67, %61
+  store i64 %69, i64* %66, align 4
+  %70 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"303_0.sroa.15.0.i297.i"
+  store { i1, i64, i1 } %"367_054.fca.1.insert.i.i", { i1, i64, i1 }* %70, align 4
+  %exitcond298.not.i = icmp eq i64 %57, 10
+  br i1 %exitcond298.not.i, label %mask_block_ok.i.i.i.i, label %56
 
-mask_block_err.i.i:                               ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i"
-  tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
+cond_160_case_0.i:                                ; preds = %cond_exit_160.i
+  %71 = load i64, i64* %52, align 4
+  %72 = or i64 %71, -1024
+  store i64 %72, i64* %52, align 4
+  %73 = icmp eq i64 %72, -1
+  br i1 %73, label %__hugr__.main.1.exit, label %mask_block_err.i.i
+
+mask_block_err.i.i:                               ; preds = %cond_160_case_0.i
+  tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit.i:              ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i"
-  %74 = tail call i8* @heap_alloc(i64 0)
-  %75 = tail call i8* @heap_alloc(i64 8)
-  %76 = bitcast i8* %75 to i64*
-  store i64 0, i64* %76, align 1
-  %77 = load { i1, i64, i1 }, { i1, i64, i1 }* %50, align 4
-  %.fca.0.extract.i209.i = extractvalue { i1, i64, i1 } %77, 0
-  br i1 %.fca.0.extract.i209.i, label %cond_163_case_1.i.i, label %__hugr__.const_fun_169.166.exit.i
+__barray_check_bounds.exit284.i:                  ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i", %cond_exit_160.i
+  %"162_0.0.i1" = phi i64 [ 0, %"__hugr__.$measure_array$$n(10).277.exit.i" ], [ %82, %cond_exit_160.i ]
+  %74 = lshr i64 %"162_0.0.i1", 6
+  %75 = getelementptr inbounds i64, i64* %52, i64 %74
+  %76 = load i64, i64* %75, align 4
+  %77 = shl nuw nsw i64 1, %"162_0.0.i1"
+  %78 = and i64 %76, %77
+  %.not.i = icmp eq i64 %78, 0
+  br i1 %.not.i, label %__barray_mask_borrow.exit289.i, label %cond_exit_160.i
 
-cond_163_case_1.i.i:                              ; preds = %__barray_check_none_borrowed.exit.i
-  %.fca.1.extract.i210.i = extractvalue { i1, i64, i1 } %77, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.i)
-  br label %__hugr__.const_fun_169.166.exit.i
+__barray_mask_borrow.exit289.i:                   ; preds = %__barray_check_bounds.exit284.i
+  %79 = xor i64 %76, %77
+  store i64 %79, i64* %75, align 4
+  %80 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"162_0.0.i1"
+  %81 = load { i1, i64, i1 }, { i1, i64, i1 }* %80, align 4
+  %.fca.0.extract180.i = extractvalue { i1, i64, i1 } %81, 0
+  br i1 %.fca.0.extract180.i, label %cond_85_case_1.i, label %cond_exit_160.i
 
-__hugr__.const_fun_169.166.exit.i:                ; preds = %cond_163_case_1.i.i, %__barray_check_none_borrowed.exit.i
-  %78 = getelementptr inbounds i8, i8* %49, i64 24
-  %79 = bitcast i8* %78 to { i1, i64, i1 }*
-  %80 = load { i1, i64, i1 }, { i1, i64, i1 }* %79, align 4
-  %.fca.0.extract.i209.1.i = extractvalue { i1, i64, i1 } %80, 0
-  br i1 %.fca.0.extract.i209.1.i, label %cond_163_case_1.i.1.i, label %__hugr__.const_fun_169.166.exit.1.i
+cond_exit_160.i:                                  ; preds = %cond_85_case_1.i, %__barray_mask_borrow.exit289.i, %__barray_check_bounds.exit284.i
+  %82 = add nuw nsw i64 %"162_0.0.i1", 1
+  %exitcond.not = icmp eq i64 %82, 10
+  br i1 %exitcond.not, label %cond_160_case_0.i, label %__barray_check_bounds.exit284.i
 
-cond_163_case_1.i.1.i:                            ; preds = %__hugr__.const_fun_169.166.exit.i
-  %.fca.1.extract.i210.1.i = extractvalue { i1, i64, i1 } %80, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.1.i)
-  br label %__hugr__.const_fun_169.166.exit.1.i
+cond_85_case_1.i:                                 ; preds = %__barray_mask_borrow.exit289.i
+  %.fca.1.extract.i = extractvalue { i1, i64, i1 } %81, 1
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i)
+  br label %cond_exit_160.i
 
-__hugr__.const_fun_169.166.exit.1.i:              ; preds = %cond_163_case_1.i.1.i, %__hugr__.const_fun_169.166.exit.i
-  %81 = getelementptr inbounds i8, i8* %49, i64 48
-  %82 = bitcast i8* %81 to { i1, i64, i1 }*
-  %83 = load { i1, i64, i1 }, { i1, i64, i1 }* %82, align 4
-  %.fca.0.extract.i209.2.i = extractvalue { i1, i64, i1 } %83, 0
-  br i1 %.fca.0.extract.i209.2.i, label %cond_163_case_1.i.2.i, label %__hugr__.const_fun_169.166.exit.2.i
-
-cond_163_case_1.i.2.i:                            ; preds = %__hugr__.const_fun_169.166.exit.1.i
-  %.fca.1.extract.i210.2.i = extractvalue { i1, i64, i1 } %83, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.2.i)
-  br label %__hugr__.const_fun_169.166.exit.2.i
-
-__hugr__.const_fun_169.166.exit.2.i:              ; preds = %cond_163_case_1.i.2.i, %__hugr__.const_fun_169.166.exit.1.i
-  %84 = getelementptr inbounds i8, i8* %49, i64 72
-  %85 = bitcast i8* %84 to { i1, i64, i1 }*
-  %86 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
-  %.fca.0.extract.i209.3.i = extractvalue { i1, i64, i1 } %86, 0
-  br i1 %.fca.0.extract.i209.3.i, label %cond_163_case_1.i.3.i, label %__hugr__.const_fun_169.166.exit.3.i
-
-cond_163_case_1.i.3.i:                            ; preds = %__hugr__.const_fun_169.166.exit.2.i
-  %.fca.1.extract.i210.3.i = extractvalue { i1, i64, i1 } %86, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.3.i)
-  br label %__hugr__.const_fun_169.166.exit.3.i
-
-__hugr__.const_fun_169.166.exit.3.i:              ; preds = %cond_163_case_1.i.3.i, %__hugr__.const_fun_169.166.exit.2.i
-  %87 = getelementptr inbounds i8, i8* %49, i64 96
-  %88 = bitcast i8* %87 to { i1, i64, i1 }*
-  %89 = load { i1, i64, i1 }, { i1, i64, i1 }* %88, align 4
-  %.fca.0.extract.i209.4.i = extractvalue { i1, i64, i1 } %89, 0
-  br i1 %.fca.0.extract.i209.4.i, label %cond_163_case_1.i.4.i, label %__hugr__.const_fun_169.166.exit.4.i
-
-cond_163_case_1.i.4.i:                            ; preds = %__hugr__.const_fun_169.166.exit.3.i
-  %.fca.1.extract.i210.4.i = extractvalue { i1, i64, i1 } %89, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.4.i)
-  br label %__hugr__.const_fun_169.166.exit.4.i
-
-__hugr__.const_fun_169.166.exit.4.i:              ; preds = %cond_163_case_1.i.4.i, %__hugr__.const_fun_169.166.exit.3.i
-  %90 = getelementptr inbounds i8, i8* %49, i64 120
-  %91 = bitcast i8* %90 to { i1, i64, i1 }*
-  %92 = load { i1, i64, i1 }, { i1, i64, i1 }* %91, align 4
-  %.fca.0.extract.i209.5.i = extractvalue { i1, i64, i1 } %92, 0
-  br i1 %.fca.0.extract.i209.5.i, label %cond_163_case_1.i.5.i, label %__hugr__.const_fun_169.166.exit.5.i
-
-cond_163_case_1.i.5.i:                            ; preds = %__hugr__.const_fun_169.166.exit.4.i
-  %.fca.1.extract.i210.5.i = extractvalue { i1, i64, i1 } %92, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.5.i)
-  br label %__hugr__.const_fun_169.166.exit.5.i
-
-__hugr__.const_fun_169.166.exit.5.i:              ; preds = %cond_163_case_1.i.5.i, %__hugr__.const_fun_169.166.exit.4.i
-  %93 = getelementptr inbounds i8, i8* %49, i64 144
-  %94 = bitcast i8* %93 to { i1, i64, i1 }*
-  %95 = load { i1, i64, i1 }, { i1, i64, i1 }* %94, align 4
-  %.fca.0.extract.i209.6.i = extractvalue { i1, i64, i1 } %95, 0
-  br i1 %.fca.0.extract.i209.6.i, label %cond_163_case_1.i.6.i, label %__hugr__.const_fun_169.166.exit.6.i
-
-cond_163_case_1.i.6.i:                            ; preds = %__hugr__.const_fun_169.166.exit.5.i
-  %.fca.1.extract.i210.6.i = extractvalue { i1, i64, i1 } %95, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.6.i)
-  br label %__hugr__.const_fun_169.166.exit.6.i
-
-__hugr__.const_fun_169.166.exit.6.i:              ; preds = %cond_163_case_1.i.6.i, %__hugr__.const_fun_169.166.exit.5.i
-  %96 = getelementptr inbounds i8, i8* %49, i64 168
-  %97 = bitcast i8* %96 to { i1, i64, i1 }*
-  %98 = load { i1, i64, i1 }, { i1, i64, i1 }* %97, align 4
-  %.fca.0.extract.i209.7.i = extractvalue { i1, i64, i1 } %98, 0
-  br i1 %.fca.0.extract.i209.7.i, label %cond_163_case_1.i.7.i, label %__hugr__.const_fun_169.166.exit.7.i
-
-cond_163_case_1.i.7.i:                            ; preds = %__hugr__.const_fun_169.166.exit.6.i
-  %.fca.1.extract.i210.7.i = extractvalue { i1, i64, i1 } %98, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.7.i)
-  br label %__hugr__.const_fun_169.166.exit.7.i
-
-__hugr__.const_fun_169.166.exit.7.i:              ; preds = %cond_163_case_1.i.7.i, %__hugr__.const_fun_169.166.exit.6.i
-  %99 = getelementptr inbounds i8, i8* %49, i64 192
-  %100 = bitcast i8* %99 to { i1, i64, i1 }*
-  %101 = load { i1, i64, i1 }, { i1, i64, i1 }* %100, align 4
-  %.fca.0.extract.i209.8.i = extractvalue { i1, i64, i1 } %101, 0
-  br i1 %.fca.0.extract.i209.8.i, label %cond_163_case_1.i.8.i, label %__hugr__.const_fun_169.166.exit.8.i
-
-cond_163_case_1.i.8.i:                            ; preds = %__hugr__.const_fun_169.166.exit.7.i
-  %.fca.1.extract.i210.8.i = extractvalue { i1, i64, i1 } %101, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.8.i)
-  br label %__hugr__.const_fun_169.166.exit.8.i
-
-__hugr__.const_fun_169.166.exit.8.i:              ; preds = %cond_163_case_1.i.8.i, %__hugr__.const_fun_169.166.exit.7.i
-  %102 = getelementptr inbounds i8, i8* %49, i64 216
-  %103 = bitcast i8* %102 to { i1, i64, i1 }*
-  %104 = load { i1, i64, i1 }, { i1, i64, i1 }* %103, align 4
-  %.fca.0.extract.i209.9.i = extractvalue { i1, i64, i1 } %104, 0
-  br i1 %.fca.0.extract.i209.9.i, label %cond_163_case_1.i.9.i, label %__hugr__.main.1.exit
-
-cond_163_case_1.i.9.i:                            ; preds = %__hugr__.const_fun_169.166.exit.8.i
-  %.fca.1.extract.i210.9.i = extractvalue { i1, i64, i1 } %104, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.9.i)
-  br label %__hugr__.main.1.exit
-
-__hugr__.main.1.exit:                             ; preds = %__hugr__.const_fun_169.166.exit.8.i, %cond_163_case_1.i.9.i
-  tail call void @heap_free(i8* nonnull %49)
+__hugr__.main.1.exit:                             ; preds = %cond_160_case_0.i
+  tail call void @heap_free(i8* %49)
   tail call void @heap_free(i8* nonnull %51)
-  tail call void @heap_free(i8* %74)
-  %105 = tail call i64 @teardown()
-  ret i64 %105
+  %83 = tail call i64 @teardown()
+  ret i64 %83
 }
 
 declare void @setup(i64) local_unnamed_addr

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-windows-msvc/measure_array_x86_64-windows-msvc
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_measure_array/x86_64-windows-msvc/measure_array_x86_64-windows-msvc
@@ -5,7 +5,6 @@ target triple = "x86_64-windows-msvc"
 
 @"e_Array alre.5A300C2A.0" = private constant [57 x i8] c"8EXIT:INT:Array already contains an element at this index"
 @"e_Array elem.E746B1A3.0" = private constant [43 x i8] c"*EXIT:INT:Array element is already borrowed"
-@"e_Some array.A77EF32E.0" = private constant [48 x i8] c"/EXIT:INT:Some array elements have been borrowed"
 @"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @"e_No more qu.3B2EEBF0.0" = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
 
@@ -39,8 +38,8 @@ entry:
   br label %cond_20_case_1.i
 
 cond_20_case_1.i:                                 ; preds = %cond_exit_20.i, %entry
-  %"15_0.sroa.0.0216.i" = phi i64 [ 0, %entry ], [ %5, %cond_exit_20.i ]
-  %5 = add nuw nsw i64 %"15_0.sroa.0.0216.i", 1
+  %"15_0.sroa.0.0295.i" = phi i64 [ 0, %entry ], [ %5, %cond_exit_20.i ]
+  %5 = add nuw nsw i64 %"15_0.sroa.0.0295.i", 1
   %qalloc.i.i = tail call i64 @___qalloc()
   %not_max.not.i.i = icmp eq i64 %qalloc.i.i, -1
   br i1 %not_max.not.i.i, label %id_bb.i.i, label %reset_bb.i.i
@@ -60,10 +59,10 @@ cond_217_case_0.i.i:                              ; preds = %id_bb.i.i
   unreachable
 
 __barray_check_bounds.exit.i:                     ; preds = %id_bb.i.i
-  %8 = lshr i64 %"15_0.sroa.0.0216.i", 6
+  %8 = lshr i64 %"15_0.sroa.0.0295.i", 6
   %9 = getelementptr inbounds i64, i64* %4, i64 %8
   %10 = load i64, i64* %9, align 4
-  %11 = shl nuw nsw i64 1, %"15_0.sroa.0.0216.i"
+  %11 = shl nuw nsw i64 1, %"15_0.sroa.0.0295.i"
   %12 = and i64 %10, %11
   %.not.i.i = icmp eq i64 %12, 0
   br i1 %.not.i.i, label %panic.i.i, label %cond_exit_20.i
@@ -76,7 +75,7 @@ cond_exit_20.i:                                   ; preds = %__barray_check_boun
   %.fca.1.extract.i.i = extractvalue { i1, i64 } %7, 1
   %13 = xor i64 %10, %11
   store i64 %13, i64* %9, align 4
-  %14 = getelementptr inbounds i64, i64* %2, i64 %"15_0.sroa.0.0216.i"
+  %14 = getelementptr inbounds i64, i64* %2, i64 %"15_0.sroa.0.0295.i"
   store i64 %.fca.1.extract.i.i, i64* %14, align 4
   %exitcond.not.i = icmp eq i64 %5, 10
   br i1 %exitcond.not.i, label %loop_out.i, label %cond_20_case_1.i
@@ -84,10 +83,10 @@ cond_exit_20.i:                                   ; preds = %__barray_check_boun
 loop_out.i:                                       ; preds = %cond_exit_20.i
   %15 = load i64, i64* %4, align 4
   %16 = and i64 %15, 1
-  %.not.i186.i = icmp eq i64 %16, 0
-  br i1 %.not.i186.i, label %__barray_mask_borrow.exit.i, label %panic.i187.i
+  %.not.i259.i = icmp eq i64 %16, 0
+  br i1 %.not.i259.i, label %__barray_mask_borrow.exit.i, label %panic.i260.i
 
-panic.i187.i:                                     ; preds = %loop_out.i
+panic.i260.i:                                     ; preds = %loop_out.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
@@ -98,27 +97,27 @@ __barray_mask_borrow.exit.i:                      ; preds = %loop_out.i
   tail call void @___rxy(i64 %18, double 0x400921FB54442D18, double 0.000000e+00)
   %19 = load i64, i64* %4, align 4
   %20 = and i64 %19, 1
-  %.not.i188.i = icmp eq i64 %20, 0
-  br i1 %.not.i188.i, label %panic.i189.i, label %__barray_mask_return.exit190.i
+  %.not.i261.i = icmp eq i64 %20, 0
+  br i1 %.not.i261.i, label %panic.i262.i, label %__barray_mask_return.exit263.i
 
-panic.i189.i:                                     ; preds = %__barray_mask_borrow.exit.i
+panic.i262.i:                                     ; preds = %__barray_mask_borrow.exit.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit190.i:                   ; preds = %__barray_mask_borrow.exit.i
+__barray_mask_return.exit263.i:                   ; preds = %__barray_mask_borrow.exit.i
   %21 = xor i64 %19, 1
   store i64 %21, i64* %4, align 4
   store i64 %18, i64* %2, align 4
   %22 = load i64, i64* %4, align 4
   %23 = and i64 %22, 4
-  %.not.i191.i = icmp eq i64 %23, 0
-  br i1 %.not.i191.i, label %__barray_mask_borrow.exit193.i, label %panic.i192.i
+  %.not.i264.i = icmp eq i64 %23, 0
+  br i1 %.not.i264.i, label %__barray_mask_borrow.exit266.i, label %panic.i265.i
 
-panic.i192.i:                                     ; preds = %__barray_mask_return.exit190.i
+panic.i265.i:                                     ; preds = %__barray_mask_return.exit263.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit193.i:                   ; preds = %__barray_mask_return.exit190.i
+__barray_mask_borrow.exit266.i:                   ; preds = %__barray_mask_return.exit263.i
   %24 = xor i64 %22, 4
   store i64 %24, i64* %4, align 4
   %25 = getelementptr inbounds i8, i8* %1, i64 16
@@ -127,27 +126,27 @@ __barray_mask_borrow.exit193.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %27, double 0x400921FB54442D18, double 0.000000e+00)
   %28 = load i64, i64* %4, align 4
   %29 = and i64 %28, 4
-  %.not.i194.i = icmp eq i64 %29, 0
-  br i1 %.not.i194.i, label %panic.i195.i, label %__barray_mask_return.exit196.i
+  %.not.i267.i = icmp eq i64 %29, 0
+  br i1 %.not.i267.i, label %panic.i268.i, label %__barray_mask_return.exit269.i
 
-panic.i195.i:                                     ; preds = %__barray_mask_borrow.exit193.i
+panic.i268.i:                                     ; preds = %__barray_mask_borrow.exit266.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit196.i:                   ; preds = %__barray_mask_borrow.exit193.i
+__barray_mask_return.exit269.i:                   ; preds = %__barray_mask_borrow.exit266.i
   %30 = xor i64 %28, 4
   store i64 %30, i64* %4, align 4
   store i64 %27, i64* %26, align 4
   %31 = load i64, i64* %4, align 4
   %32 = and i64 %31, 8
-  %.not.i197.i = icmp eq i64 %32, 0
-  br i1 %.not.i197.i, label %__barray_mask_borrow.exit199.i, label %panic.i198.i
+  %.not.i270.i = icmp eq i64 %32, 0
+  br i1 %.not.i270.i, label %__barray_mask_borrow.exit272.i, label %panic.i271.i
 
-panic.i198.i:                                     ; preds = %__barray_mask_return.exit196.i
+panic.i271.i:                                     ; preds = %__barray_mask_return.exit269.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit199.i:                   ; preds = %__barray_mask_return.exit196.i
+__barray_mask_borrow.exit272.i:                   ; preds = %__barray_mask_return.exit269.i
   %33 = xor i64 %31, 8
   store i64 %33, i64* %4, align 4
   %34 = getelementptr inbounds i8, i8* %1, i64 24
@@ -156,27 +155,27 @@ __barray_mask_borrow.exit199.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %36, double 0x400921FB54442D18, double 0.000000e+00)
   %37 = load i64, i64* %4, align 4
   %38 = and i64 %37, 8
-  %.not.i200.i = icmp eq i64 %38, 0
-  br i1 %.not.i200.i, label %panic.i201.i, label %__barray_mask_return.exit202.i
+  %.not.i273.i = icmp eq i64 %38, 0
+  br i1 %.not.i273.i, label %panic.i274.i, label %__barray_mask_return.exit275.i
 
-panic.i201.i:                                     ; preds = %__barray_mask_borrow.exit199.i
+panic.i274.i:                                     ; preds = %__barray_mask_borrow.exit272.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit202.i:                   ; preds = %__barray_mask_borrow.exit199.i
+__barray_mask_return.exit275.i:                   ; preds = %__barray_mask_borrow.exit272.i
   %39 = xor i64 %37, 8
   store i64 %39, i64* %4, align 4
   store i64 %36, i64* %35, align 4
   %40 = load i64, i64* %4, align 4
   %41 = and i64 %40, 512
-  %.not.i203.i = icmp eq i64 %41, 0
-  br i1 %.not.i203.i, label %__barray_mask_borrow.exit205.i, label %panic.i204.i
+  %.not.i276.i = icmp eq i64 %41, 0
+  br i1 %.not.i276.i, label %__barray_mask_borrow.exit278.i, label %panic.i277.i
 
-panic.i204.i:                                     ; preds = %__barray_mask_return.exit202.i
+panic.i277.i:                                     ; preds = %__barray_mask_return.exit275.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit205.i:                   ; preds = %__barray_mask_return.exit202.i
+__barray_mask_borrow.exit278.i:                   ; preds = %__barray_mask_return.exit275.i
   %42 = xor i64 %40, 512
   store i64 %42, i64* %4, align 4
   %43 = getelementptr inbounds i8, i8* %1, i64 72
@@ -185,14 +184,14 @@ __barray_mask_borrow.exit205.i:                   ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %45, double 0x400921FB54442D18, double 0.000000e+00)
   %46 = load i64, i64* %4, align 4
   %47 = and i64 %46, 512
-  %.not.i206.i = icmp eq i64 %47, 0
-  br i1 %.not.i206.i, label %panic.i207.i, label %__barray_mask_return.exit208.i
+  %.not.i279.i = icmp eq i64 %47, 0
+  br i1 %.not.i279.i, label %panic.i280.i, label %__barray_mask_return.exit281.i
 
-panic.i207.i:                                     ; preds = %__barray_mask_borrow.exit205.i
+panic.i280.i:                                     ; preds = %__barray_mask_borrow.exit278.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit208.i:                   ; preds = %__barray_mask_borrow.exit205.i
+__barray_mask_return.exit281.i:                   ; preds = %__barray_mask_borrow.exit278.i
   %48 = xor i64 %46, 512
   store i64 %48, i64* %4, align 4
   store i64 %45, i64* %44, align 4
@@ -201,7 +200,7 @@ __barray_mask_return.exit208.i:                   ; preds = %__barray_mask_borro
   %51 = tail call i8* @heap_alloc(i64 8)
   %52 = bitcast i8* %51 to i64*
   store i64 -1, i64* %52, align 1
-  br label %59
+  br label %56
 
 mask_block_ok.i.i.i.i:                            ; preds = %cond_exit_353.i.i
   %53 = load i64, i64* %4, align 4
@@ -213,42 +212,38 @@ mask_block_ok.i.i.i.i:                            ; preds = %cond_exit_353.i.i
 "__hugr__.$measure_array$$n(10).277.exit.i":      ; preds = %mask_block_ok.i.i.i.i
   tail call void @heap_free(i8* nonnull %1)
   tail call void @heap_free(i8* nonnull %3)
-  %56 = load i64, i64* %52, align 4
-  %57 = and i64 %56, 1023
-  store i64 %57, i64* %52, align 4
-  %58 = icmp eq i64 %57, 0
-  br i1 %58, label %__barray_check_none_borrowed.exit.i, label %mask_block_err.i.i
+  br label %__barray_check_bounds.exit284.i
 
 mask_block_err.i.i.i.i:                           ; preds = %mask_block_ok.i.i.i.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-59:                                               ; preds = %cond_exit_353.i.i, %__barray_mask_return.exit208.i
-  %"303_0.sroa.15.0.i218.i" = phi i64 [ 0, %__barray_mask_return.exit208.i ], [ %60, %cond_exit_353.i.i ]
-  %60 = add nuw nsw i64 %"303_0.sroa.15.0.i218.i", 1
-  %61 = lshr i64 %"303_0.sroa.15.0.i218.i", 6
-  %62 = getelementptr inbounds i64, i64* %4, i64 %61
-  %63 = load i64, i64* %62, align 4
-  %64 = shl nuw nsw i64 1, %"303_0.sroa.15.0.i218.i"
-  %65 = and i64 %63, %64
-  %.not.i99.i.i.i = icmp eq i64 %65, 0
+56:                                               ; preds = %cond_exit_353.i.i, %__barray_mask_return.exit281.i
+  %"303_0.sroa.15.0.i297.i" = phi i64 [ 0, %__barray_mask_return.exit281.i ], [ %57, %cond_exit_353.i.i ]
+  %57 = add nuw nsw i64 %"303_0.sroa.15.0.i297.i", 1
+  %58 = lshr i64 %"303_0.sroa.15.0.i297.i", 6
+  %59 = getelementptr inbounds i64, i64* %4, i64 %58
+  %60 = load i64, i64* %59, align 4
+  %61 = shl nuw nsw i64 1, %"303_0.sroa.15.0.i297.i"
+  %62 = and i64 %60, %61
+  %.not.i99.i.i.i = icmp eq i64 %62, 0
   br i1 %.not.i99.i.i.i, label %__barray_check_bounds.exit.i.i, label %panic.i.i.i.i
 
-panic.i.i.i.i:                                    ; preds = %59
+panic.i.i.i.i:                                    ; preds = %56
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit.i.i:                   ; preds = %59
-  %66 = xor i64 %63, %64
-  store i64 %66, i64* %62, align 4
-  %67 = getelementptr inbounds i64, i64* %2, i64 %"303_0.sroa.15.0.i218.i"
-  %68 = load i64, i64* %67, align 4
-  %lazy_measure.i.i = tail call i64 @___lazy_measure(i64 %68)
-  tail call void @___qfree(i64 %68)
-  %69 = getelementptr inbounds i64, i64* %52, i64 %61
-  %70 = load i64, i64* %69, align 4
-  %71 = and i64 %70, %64
-  %.not.i.i.i = icmp eq i64 %71, 0
+__barray_check_bounds.exit.i.i:                   ; preds = %56
+  %63 = xor i64 %60, %61
+  store i64 %63, i64* %59, align 4
+  %64 = getelementptr inbounds i64, i64* %2, i64 %"303_0.sroa.15.0.i297.i"
+  %65 = load i64, i64* %64, align 4
+  %lazy_measure.i.i = tail call i64 @___lazy_measure(i64 %65)
+  tail call void @___qfree(i64 %65)
+  %66 = getelementptr inbounds i64, i64* %52, i64 %58
+  %67 = load i64, i64* %66, align 4
+  %68 = and i64 %67, %61
+  %.not.i.i.i = icmp eq i64 %68, 0
   br i1 %.not.i.i.i, label %panic.i.i.i, label %cond_exit_353.i.i
 
 panic.i.i.i:                                      ; preds = %__barray_check_bounds.exit.i.i
@@ -257,145 +252,57 @@ panic.i.i.i:                                      ; preds = %__barray_check_boun
 
 cond_exit_353.i.i:                                ; preds = %__barray_check_bounds.exit.i.i
   %"367_054.fca.1.insert.i.i" = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %lazy_measure.i.i, 1
-  %72 = xor i64 %70, %64
-  store i64 %72, i64* %69, align 4
-  %73 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"303_0.sroa.15.0.i218.i"
-  store { i1, i64, i1 } %"367_054.fca.1.insert.i.i", { i1, i64, i1 }* %73, align 4
-  %exitcond220.not.i = icmp eq i64 %60, 10
-  br i1 %exitcond220.not.i, label %mask_block_ok.i.i.i.i, label %59
+  %69 = xor i64 %67, %61
+  store i64 %69, i64* %66, align 4
+  %70 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"303_0.sroa.15.0.i297.i"
+  store { i1, i64, i1 } %"367_054.fca.1.insert.i.i", { i1, i64, i1 }* %70, align 4
+  %exitcond298.not.i = icmp eq i64 %57, 10
+  br i1 %exitcond298.not.i, label %mask_block_ok.i.i.i.i, label %56
 
-mask_block_err.i.i:                               ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i"
-  tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
+cond_160_case_0.i:                                ; preds = %cond_exit_160.i
+  %71 = load i64, i64* %52, align 4
+  %72 = or i64 %71, -1024
+  store i64 %72, i64* %52, align 4
+  %73 = icmp eq i64 %72, -1
+  br i1 %73, label %__hugr__.main.1.exit, label %mask_block_err.i.i
+
+mask_block_err.i.i:                               ; preds = %cond_160_case_0.i
+  tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit.i:              ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i"
-  %74 = tail call i8* @heap_alloc(i64 0)
-  %75 = tail call i8* @heap_alloc(i64 8)
-  %76 = bitcast i8* %75 to i64*
-  store i64 0, i64* %76, align 1
-  %77 = load { i1, i64, i1 }, { i1, i64, i1 }* %50, align 4
-  %.fca.0.extract.i209.i = extractvalue { i1, i64, i1 } %77, 0
-  br i1 %.fca.0.extract.i209.i, label %cond_163_case_1.i.i, label %__hugr__.const_fun_169.166.exit.i
+__barray_check_bounds.exit284.i:                  ; preds = %"__hugr__.$measure_array$$n(10).277.exit.i", %cond_exit_160.i
+  %"162_0.0.i1" = phi i64 [ 0, %"__hugr__.$measure_array$$n(10).277.exit.i" ], [ %82, %cond_exit_160.i ]
+  %74 = lshr i64 %"162_0.0.i1", 6
+  %75 = getelementptr inbounds i64, i64* %52, i64 %74
+  %76 = load i64, i64* %75, align 4
+  %77 = shl nuw nsw i64 1, %"162_0.0.i1"
+  %78 = and i64 %76, %77
+  %.not.i = icmp eq i64 %78, 0
+  br i1 %.not.i, label %__barray_mask_borrow.exit289.i, label %cond_exit_160.i
 
-cond_163_case_1.i.i:                              ; preds = %__barray_check_none_borrowed.exit.i
-  %.fca.1.extract.i210.i = extractvalue { i1, i64, i1 } %77, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.i)
-  br label %__hugr__.const_fun_169.166.exit.i
+__barray_mask_borrow.exit289.i:                   ; preds = %__barray_check_bounds.exit284.i
+  %79 = xor i64 %76, %77
+  store i64 %79, i64* %75, align 4
+  %80 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %50, i64 %"162_0.0.i1"
+  %81 = load { i1, i64, i1 }, { i1, i64, i1 }* %80, align 4
+  %.fca.0.extract180.i = extractvalue { i1, i64, i1 } %81, 0
+  br i1 %.fca.0.extract180.i, label %cond_85_case_1.i, label %cond_exit_160.i
 
-__hugr__.const_fun_169.166.exit.i:                ; preds = %cond_163_case_1.i.i, %__barray_check_none_borrowed.exit.i
-  %78 = getelementptr inbounds i8, i8* %49, i64 24
-  %79 = bitcast i8* %78 to { i1, i64, i1 }*
-  %80 = load { i1, i64, i1 }, { i1, i64, i1 }* %79, align 4
-  %.fca.0.extract.i209.1.i = extractvalue { i1, i64, i1 } %80, 0
-  br i1 %.fca.0.extract.i209.1.i, label %cond_163_case_1.i.1.i, label %__hugr__.const_fun_169.166.exit.1.i
+cond_exit_160.i:                                  ; preds = %cond_85_case_1.i, %__barray_mask_borrow.exit289.i, %__barray_check_bounds.exit284.i
+  %82 = add nuw nsw i64 %"162_0.0.i1", 1
+  %exitcond.not = icmp eq i64 %82, 10
+  br i1 %exitcond.not, label %cond_160_case_0.i, label %__barray_check_bounds.exit284.i
 
-cond_163_case_1.i.1.i:                            ; preds = %__hugr__.const_fun_169.166.exit.i
-  %.fca.1.extract.i210.1.i = extractvalue { i1, i64, i1 } %80, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.1.i)
-  br label %__hugr__.const_fun_169.166.exit.1.i
+cond_85_case_1.i:                                 ; preds = %__barray_mask_borrow.exit289.i
+  %.fca.1.extract.i = extractvalue { i1, i64, i1 } %81, 1
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i)
+  br label %cond_exit_160.i
 
-__hugr__.const_fun_169.166.exit.1.i:              ; preds = %cond_163_case_1.i.1.i, %__hugr__.const_fun_169.166.exit.i
-  %81 = getelementptr inbounds i8, i8* %49, i64 48
-  %82 = bitcast i8* %81 to { i1, i64, i1 }*
-  %83 = load { i1, i64, i1 }, { i1, i64, i1 }* %82, align 4
-  %.fca.0.extract.i209.2.i = extractvalue { i1, i64, i1 } %83, 0
-  br i1 %.fca.0.extract.i209.2.i, label %cond_163_case_1.i.2.i, label %__hugr__.const_fun_169.166.exit.2.i
-
-cond_163_case_1.i.2.i:                            ; preds = %__hugr__.const_fun_169.166.exit.1.i
-  %.fca.1.extract.i210.2.i = extractvalue { i1, i64, i1 } %83, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.2.i)
-  br label %__hugr__.const_fun_169.166.exit.2.i
-
-__hugr__.const_fun_169.166.exit.2.i:              ; preds = %cond_163_case_1.i.2.i, %__hugr__.const_fun_169.166.exit.1.i
-  %84 = getelementptr inbounds i8, i8* %49, i64 72
-  %85 = bitcast i8* %84 to { i1, i64, i1 }*
-  %86 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
-  %.fca.0.extract.i209.3.i = extractvalue { i1, i64, i1 } %86, 0
-  br i1 %.fca.0.extract.i209.3.i, label %cond_163_case_1.i.3.i, label %__hugr__.const_fun_169.166.exit.3.i
-
-cond_163_case_1.i.3.i:                            ; preds = %__hugr__.const_fun_169.166.exit.2.i
-  %.fca.1.extract.i210.3.i = extractvalue { i1, i64, i1 } %86, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.3.i)
-  br label %__hugr__.const_fun_169.166.exit.3.i
-
-__hugr__.const_fun_169.166.exit.3.i:              ; preds = %cond_163_case_1.i.3.i, %__hugr__.const_fun_169.166.exit.2.i
-  %87 = getelementptr inbounds i8, i8* %49, i64 96
-  %88 = bitcast i8* %87 to { i1, i64, i1 }*
-  %89 = load { i1, i64, i1 }, { i1, i64, i1 }* %88, align 4
-  %.fca.0.extract.i209.4.i = extractvalue { i1, i64, i1 } %89, 0
-  br i1 %.fca.0.extract.i209.4.i, label %cond_163_case_1.i.4.i, label %__hugr__.const_fun_169.166.exit.4.i
-
-cond_163_case_1.i.4.i:                            ; preds = %__hugr__.const_fun_169.166.exit.3.i
-  %.fca.1.extract.i210.4.i = extractvalue { i1, i64, i1 } %89, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.4.i)
-  br label %__hugr__.const_fun_169.166.exit.4.i
-
-__hugr__.const_fun_169.166.exit.4.i:              ; preds = %cond_163_case_1.i.4.i, %__hugr__.const_fun_169.166.exit.3.i
-  %90 = getelementptr inbounds i8, i8* %49, i64 120
-  %91 = bitcast i8* %90 to { i1, i64, i1 }*
-  %92 = load { i1, i64, i1 }, { i1, i64, i1 }* %91, align 4
-  %.fca.0.extract.i209.5.i = extractvalue { i1, i64, i1 } %92, 0
-  br i1 %.fca.0.extract.i209.5.i, label %cond_163_case_1.i.5.i, label %__hugr__.const_fun_169.166.exit.5.i
-
-cond_163_case_1.i.5.i:                            ; preds = %__hugr__.const_fun_169.166.exit.4.i
-  %.fca.1.extract.i210.5.i = extractvalue { i1, i64, i1 } %92, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.5.i)
-  br label %__hugr__.const_fun_169.166.exit.5.i
-
-__hugr__.const_fun_169.166.exit.5.i:              ; preds = %cond_163_case_1.i.5.i, %__hugr__.const_fun_169.166.exit.4.i
-  %93 = getelementptr inbounds i8, i8* %49, i64 144
-  %94 = bitcast i8* %93 to { i1, i64, i1 }*
-  %95 = load { i1, i64, i1 }, { i1, i64, i1 }* %94, align 4
-  %.fca.0.extract.i209.6.i = extractvalue { i1, i64, i1 } %95, 0
-  br i1 %.fca.0.extract.i209.6.i, label %cond_163_case_1.i.6.i, label %__hugr__.const_fun_169.166.exit.6.i
-
-cond_163_case_1.i.6.i:                            ; preds = %__hugr__.const_fun_169.166.exit.5.i
-  %.fca.1.extract.i210.6.i = extractvalue { i1, i64, i1 } %95, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.6.i)
-  br label %__hugr__.const_fun_169.166.exit.6.i
-
-__hugr__.const_fun_169.166.exit.6.i:              ; preds = %cond_163_case_1.i.6.i, %__hugr__.const_fun_169.166.exit.5.i
-  %96 = getelementptr inbounds i8, i8* %49, i64 168
-  %97 = bitcast i8* %96 to { i1, i64, i1 }*
-  %98 = load { i1, i64, i1 }, { i1, i64, i1 }* %97, align 4
-  %.fca.0.extract.i209.7.i = extractvalue { i1, i64, i1 } %98, 0
-  br i1 %.fca.0.extract.i209.7.i, label %cond_163_case_1.i.7.i, label %__hugr__.const_fun_169.166.exit.7.i
-
-cond_163_case_1.i.7.i:                            ; preds = %__hugr__.const_fun_169.166.exit.6.i
-  %.fca.1.extract.i210.7.i = extractvalue { i1, i64, i1 } %98, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.7.i)
-  br label %__hugr__.const_fun_169.166.exit.7.i
-
-__hugr__.const_fun_169.166.exit.7.i:              ; preds = %cond_163_case_1.i.7.i, %__hugr__.const_fun_169.166.exit.6.i
-  %99 = getelementptr inbounds i8, i8* %49, i64 192
-  %100 = bitcast i8* %99 to { i1, i64, i1 }*
-  %101 = load { i1, i64, i1 }, { i1, i64, i1 }* %100, align 4
-  %.fca.0.extract.i209.8.i = extractvalue { i1, i64, i1 } %101, 0
-  br i1 %.fca.0.extract.i209.8.i, label %cond_163_case_1.i.8.i, label %__hugr__.const_fun_169.166.exit.8.i
-
-cond_163_case_1.i.8.i:                            ; preds = %__hugr__.const_fun_169.166.exit.7.i
-  %.fca.1.extract.i210.8.i = extractvalue { i1, i64, i1 } %101, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.8.i)
-  br label %__hugr__.const_fun_169.166.exit.8.i
-
-__hugr__.const_fun_169.166.exit.8.i:              ; preds = %cond_163_case_1.i.8.i, %__hugr__.const_fun_169.166.exit.7.i
-  %102 = getelementptr inbounds i8, i8* %49, i64 216
-  %103 = bitcast i8* %102 to { i1, i64, i1 }*
-  %104 = load { i1, i64, i1 }, { i1, i64, i1 }* %103, align 4
-  %.fca.0.extract.i209.9.i = extractvalue { i1, i64, i1 } %104, 0
-  br i1 %.fca.0.extract.i209.9.i, label %cond_163_case_1.i.9.i, label %__hugr__.main.1.exit
-
-cond_163_case_1.i.9.i:                            ; preds = %__hugr__.const_fun_169.166.exit.8.i
-  %.fca.1.extract.i210.9.i = extractvalue { i1, i64, i1 } %104, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i210.9.i)
-  br label %__hugr__.main.1.exit
-
-__hugr__.main.1.exit:                             ; preds = %__hugr__.const_fun_169.166.exit.8.i, %cond_163_case_1.i.9.i
-  tail call void @heap_free(i8* nonnull %49)
+__hugr__.main.1.exit:                             ; preds = %cond_160_case_0.i
+  tail call void @heap_free(i8* %49)
   tail call void @heap_free(i8* nonnull %51)
-  tail call void @heap_free(i8* %74)
-  %105 = tail call i64 @teardown()
-  ret i64 %105
+  %83 = tail call i64 @teardown()
+  ret i64 %83
 }
 
 declare void @setup(i64) local_unnamed_addr

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_print_array/aarch64-apple-darwin/print_array_aarch64-apple-darwin
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_print_array/aarch64-apple-darwin/print_array_aarch64-apple-darwin
@@ -6,10 +6,10 @@ target triple = "aarch64-apple-darwin"
 @"e_Array alre.5A300C2A.0" = private constant [57 x i8] c"8EXIT:INT:Array already contains an element at this index"
 @"e_Array elem.E746B1A3.0" = private constant [43 x i8] c"*EXIT:INT:Array element is already borrowed"
 @"e_Some array.A77EF32E.0" = private constant [48 x i8] c"/EXIT:INT:Some array elements have been borrowed"
+@"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @res_cs.46C3C4B5.0 = private constant [16 x i8] c"\0FUSER:BOOLARR:cs"
 @res_is.F21393DB.0 = private constant [15 x i8] c"\0EUSER:INTARR:is"
 @res_fs.CBD4AF54.0 = private constant [17 x i8] c"\10USER:FLOATARR:fs"
-@"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @"e_No more qu.3B2EEBF0.0" = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
 @"e_Expected v.E6312129.0" = private constant [46 x i8] c"-EXIT:INT:Expected variant 1 but got variant 0"
 @"e_Expected v.2F17E0A9.0" = private constant [46 x i8] c"-EXIT:INT:Expected variant 0 but got variant 1"
@@ -34,8 +34,8 @@ alloca_block:
   br label %cond_20_case_1
 
 cond_20_case_1:                                   ; preds = %alloca_block, %cond_exit_20
-  %"15_0.sroa.0.0887" = phi i64 [ 0, %alloca_block ], [ %12, %cond_exit_20 ]
-  %12 = add nuw nsw i64 %"15_0.sroa.0.0887", 1
+  %"15_0.sroa.0.0961" = phi i64 [ 0, %alloca_block ], [ %12, %cond_exit_20 ]
+  %12 = add nuw nsw i64 %"15_0.sroa.0.0961", 1
   %qalloc.i = tail call i64 @___qalloc()
   %not_max.not.i = icmp eq i64 %qalloc.i, -1
   br i1 %not_max.not.i, label %id_bb.i, label %reset_bb.i
@@ -55,10 +55,10 @@ cond_303_case_0.i:                                ; preds = %id_bb.i
   unreachable
 
 __barray_check_bounds.exit:                       ; preds = %id_bb.i
-  %15 = lshr i64 %"15_0.sroa.0.0887", 6
+  %15 = lshr i64 %"15_0.sroa.0.0961", 6
   %16 = getelementptr inbounds i64, i64* %11, i64 %15
   %17 = load i64, i64* %16, align 4
-  %18 = shl nuw nsw i64 1, %"15_0.sroa.0.0887"
+  %18 = shl nuw nsw i64 1, %"15_0.sroa.0.0961"
   %19 = and i64 %17, %18
   %.not.i = icmp eq i64 %19, 0
   br i1 %.not.i, label %panic.i, label %cond_exit_20
@@ -71,7 +71,7 @@ cond_exit_20:                                     ; preds = %__barray_check_boun
   %.fca.1.extract.i = extractvalue { i1, i64 } %14, 1
   %20 = xor i64 %17, %18
   store i64 %20, i64* %16, align 4
-  %21 = getelementptr inbounds i64, i64* %9, i64 %"15_0.sroa.0.0887"
+  %21 = getelementptr inbounds i64, i64* %9, i64 %"15_0.sroa.0.0961"
   store i64 %.fca.1.extract.i, i64* %21, align 4
   %exitcond.not = icmp eq i64 %12, 10
   br i1 %exitcond.not, label %loop_out, label %cond_20_case_1
@@ -79,10 +79,10 @@ cond_exit_20:                                     ; preds = %__barray_check_boun
 loop_out:                                         ; preds = %cond_exit_20
   %22 = load i64, i64* %11, align 4
   %23 = and i64 %22, 1
-  %.not.i781 = icmp eq i64 %23, 0
-  br i1 %.not.i781, label %__barray_mask_borrow.exit, label %panic.i782
+  %.not.i852 = icmp eq i64 %23, 0
+  br i1 %.not.i852, label %__barray_mask_borrow.exit, label %panic.i853
 
-panic.i782:                                       ; preds = %loop_out
+panic.i853:                                       ; preds = %loop_out
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
@@ -93,27 +93,27 @@ __barray_mask_borrow.exit:                        ; preds = %loop_out
   tail call void @___rxy(i64 %25, double 0x400921FB54442D18, double 0.000000e+00)
   %26 = load i64, i64* %11, align 4
   %27 = and i64 %26, 1
-  %.not.i783 = icmp eq i64 %27, 0
-  br i1 %.not.i783, label %panic.i784, label %__barray_mask_return.exit785
+  %.not.i854 = icmp eq i64 %27, 0
+  br i1 %.not.i854, label %panic.i855, label %__barray_mask_return.exit856
 
-panic.i784:                                       ; preds = %__barray_mask_borrow.exit
+panic.i855:                                       ; preds = %__barray_mask_borrow.exit
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit785:                     ; preds = %__barray_mask_borrow.exit
+__barray_mask_return.exit856:                     ; preds = %__barray_mask_borrow.exit
   %28 = xor i64 %26, 1
   store i64 %28, i64* %11, align 4
   store i64 %25, i64* %9, align 4
   %29 = load i64, i64* %11, align 4
   %30 = and i64 %29, 4
-  %.not.i786 = icmp eq i64 %30, 0
-  br i1 %.not.i786, label %__barray_mask_borrow.exit788, label %panic.i787
+  %.not.i857 = icmp eq i64 %30, 0
+  br i1 %.not.i857, label %__barray_mask_borrow.exit859, label %panic.i858
 
-panic.i787:                                       ; preds = %__barray_mask_return.exit785
+panic.i858:                                       ; preds = %__barray_mask_return.exit856
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit788:                     ; preds = %__barray_mask_return.exit785
+__barray_mask_borrow.exit859:                     ; preds = %__barray_mask_return.exit856
   %31 = xor i64 %29, 4
   store i64 %31, i64* %11, align 4
   %32 = getelementptr inbounds i8, i8* %8, i64 16
@@ -122,27 +122,27 @@ __barray_mask_borrow.exit788:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %34, double 0x400921FB54442D18, double 0.000000e+00)
   %35 = load i64, i64* %11, align 4
   %36 = and i64 %35, 4
-  %.not.i789 = icmp eq i64 %36, 0
-  br i1 %.not.i789, label %panic.i790, label %__barray_mask_return.exit791
+  %.not.i860 = icmp eq i64 %36, 0
+  br i1 %.not.i860, label %panic.i861, label %__barray_mask_return.exit862
 
-panic.i790:                                       ; preds = %__barray_mask_borrow.exit788
+panic.i861:                                       ; preds = %__barray_mask_borrow.exit859
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit791:                     ; preds = %__barray_mask_borrow.exit788
+__barray_mask_return.exit862:                     ; preds = %__barray_mask_borrow.exit859
   %37 = xor i64 %35, 4
   store i64 %37, i64* %11, align 4
   store i64 %34, i64* %33, align 4
   %38 = load i64, i64* %11, align 4
   %39 = and i64 %38, 8
-  %.not.i792 = icmp eq i64 %39, 0
-  br i1 %.not.i792, label %__barray_mask_borrow.exit794, label %panic.i793
+  %.not.i863 = icmp eq i64 %39, 0
+  br i1 %.not.i863, label %__barray_mask_borrow.exit865, label %panic.i864
 
-panic.i793:                                       ; preds = %__barray_mask_return.exit791
+panic.i864:                                       ; preds = %__barray_mask_return.exit862
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit794:                     ; preds = %__barray_mask_return.exit791
+__barray_mask_borrow.exit865:                     ; preds = %__barray_mask_return.exit862
   %40 = xor i64 %38, 8
   store i64 %40, i64* %11, align 4
   %41 = getelementptr inbounds i8, i8* %8, i64 24
@@ -151,27 +151,27 @@ __barray_mask_borrow.exit794:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %43, double 0x400921FB54442D18, double 0.000000e+00)
   %44 = load i64, i64* %11, align 4
   %45 = and i64 %44, 8
-  %.not.i795 = icmp eq i64 %45, 0
-  br i1 %.not.i795, label %panic.i796, label %__barray_mask_return.exit797
+  %.not.i866 = icmp eq i64 %45, 0
+  br i1 %.not.i866, label %panic.i867, label %__barray_mask_return.exit868
 
-panic.i796:                                       ; preds = %__barray_mask_borrow.exit794
+panic.i867:                                       ; preds = %__barray_mask_borrow.exit865
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit797:                     ; preds = %__barray_mask_borrow.exit794
+__barray_mask_return.exit868:                     ; preds = %__barray_mask_borrow.exit865
   %46 = xor i64 %44, 8
   store i64 %46, i64* %11, align 4
   store i64 %43, i64* %42, align 4
   %47 = load i64, i64* %11, align 4
   %48 = and i64 %47, 512
-  %.not.i798 = icmp eq i64 %48, 0
-  br i1 %.not.i798, label %__barray_mask_borrow.exit800, label %panic.i799
+  %.not.i869 = icmp eq i64 %48, 0
+  br i1 %.not.i869, label %__barray_mask_borrow.exit871, label %panic.i870
 
-panic.i799:                                       ; preds = %__barray_mask_return.exit797
+panic.i870:                                       ; preds = %__barray_mask_return.exit868
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit800:                     ; preds = %__barray_mask_return.exit797
+__barray_mask_borrow.exit871:                     ; preds = %__barray_mask_return.exit868
   %49 = xor i64 %47, 512
   store i64 %49, i64* %11, align 4
   %50 = getelementptr inbounds i8, i8* %8, i64 72
@@ -180,14 +180,14 @@ __barray_mask_borrow.exit800:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %52, double 0x400921FB54442D18, double 0.000000e+00)
   %53 = load i64, i64* %11, align 4
   %54 = and i64 %53, 512
-  %.not.i801 = icmp eq i64 %54, 0
-  br i1 %.not.i801, label %panic.i802, label %__barray_mask_return.exit803
+  %.not.i872 = icmp eq i64 %54, 0
+  br i1 %.not.i872, label %panic.i873, label %__barray_mask_return.exit874
 
-panic.i802:                                       ; preds = %__barray_mask_borrow.exit800
+panic.i873:                                       ; preds = %__barray_mask_borrow.exit871
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit803:                     ; preds = %__barray_mask_borrow.exit800
+__barray_mask_return.exit874:                     ; preds = %__barray_mask_borrow.exit871
   %55 = xor i64 %53, 512
   store i64 %55, i64* %11, align 4
   store i64 %52, i64* %51, align 4
@@ -223,13 +223,13 @@ mask_block_err.i.i.i:                             ; preds = %mask_block_ok.i.i.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-69:                                               ; preds = %__barray_mask_return.exit803, %cond_exit_443.i
-  %"393_0.sroa.15.0.i889" = phi i64 [ 0, %__barray_mask_return.exit803 ], [ %70, %cond_exit_443.i ]
-  %70 = add nuw nsw i64 %"393_0.sroa.15.0.i889", 1
-  %71 = lshr i64 %"393_0.sroa.15.0.i889", 6
+69:                                               ; preds = %__barray_mask_return.exit874, %cond_exit_443.i
+  %"393_0.sroa.15.0.i963" = phi i64 [ 0, %__barray_mask_return.exit874 ], [ %70, %cond_exit_443.i ]
+  %70 = add nuw nsw i64 %"393_0.sroa.15.0.i963", 1
+  %71 = lshr i64 %"393_0.sroa.15.0.i963", 6
   %72 = getelementptr inbounds i64, i64* %11, i64 %71
   %73 = load i64, i64* %72, align 4
-  %74 = shl nuw nsw i64 1, %"393_0.sroa.15.0.i889"
+  %74 = shl nuw nsw i64 1, %"393_0.sroa.15.0.i963"
   %75 = and i64 %73, %74
   %.not.i99.i.i = icmp eq i64 %75, 0
   br i1 %.not.i99.i.i, label %__barray_check_bounds.exit.i, label %panic.i.i.i
@@ -241,7 +241,7 @@ panic.i.i.i:                                      ; preds = %69
 __barray_check_bounds.exit.i:                     ; preds = %69
   %76 = xor i64 %73, %74
   store i64 %76, i64* %72, align 4
-  %77 = getelementptr inbounds i64, i64* %9, i64 %"393_0.sroa.15.0.i889"
+  %77 = getelementptr inbounds i64, i64* %9, i64 %"393_0.sroa.15.0.i963"
   %78 = load i64, i64* %77, align 4
   %lazy_measure.i = tail call i64 @___lazy_measure(i64 %78)
   tail call void @___qfree(i64 %78)
@@ -259,10 +259,10 @@ cond_exit_443.i:                                  ; preds = %__barray_check_boun
   %"457_054.fca.1.insert.i" = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %lazy_measure.i, 1
   %82 = xor i64 %80, %74
   store i64 %82, i64* %79, align 4
-  %83 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %"393_0.sroa.15.0.i889"
+  %83 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %"393_0.sroa.15.0.i963"
   store { i1, i64, i1 } %"457_054.fca.1.insert.i", { i1, i64, i1 }* %83, align 4
-  %exitcond906.not = icmp eq i64 %70, 10
-  br i1 %exitcond906.not, label %mask_block_ok.i.i.i, label %69
+  %exitcond979.not = icmp eq i64 %70, 10
+  br i1 %exitcond979.not, label %mask_block_ok.i.i.i, label %69
 
 __barray_check_none_borrowed.exit:                ; preds = %"__hugr__.$measure_array$$n(10).367.exit"
   %84 = tail call i8* @heap_alloc(i64 240)
@@ -278,78 +278,78 @@ mask_block_err.i:                                 ; preds = %"__hugr__.$measure_
   unreachable
 
 89:                                               ; preds = %__barray_check_none_borrowed.exit, %__hugr__.const_fun_290.309.exit
-  %storemerge779894 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %107, %__hugr__.const_fun_290.309.exit ]
+  %storemerge850968 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %107, %__hugr__.const_fun_290.309.exit ]
   %90 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %105, %__hugr__.const_fun_290.309.exit ]
-  %91 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %storemerge779894
+  %91 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %storemerge850968
   %92 = load { i1, i64, i1 }, { i1, i64, i1 }* %91, align 4
   %.fca.0.extract118.i = extractvalue { i1, i64, i1 } %92, 0
   %.fca.1.extract119.i = extractvalue { i1, i64, i1 } %92, 1
-  br i1 %.fca.0.extract118.i, label %cond_485_case_1.i, label %cond_exit_485.i
+  br i1 %.fca.0.extract118.i, label %cond_525_case_1.i, label %cond_exit_525.i
 
-cond_485_case_1.i:                                ; preds = %89
+cond_525_case_1.i:                                ; preds = %89
   tail call void @___inc_future_refcount(i64 %.fca.1.extract119.i)
   %93 = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %.fca.1.extract119.i, 1
-  br label %cond_exit_485.i
+  br label %cond_exit_525.i
 
-cond_exit_485.i:                                  ; preds = %cond_485_case_1.i, %89
-  %.pn.i = phi { i1, i64, i1 } [ %93, %cond_485_case_1.i ], [ %92, %89 ]
+cond_exit_525.i:                                  ; preds = %cond_525_case_1.i, %89
+  %.pn.i = phi { i1, i64, i1 } [ %93, %cond_525_case_1.i ], [ %92, %89 ]
   %"04.sroa.6.0.i" = extractvalue { i1, i64, i1 } %.pn.i, 2
-  %exitcond907.not = icmp eq i64 %storemerge779894, 10
-  br i1 %exitcond907.not, label %cond_488_case_0.i, label %94
+  %exitcond980.not = icmp eq i64 %storemerge850968, 10
+  br i1 %exitcond980.not, label %cond_528_case_0.i, label %94
 
-94:                                               ; preds = %cond_exit_485.i
+94:                                               ; preds = %cond_exit_525.i
   %95 = lshr i64 %90, 6
   %96 = getelementptr inbounds i64, i64* %65, i64 %95
   %97 = load i64, i64* %96, align 4
   %98 = and i64 %90, 63
   %99 = shl nuw i64 1, %98
   %100 = and i64 %97, %99
-  %.not.i.i805 = icmp eq i64 %100, 0
-  br i1 %.not.i.i805, label %cond_488_case_1.i, label %panic.i.i806
+  %.not.i.i876 = icmp eq i64 %100, 0
+  br i1 %.not.i.i876, label %cond_528_case_1.i, label %panic.i.i877
 
-panic.i.i806:                                     ; preds = %94
+panic.i.i877:                                     ; preds = %94
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-cond_488_case_0.i:                                ; preds = %cond_exit_485.i
+cond_528_case_0.i:                                ; preds = %cond_exit_525.i
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.E6312129.0", i64 0, i64 0))
   unreachable
 
-cond_488_case_1.i:                                ; preds = %94
+cond_528_case_1.i:                                ; preds = %94
   %"17.fca.2.insert.i" = insertvalue { i1, i64, i1 } %92, i1 %"04.sroa.6.0.i", 2
   %101 = insertvalue { i1, { i1, i64, i1 } } { i1 true, { i1, i64, i1 } poison }, { i1, i64, i1 } %"17.fca.2.insert.i", 1
   %102 = getelementptr inbounds { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %88, i64 %90
   %103 = getelementptr inbounds { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %102, i64 0, i32 0
   %104 = load i1, i1* %103, align 1
   store { i1, { i1, i64, i1 } } %101, { i1, { i1, i64, i1 } }* %102, align 4
-  br i1 %104, label %cond_489_case_1.i, label %__hugr__.const_fun_290.309.exit
+  br i1 %104, label %cond_529_case_1.i, label %__hugr__.const_fun_290.309.exit
 
-cond_489_case_1.i:                                ; preds = %cond_488_case_1.i
+cond_529_case_1.i:                                ; preds = %cond_528_case_1.i
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.2F17E0A9.0", i64 0, i64 0))
   unreachable
 
-__hugr__.const_fun_290.309.exit:                  ; preds = %cond_488_case_1.i
+__hugr__.const_fun_290.309.exit:                  ; preds = %cond_528_case_1.i
   %105 = add nuw nsw i64 %90, 1
-  %106 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %85, i64 %storemerge779894
+  %106 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %85, i64 %storemerge850968
   store { i1, i64, i1 } %"17.fca.2.insert.i", { i1, i64, i1 }* %106, align 4
-  %107 = add nuw nsw i64 %storemerge779894, 1
-  %exitcond908.not = icmp eq i64 %107, 10
-  br i1 %exitcond908.not, label %mask_block_ok.i810, label %89
+  %107 = add nuw nsw i64 %storemerge850968, 1
+  %exitcond981.not = icmp eq i64 %107, 10
+  br i1 %exitcond981.not, label %mask_block_ok.i881, label %89
 
-mask_block_ok.i810:                               ; preds = %__hugr__.const_fun_290.309.exit
+mask_block_ok.i881:                               ; preds = %__hugr__.const_fun_290.309.exit
   tail call void @heap_free(i8* nonnull %56)
   tail call void @heap_free(i8* %58)
   %108 = load i64, i64* %65, align 4
   %109 = and i64 %108, 1023
   store i64 %109, i64* %65, align 4
   %110 = icmp eq i64 %109, 0
-  br i1 %110, label %__barray_check_none_borrowed.exit812, label %mask_block_err.i811
+  br i1 %110, label %__barray_check_none_borrowed.exit883, label %mask_block_err.i882
 
-mask_block_err.i811:                              ; preds = %mask_block_ok.i810
+mask_block_err.i882:                              ; preds = %mask_block_ok.i881
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit812:             ; preds = %mask_block_ok.i810
+__barray_check_none_borrowed.exit883:             ; preds = %mask_block_ok.i881
   %111 = tail call i8* @heap_alloc(i64 240)
   %112 = bitcast i8* %111 to { i1, i64, i1 }*
   %113 = tail call i8* @heap_alloc(i64 8)
@@ -357,20 +357,20 @@ __barray_check_none_borrowed.exit812:             ; preds = %mask_block_ok.i810
   store i64 0, i64* %114, align 1
   %115 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %88, align 4
   %.fca.0.extract11.i = extractvalue { i1, { i1, i64, i1 } } %115, 0
-  br i1 %.fca.0.extract11.i, label %__hugr__.const_fun_284.290.exit, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i, label %__hugr__.const_fun_284.290.exit, label %cond_570_case_0.i
 
-cond_530_case_0.i:                                ; preds = %__hugr__.const_fun_284.290.exit.8, %__hugr__.const_fun_284.290.exit.7, %__hugr__.const_fun_284.290.exit.6, %__hugr__.const_fun_284.290.exit.5, %__hugr__.const_fun_284.290.exit.4, %__hugr__.const_fun_284.290.exit.3, %__hugr__.const_fun_284.290.exit.2, %__hugr__.const_fun_284.290.exit.1, %__hugr__.const_fun_284.290.exit, %__barray_check_none_borrowed.exit812
+cond_570_case_0.i:                                ; preds = %__hugr__.const_fun_284.290.exit.8, %__hugr__.const_fun_284.290.exit.7, %__hugr__.const_fun_284.290.exit.6, %__hugr__.const_fun_284.290.exit.5, %__hugr__.const_fun_284.290.exit.4, %__hugr__.const_fun_284.290.exit.3, %__hugr__.const_fun_284.290.exit.2, %__hugr__.const_fun_284.290.exit.1, %__hugr__.const_fun_284.290.exit, %__barray_check_none_borrowed.exit883
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.E6312129.0", i64 0, i64 0))
   unreachable
 
-__hugr__.const_fun_284.290.exit:                  ; preds = %__barray_check_none_borrowed.exit812
+__hugr__.const_fun_284.290.exit:                  ; preds = %__barray_check_none_borrowed.exit883
   %116 = extractvalue { i1, { i1, i64, i1 } } %115, 1
   store { i1, i64, i1 } %116, { i1, i64, i1 }* %112, align 4
   %117 = getelementptr inbounds i8, i8* %63, i64 32
   %118 = bitcast i8* %117 to { i1, { i1, i64, i1 } }*
   %119 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %118, align 4
   %.fca.0.extract11.i.1 = extractvalue { i1, { i1, i64, i1 } } %119, 0
-  br i1 %.fca.0.extract11.i.1, label %__hugr__.const_fun_284.290.exit.1, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.1, label %__hugr__.const_fun_284.290.exit.1, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.1:                ; preds = %__hugr__.const_fun_284.290.exit
   %120 = extractvalue { i1, { i1, i64, i1 } } %119, 1
@@ -381,7 +381,7 @@ __hugr__.const_fun_284.290.exit.1:                ; preds = %__hugr__.const_fun_
   %124 = bitcast i8* %123 to { i1, { i1, i64, i1 } }*
   %125 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %124, align 4
   %.fca.0.extract11.i.2 = extractvalue { i1, { i1, i64, i1 } } %125, 0
-  br i1 %.fca.0.extract11.i.2, label %__hugr__.const_fun_284.290.exit.2, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.2, label %__hugr__.const_fun_284.290.exit.2, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.2:                ; preds = %__hugr__.const_fun_284.290.exit.1
   %126 = extractvalue { i1, { i1, i64, i1 } } %125, 1
@@ -392,7 +392,7 @@ __hugr__.const_fun_284.290.exit.2:                ; preds = %__hugr__.const_fun_
   %130 = bitcast i8* %129 to { i1, { i1, i64, i1 } }*
   %131 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %130, align 4
   %.fca.0.extract11.i.3 = extractvalue { i1, { i1, i64, i1 } } %131, 0
-  br i1 %.fca.0.extract11.i.3, label %__hugr__.const_fun_284.290.exit.3, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.3, label %__hugr__.const_fun_284.290.exit.3, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.3:                ; preds = %__hugr__.const_fun_284.290.exit.2
   %132 = extractvalue { i1, { i1, i64, i1 } } %131, 1
@@ -403,7 +403,7 @@ __hugr__.const_fun_284.290.exit.3:                ; preds = %__hugr__.const_fun_
   %136 = bitcast i8* %135 to { i1, { i1, i64, i1 } }*
   %137 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %136, align 4
   %.fca.0.extract11.i.4 = extractvalue { i1, { i1, i64, i1 } } %137, 0
-  br i1 %.fca.0.extract11.i.4, label %__hugr__.const_fun_284.290.exit.4, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.4, label %__hugr__.const_fun_284.290.exit.4, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.4:                ; preds = %__hugr__.const_fun_284.290.exit.3
   %138 = extractvalue { i1, { i1, i64, i1 } } %137, 1
@@ -414,7 +414,7 @@ __hugr__.const_fun_284.290.exit.4:                ; preds = %__hugr__.const_fun_
   %142 = bitcast i8* %141 to { i1, { i1, i64, i1 } }*
   %143 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %142, align 4
   %.fca.0.extract11.i.5 = extractvalue { i1, { i1, i64, i1 } } %143, 0
-  br i1 %.fca.0.extract11.i.5, label %__hugr__.const_fun_284.290.exit.5, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.5, label %__hugr__.const_fun_284.290.exit.5, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.5:                ; preds = %__hugr__.const_fun_284.290.exit.4
   %144 = extractvalue { i1, { i1, i64, i1 } } %143, 1
@@ -425,7 +425,7 @@ __hugr__.const_fun_284.290.exit.5:                ; preds = %__hugr__.const_fun_
   %148 = bitcast i8* %147 to { i1, { i1, i64, i1 } }*
   %149 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %148, align 4
   %.fca.0.extract11.i.6 = extractvalue { i1, { i1, i64, i1 } } %149, 0
-  br i1 %.fca.0.extract11.i.6, label %__hugr__.const_fun_284.290.exit.6, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.6, label %__hugr__.const_fun_284.290.exit.6, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.6:                ; preds = %__hugr__.const_fun_284.290.exit.5
   %150 = extractvalue { i1, { i1, i64, i1 } } %149, 1
@@ -436,7 +436,7 @@ __hugr__.const_fun_284.290.exit.6:                ; preds = %__hugr__.const_fun_
   %154 = bitcast i8* %153 to { i1, { i1, i64, i1 } }*
   %155 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %154, align 4
   %.fca.0.extract11.i.7 = extractvalue { i1, { i1, i64, i1 } } %155, 0
-  br i1 %.fca.0.extract11.i.7, label %__hugr__.const_fun_284.290.exit.7, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.7, label %__hugr__.const_fun_284.290.exit.7, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.7:                ; preds = %__hugr__.const_fun_284.290.exit.6
   %156 = extractvalue { i1, { i1, i64, i1 } } %155, 1
@@ -447,7 +447,7 @@ __hugr__.const_fun_284.290.exit.7:                ; preds = %__hugr__.const_fun_
   %160 = bitcast i8* %159 to { i1, { i1, i64, i1 } }*
   %161 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %160, align 4
   %.fca.0.extract11.i.8 = extractvalue { i1, { i1, i64, i1 } } %161, 0
-  br i1 %.fca.0.extract11.i.8, label %__hugr__.const_fun_284.290.exit.8, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.8, label %__hugr__.const_fun_284.290.exit.8, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.8:                ; preds = %__hugr__.const_fun_284.290.exit.7
   %162 = extractvalue { i1, { i1, i64, i1 } } %161, 1
@@ -458,7 +458,7 @@ __hugr__.const_fun_284.290.exit.8:                ; preds = %__hugr__.const_fun_
   %166 = bitcast i8* %165 to { i1, { i1, i64, i1 } }*
   %167 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %166, align 4
   %.fca.0.extract11.i.9 = extractvalue { i1, { i1, i64, i1 } } %167, 0
-  br i1 %.fca.0.extract11.i.9, label %__hugr__.const_fun_284.290.exit.9, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.9, label %__hugr__.const_fun_284.290.exit.9, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.9:                ; preds = %__hugr__.const_fun_284.290.exit.8
   %168 = extractvalue { i1, { i1, i64, i1 } } %167, 1
@@ -467,533 +467,459 @@ __hugr__.const_fun_284.290.exit.9:                ; preds = %__hugr__.const_fun_
   store { i1, i64, i1 } %168, { i1, i64, i1 }* %170, align 4
   tail call void @heap_free(i8* nonnull %63)
   tail call void @heap_free(i8* nonnull %64)
+  br label %__barray_check_bounds.exit888
+
+cond_165_case_0:                                  ; preds = %cond_exit_165
   %171 = load i64, i64* %114, align 4
-  %172 = and i64 %171, 1023
+  %172 = or i64 %171, -1024
   store i64 %172, i64* %114, align 4
-  %173 = icmp eq i64 %172, 0
-  br i1 %173, label %__barray_check_none_borrowed.exit817, label %mask_block_err.i816
+  %173 = icmp eq i64 %172, -1
+  br i1 %173, label %loop_out139, label %mask_block_err.i886
 
-__barray_check_none_borrowed.exit817:             ; preds = %__hugr__.const_fun_284.290.exit.9
-  %174 = tail call i8* @heap_alloc(i64 0)
-  %175 = tail call i8* @heap_alloc(i64 8)
-  %176 = bitcast i8* %175 to i64*
-  store i64 0, i64* %176, align 1
-  %177 = load { i1, i64, i1 }, { i1, i64, i1 }* %112, align 4
-  %.fca.0.extract.i818 = extractvalue { i1, i64, i1 } %177, 0
-  br i1 %.fca.0.extract.i818, label %cond_543_case_1.i, label %__hugr__.const_fun_175.284.exit
-
-mask_block_err.i816:                              ; preds = %__hugr__.const_fun_284.290.exit.9
-  tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
+mask_block_err.i886:                              ; preds = %cond_165_case_0
+  tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-cond_543_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit817
-  %.fca.1.extract.i819 = extractvalue { i1, i64, i1 } %177, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819)
-  br label %__hugr__.const_fun_175.284.exit
+__barray_check_bounds.exit888:                    ; preds = %__hugr__.const_fun_284.290.exit.9, %cond_exit_165
+  %"167_0.0990" = phi i64 [ 0, %__hugr__.const_fun_284.290.exit.9 ], [ %174, %cond_exit_165 ]
+  %174 = add nuw nsw i64 %"167_0.0990", 1
+  %175 = lshr i64 %"167_0.0990", 6
+  %176 = getelementptr inbounds i64, i64* %114, i64 %175
+  %177 = load i64, i64* %176, align 4
+  %178 = shl nuw nsw i64 1, %"167_0.0990"
+  %179 = and i64 %177, %178
+  %.not = icmp eq i64 %179, 0
+  br i1 %.not, label %__barray_mask_borrow.exit893, label %cond_exit_165
 
-__hugr__.const_fun_175.284.exit:                  ; preds = %__barray_check_none_borrowed.exit817, %cond_543_case_1.i
-  %178 = load { i1, i64, i1 }, { i1, i64, i1 }* %122, align 4
-  %.fca.0.extract.i818.1 = extractvalue { i1, i64, i1 } %178, 0
-  br i1 %.fca.0.extract.i818.1, label %cond_543_case_1.i.1, label %__hugr__.const_fun_175.284.exit.1
+__barray_mask_borrow.exit893:                     ; preds = %__barray_check_bounds.exit888
+  %180 = xor i64 %177, %178
+  store i64 %180, i64* %176, align 4
+  %181 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %112, i64 %"167_0.0990"
+  %182 = load { i1, i64, i1 }, { i1, i64, i1 }* %181, align 4
+  %.fca.0.extract511 = extractvalue { i1, i64, i1 } %182, 0
+  br i1 %.fca.0.extract511, label %cond_501_case_1, label %cond_exit_165
 
-cond_543_case_1.i.1:                              ; preds = %__hugr__.const_fun_175.284.exit
-  %.fca.1.extract.i819.1 = extractvalue { i1, i64, i1 } %178, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.1)
-  br label %__hugr__.const_fun_175.284.exit.1
+cond_exit_165:                                    ; preds = %cond_501_case_1, %__barray_mask_borrow.exit893, %__barray_check_bounds.exit888
+  %183 = icmp ult i64 %"167_0.0990", 9
+  br i1 %183, label %__barray_check_bounds.exit888, label %cond_165_case_0
 
-__hugr__.const_fun_175.284.exit.1:                ; preds = %cond_543_case_1.i.1, %__hugr__.const_fun_175.284.exit
-  %179 = load { i1, i64, i1 }, { i1, i64, i1 }* %128, align 4
-  %.fca.0.extract.i818.2 = extractvalue { i1, i64, i1 } %179, 0
-  br i1 %.fca.0.extract.i818.2, label %cond_543_case_1.i.2, label %__hugr__.const_fun_175.284.exit.2
-
-cond_543_case_1.i.2:                              ; preds = %__hugr__.const_fun_175.284.exit.1
-  %.fca.1.extract.i819.2 = extractvalue { i1, i64, i1 } %179, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.2)
-  br label %__hugr__.const_fun_175.284.exit.2
-
-__hugr__.const_fun_175.284.exit.2:                ; preds = %cond_543_case_1.i.2, %__hugr__.const_fun_175.284.exit.1
-  %180 = load { i1, i64, i1 }, { i1, i64, i1 }* %134, align 4
-  %.fca.0.extract.i818.3 = extractvalue { i1, i64, i1 } %180, 0
-  br i1 %.fca.0.extract.i818.3, label %cond_543_case_1.i.3, label %__hugr__.const_fun_175.284.exit.3
-
-cond_543_case_1.i.3:                              ; preds = %__hugr__.const_fun_175.284.exit.2
-  %.fca.1.extract.i819.3 = extractvalue { i1, i64, i1 } %180, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.3)
-  br label %__hugr__.const_fun_175.284.exit.3
-
-__hugr__.const_fun_175.284.exit.3:                ; preds = %cond_543_case_1.i.3, %__hugr__.const_fun_175.284.exit.2
-  %181 = load { i1, i64, i1 }, { i1, i64, i1 }* %140, align 4
-  %.fca.0.extract.i818.4 = extractvalue { i1, i64, i1 } %181, 0
-  br i1 %.fca.0.extract.i818.4, label %cond_543_case_1.i.4, label %__hugr__.const_fun_175.284.exit.4
-
-cond_543_case_1.i.4:                              ; preds = %__hugr__.const_fun_175.284.exit.3
-  %.fca.1.extract.i819.4 = extractvalue { i1, i64, i1 } %181, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.4)
-  br label %__hugr__.const_fun_175.284.exit.4
-
-__hugr__.const_fun_175.284.exit.4:                ; preds = %cond_543_case_1.i.4, %__hugr__.const_fun_175.284.exit.3
-  %182 = load { i1, i64, i1 }, { i1, i64, i1 }* %146, align 4
-  %.fca.0.extract.i818.5 = extractvalue { i1, i64, i1 } %182, 0
-  br i1 %.fca.0.extract.i818.5, label %cond_543_case_1.i.5, label %__hugr__.const_fun_175.284.exit.5
-
-cond_543_case_1.i.5:                              ; preds = %__hugr__.const_fun_175.284.exit.4
-  %.fca.1.extract.i819.5 = extractvalue { i1, i64, i1 } %182, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.5)
-  br label %__hugr__.const_fun_175.284.exit.5
-
-__hugr__.const_fun_175.284.exit.5:                ; preds = %cond_543_case_1.i.5, %__hugr__.const_fun_175.284.exit.4
-  %183 = load { i1, i64, i1 }, { i1, i64, i1 }* %152, align 4
-  %.fca.0.extract.i818.6 = extractvalue { i1, i64, i1 } %183, 0
-  br i1 %.fca.0.extract.i818.6, label %cond_543_case_1.i.6, label %__hugr__.const_fun_175.284.exit.6
-
-cond_543_case_1.i.6:                              ; preds = %__hugr__.const_fun_175.284.exit.5
-  %.fca.1.extract.i819.6 = extractvalue { i1, i64, i1 } %183, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.6)
-  br label %__hugr__.const_fun_175.284.exit.6
-
-__hugr__.const_fun_175.284.exit.6:                ; preds = %cond_543_case_1.i.6, %__hugr__.const_fun_175.284.exit.5
-  %184 = load { i1, i64, i1 }, { i1, i64, i1 }* %158, align 4
-  %.fca.0.extract.i818.7 = extractvalue { i1, i64, i1 } %184, 0
-  br i1 %.fca.0.extract.i818.7, label %cond_543_case_1.i.7, label %__hugr__.const_fun_175.284.exit.7
-
-cond_543_case_1.i.7:                              ; preds = %__hugr__.const_fun_175.284.exit.6
-  %.fca.1.extract.i819.7 = extractvalue { i1, i64, i1 } %184, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.7)
-  br label %__hugr__.const_fun_175.284.exit.7
-
-__hugr__.const_fun_175.284.exit.7:                ; preds = %cond_543_case_1.i.7, %__hugr__.const_fun_175.284.exit.6
-  %185 = load { i1, i64, i1 }, { i1, i64, i1 }* %164, align 4
-  %.fca.0.extract.i818.8 = extractvalue { i1, i64, i1 } %185, 0
-  br i1 %.fca.0.extract.i818.8, label %cond_543_case_1.i.8, label %__hugr__.const_fun_175.284.exit.8
-
-cond_543_case_1.i.8:                              ; preds = %__hugr__.const_fun_175.284.exit.7
-  %.fca.1.extract.i819.8 = extractvalue { i1, i64, i1 } %185, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.8)
-  br label %__hugr__.const_fun_175.284.exit.8
-
-__hugr__.const_fun_175.284.exit.8:                ; preds = %cond_543_case_1.i.8, %__hugr__.const_fun_175.284.exit.7
-  %186 = load { i1, i64, i1 }, { i1, i64, i1 }* %170, align 4
-  %.fca.0.extract.i818.9 = extractvalue { i1, i64, i1 } %186, 0
-  br i1 %.fca.0.extract.i818.9, label %cond_543_case_1.i.9, label %__hugr__.const_fun_175.284.exit.9
-
-cond_543_case_1.i.9:                              ; preds = %__hugr__.const_fun_175.284.exit.8
-  %.fca.1.extract.i819.9 = extractvalue { i1, i64, i1 } %186, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.9)
-  br label %__hugr__.const_fun_175.284.exit.9
-
-__hugr__.const_fun_175.284.exit.9:                ; preds = %cond_543_case_1.i.9, %__hugr__.const_fun_175.284.exit.8
-  tail call void @heap_free(i8* nonnull %111)
+loop_out139:                                      ; preds = %cond_165_case_0
+  tail call void @heap_free(i8* %111)
   tail call void @heap_free(i8* nonnull %113)
-  tail call void @heap_free(i8* %174)
-  %187 = load i64, i64* %87, align 4
-  %188 = and i64 %187, 1023
-  store i64 %188, i64* %87, align 4
-  %189 = icmp eq i64 %188, 0
-  br i1 %189, label %__barray_check_none_borrowed.exit824, label %mask_block_err.i823
+  %184 = load i64, i64* %87, align 4
+  %185 = and i64 %184, 1023
+  store i64 %185, i64* %87, align 4
+  %186 = icmp eq i64 %185, 0
+  br i1 %186, label %__barray_check_none_borrowed.exit898, label %mask_block_err.i897
 
-__barray_check_none_borrowed.exit824:             ; preds = %__hugr__.const_fun_175.284.exit.9
-  %190 = tail call i8* @heap_alloc(i64 10)
-  %191 = tail call i8* @heap_alloc(i64 8)
-  %192 = bitcast i8* %191 to i64*
-  store i64 0, i64* %192, align 1
-  %193 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
-  %.fca.0.extract.i825 = extractvalue { i1, i64, i1 } %193, 0
-  %.fca.1.extract.i826 = extractvalue { i1, i64, i1 } %193, 1
-  br i1 %.fca.0.extract.i825, label %cond_300_case_1.i, label %cond_300_case_0.i
+__barray_check_none_borrowed.exit898:             ; preds = %loop_out139
+  %187 = tail call i8* @heap_alloc(i64 10)
+  %188 = tail call i8* @heap_alloc(i64 8)
+  %189 = bitcast i8* %188 to i64*
+  store i64 0, i64* %189, align 1
+  %190 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
+  %.fca.0.extract.i899 = extractvalue { i1, i64, i1 } %190, 0
+  %.fca.1.extract.i900 = extractvalue { i1, i64, i1 } %190, 1
+  br i1 %.fca.0.extract.i899, label %cond_300_case_1.i, label %cond_300_case_0.i
 
-mask_block_err.i823:                              ; preds = %__hugr__.const_fun_175.284.exit.9
+mask_block_err.i897:                              ; preds = %loop_out139
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-cond_300_case_0.i:                                ; preds = %__barray_check_none_borrowed.exit824
-  %.fca.2.extract.i = extractvalue { i1, i64, i1 } %193, 2
+cond_501_case_1:                                  ; preds = %__barray_mask_borrow.exit893
+  %.fca.1.extract512 = extractvalue { i1, i64, i1 } %182, 1
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract512)
+  br label %cond_exit_165
+
+cond_300_case_0.i:                                ; preds = %__barray_check_none_borrowed.exit898
+  %.fca.2.extract.i = extractvalue { i1, i64, i1 } %190, 2
   br label %__hugr__.array.__read_bool.3.271.exit
 
-cond_300_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit824
-  %read_bool.i = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826)
+cond_300_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit898
+  %read_bool.i = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900)
   br label %__hugr__.array.__read_bool.3.271.exit
 
 __hugr__.array.__read_bool.3.271.exit:            ; preds = %cond_300_case_0.i, %cond_300_case_1.i
   %"03.0.i" = phi i1 [ %read_bool.i, %cond_300_case_1.i ], [ %.fca.2.extract.i, %cond_300_case_0.i ]
-  %194 = bitcast i8* %190 to i1*
-  store i1 %"03.0.i", i1* %194, align 1
-  %195 = getelementptr inbounds i8, i8* %84, i64 24
-  %196 = bitcast i8* %195 to { i1, i64, i1 }*
-  %197 = load { i1, i64, i1 }, { i1, i64, i1 }* %196, align 4
-  %.fca.0.extract.i825.1 = extractvalue { i1, i64, i1 } %197, 0
-  %.fca.1.extract.i826.1 = extractvalue { i1, i64, i1 } %197, 1
-  br i1 %.fca.0.extract.i825.1, label %cond_300_case_1.i.1, label %cond_300_case_0.i.1
+  %191 = bitcast i8* %187 to i1*
+  store i1 %"03.0.i", i1* %191, align 1
+  %192 = getelementptr inbounds i8, i8* %84, i64 24
+  %193 = bitcast i8* %192 to { i1, i64, i1 }*
+  %194 = load { i1, i64, i1 }, { i1, i64, i1 }* %193, align 4
+  %.fca.0.extract.i899.1 = extractvalue { i1, i64, i1 } %194, 0
+  %.fca.1.extract.i900.1 = extractvalue { i1, i64, i1 } %194, 1
+  br i1 %.fca.0.extract.i899.1, label %cond_300_case_1.i.1, label %cond_300_case_0.i.1
 
 cond_300_case_0.i.1:                              ; preds = %__hugr__.array.__read_bool.3.271.exit
-  %.fca.2.extract.i.1 = extractvalue { i1, i64, i1 } %197, 2
+  %.fca.2.extract.i.1 = extractvalue { i1, i64, i1 } %194, 2
   br label %__hugr__.array.__read_bool.3.271.exit.1
 
 cond_300_case_1.i.1:                              ; preds = %__hugr__.array.__read_bool.3.271.exit
-  %read_bool.i.1 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.1)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.1)
+  %read_bool.i.1 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.1)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.1)
   br label %__hugr__.array.__read_bool.3.271.exit.1
 
 __hugr__.array.__read_bool.3.271.exit.1:          ; preds = %cond_300_case_1.i.1, %cond_300_case_0.i.1
   %"03.0.i.1" = phi i1 [ %read_bool.i.1, %cond_300_case_1.i.1 ], [ %.fca.2.extract.i.1, %cond_300_case_0.i.1 ]
-  %198 = getelementptr inbounds i8, i8* %190, i64 1
-  %199 = bitcast i8* %198 to i1*
-  store i1 %"03.0.i.1", i1* %199, align 1
-  %200 = getelementptr inbounds i8, i8* %84, i64 48
-  %201 = bitcast i8* %200 to { i1, i64, i1 }*
-  %202 = load { i1, i64, i1 }, { i1, i64, i1 }* %201, align 4
-  %.fca.0.extract.i825.2 = extractvalue { i1, i64, i1 } %202, 0
-  %.fca.1.extract.i826.2 = extractvalue { i1, i64, i1 } %202, 1
-  br i1 %.fca.0.extract.i825.2, label %cond_300_case_1.i.2, label %cond_300_case_0.i.2
+  %195 = getelementptr inbounds i8, i8* %187, i64 1
+  %196 = bitcast i8* %195 to i1*
+  store i1 %"03.0.i.1", i1* %196, align 1
+  %197 = getelementptr inbounds i8, i8* %84, i64 48
+  %198 = bitcast i8* %197 to { i1, i64, i1 }*
+  %199 = load { i1, i64, i1 }, { i1, i64, i1 }* %198, align 4
+  %.fca.0.extract.i899.2 = extractvalue { i1, i64, i1 } %199, 0
+  %.fca.1.extract.i900.2 = extractvalue { i1, i64, i1 } %199, 1
+  br i1 %.fca.0.extract.i899.2, label %cond_300_case_1.i.2, label %cond_300_case_0.i.2
 
 cond_300_case_0.i.2:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.1
-  %.fca.2.extract.i.2 = extractvalue { i1, i64, i1 } %202, 2
+  %.fca.2.extract.i.2 = extractvalue { i1, i64, i1 } %199, 2
   br label %__hugr__.array.__read_bool.3.271.exit.2
 
 cond_300_case_1.i.2:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.1
-  %read_bool.i.2 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.2)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.2)
+  %read_bool.i.2 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.2)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.2)
   br label %__hugr__.array.__read_bool.3.271.exit.2
 
 __hugr__.array.__read_bool.3.271.exit.2:          ; preds = %cond_300_case_1.i.2, %cond_300_case_0.i.2
   %"03.0.i.2" = phi i1 [ %read_bool.i.2, %cond_300_case_1.i.2 ], [ %.fca.2.extract.i.2, %cond_300_case_0.i.2 ]
-  %203 = getelementptr inbounds i8, i8* %190, i64 2
-  %204 = bitcast i8* %203 to i1*
-  store i1 %"03.0.i.2", i1* %204, align 1
-  %205 = getelementptr inbounds i8, i8* %84, i64 72
-  %206 = bitcast i8* %205 to { i1, i64, i1 }*
-  %207 = load { i1, i64, i1 }, { i1, i64, i1 }* %206, align 4
-  %.fca.0.extract.i825.3 = extractvalue { i1, i64, i1 } %207, 0
-  %.fca.1.extract.i826.3 = extractvalue { i1, i64, i1 } %207, 1
-  br i1 %.fca.0.extract.i825.3, label %cond_300_case_1.i.3, label %cond_300_case_0.i.3
+  %200 = getelementptr inbounds i8, i8* %187, i64 2
+  %201 = bitcast i8* %200 to i1*
+  store i1 %"03.0.i.2", i1* %201, align 1
+  %202 = getelementptr inbounds i8, i8* %84, i64 72
+  %203 = bitcast i8* %202 to { i1, i64, i1 }*
+  %204 = load { i1, i64, i1 }, { i1, i64, i1 }* %203, align 4
+  %.fca.0.extract.i899.3 = extractvalue { i1, i64, i1 } %204, 0
+  %.fca.1.extract.i900.3 = extractvalue { i1, i64, i1 } %204, 1
+  br i1 %.fca.0.extract.i899.3, label %cond_300_case_1.i.3, label %cond_300_case_0.i.3
 
 cond_300_case_0.i.3:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.2
-  %.fca.2.extract.i.3 = extractvalue { i1, i64, i1 } %207, 2
+  %.fca.2.extract.i.3 = extractvalue { i1, i64, i1 } %204, 2
   br label %__hugr__.array.__read_bool.3.271.exit.3
 
 cond_300_case_1.i.3:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.2
-  %read_bool.i.3 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.3)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.3)
+  %read_bool.i.3 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.3)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.3)
   br label %__hugr__.array.__read_bool.3.271.exit.3
 
 __hugr__.array.__read_bool.3.271.exit.3:          ; preds = %cond_300_case_1.i.3, %cond_300_case_0.i.3
   %"03.0.i.3" = phi i1 [ %read_bool.i.3, %cond_300_case_1.i.3 ], [ %.fca.2.extract.i.3, %cond_300_case_0.i.3 ]
-  %208 = getelementptr inbounds i8, i8* %190, i64 3
-  %209 = bitcast i8* %208 to i1*
-  store i1 %"03.0.i.3", i1* %209, align 1
-  %210 = getelementptr inbounds i8, i8* %84, i64 96
-  %211 = bitcast i8* %210 to { i1, i64, i1 }*
-  %212 = load { i1, i64, i1 }, { i1, i64, i1 }* %211, align 4
-  %.fca.0.extract.i825.4 = extractvalue { i1, i64, i1 } %212, 0
-  %.fca.1.extract.i826.4 = extractvalue { i1, i64, i1 } %212, 1
-  br i1 %.fca.0.extract.i825.4, label %cond_300_case_1.i.4, label %cond_300_case_0.i.4
+  %205 = getelementptr inbounds i8, i8* %187, i64 3
+  %206 = bitcast i8* %205 to i1*
+  store i1 %"03.0.i.3", i1* %206, align 1
+  %207 = getelementptr inbounds i8, i8* %84, i64 96
+  %208 = bitcast i8* %207 to { i1, i64, i1 }*
+  %209 = load { i1, i64, i1 }, { i1, i64, i1 }* %208, align 4
+  %.fca.0.extract.i899.4 = extractvalue { i1, i64, i1 } %209, 0
+  %.fca.1.extract.i900.4 = extractvalue { i1, i64, i1 } %209, 1
+  br i1 %.fca.0.extract.i899.4, label %cond_300_case_1.i.4, label %cond_300_case_0.i.4
 
 cond_300_case_0.i.4:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.3
-  %.fca.2.extract.i.4 = extractvalue { i1, i64, i1 } %212, 2
+  %.fca.2.extract.i.4 = extractvalue { i1, i64, i1 } %209, 2
   br label %__hugr__.array.__read_bool.3.271.exit.4
 
 cond_300_case_1.i.4:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.3
-  %read_bool.i.4 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.4)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.4)
+  %read_bool.i.4 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.4)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.4)
   br label %__hugr__.array.__read_bool.3.271.exit.4
 
 __hugr__.array.__read_bool.3.271.exit.4:          ; preds = %cond_300_case_1.i.4, %cond_300_case_0.i.4
   %"03.0.i.4" = phi i1 [ %read_bool.i.4, %cond_300_case_1.i.4 ], [ %.fca.2.extract.i.4, %cond_300_case_0.i.4 ]
-  %213 = getelementptr inbounds i8, i8* %190, i64 4
-  %214 = bitcast i8* %213 to i1*
-  store i1 %"03.0.i.4", i1* %214, align 1
-  %215 = getelementptr inbounds i8, i8* %84, i64 120
-  %216 = bitcast i8* %215 to { i1, i64, i1 }*
-  %217 = load { i1, i64, i1 }, { i1, i64, i1 }* %216, align 4
-  %.fca.0.extract.i825.5 = extractvalue { i1, i64, i1 } %217, 0
-  %.fca.1.extract.i826.5 = extractvalue { i1, i64, i1 } %217, 1
-  br i1 %.fca.0.extract.i825.5, label %cond_300_case_1.i.5, label %cond_300_case_0.i.5
+  %210 = getelementptr inbounds i8, i8* %187, i64 4
+  %211 = bitcast i8* %210 to i1*
+  store i1 %"03.0.i.4", i1* %211, align 1
+  %212 = getelementptr inbounds i8, i8* %84, i64 120
+  %213 = bitcast i8* %212 to { i1, i64, i1 }*
+  %214 = load { i1, i64, i1 }, { i1, i64, i1 }* %213, align 4
+  %.fca.0.extract.i899.5 = extractvalue { i1, i64, i1 } %214, 0
+  %.fca.1.extract.i900.5 = extractvalue { i1, i64, i1 } %214, 1
+  br i1 %.fca.0.extract.i899.5, label %cond_300_case_1.i.5, label %cond_300_case_0.i.5
 
 cond_300_case_0.i.5:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.4
-  %.fca.2.extract.i.5 = extractvalue { i1, i64, i1 } %217, 2
+  %.fca.2.extract.i.5 = extractvalue { i1, i64, i1 } %214, 2
   br label %__hugr__.array.__read_bool.3.271.exit.5
 
 cond_300_case_1.i.5:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.4
-  %read_bool.i.5 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.5)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.5)
+  %read_bool.i.5 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.5)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.5)
   br label %__hugr__.array.__read_bool.3.271.exit.5
 
 __hugr__.array.__read_bool.3.271.exit.5:          ; preds = %cond_300_case_1.i.5, %cond_300_case_0.i.5
   %"03.0.i.5" = phi i1 [ %read_bool.i.5, %cond_300_case_1.i.5 ], [ %.fca.2.extract.i.5, %cond_300_case_0.i.5 ]
-  %218 = getelementptr inbounds i8, i8* %190, i64 5
-  %219 = bitcast i8* %218 to i1*
-  store i1 %"03.0.i.5", i1* %219, align 1
-  %220 = getelementptr inbounds i8, i8* %84, i64 144
-  %221 = bitcast i8* %220 to { i1, i64, i1 }*
-  %222 = load { i1, i64, i1 }, { i1, i64, i1 }* %221, align 4
-  %.fca.0.extract.i825.6 = extractvalue { i1, i64, i1 } %222, 0
-  %.fca.1.extract.i826.6 = extractvalue { i1, i64, i1 } %222, 1
-  br i1 %.fca.0.extract.i825.6, label %cond_300_case_1.i.6, label %cond_300_case_0.i.6
+  %215 = getelementptr inbounds i8, i8* %187, i64 5
+  %216 = bitcast i8* %215 to i1*
+  store i1 %"03.0.i.5", i1* %216, align 1
+  %217 = getelementptr inbounds i8, i8* %84, i64 144
+  %218 = bitcast i8* %217 to { i1, i64, i1 }*
+  %219 = load { i1, i64, i1 }, { i1, i64, i1 }* %218, align 4
+  %.fca.0.extract.i899.6 = extractvalue { i1, i64, i1 } %219, 0
+  %.fca.1.extract.i900.6 = extractvalue { i1, i64, i1 } %219, 1
+  br i1 %.fca.0.extract.i899.6, label %cond_300_case_1.i.6, label %cond_300_case_0.i.6
 
 cond_300_case_0.i.6:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.5
-  %.fca.2.extract.i.6 = extractvalue { i1, i64, i1 } %222, 2
+  %.fca.2.extract.i.6 = extractvalue { i1, i64, i1 } %219, 2
   br label %__hugr__.array.__read_bool.3.271.exit.6
 
 cond_300_case_1.i.6:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.5
-  %read_bool.i.6 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.6)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.6)
+  %read_bool.i.6 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.6)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.6)
   br label %__hugr__.array.__read_bool.3.271.exit.6
 
 __hugr__.array.__read_bool.3.271.exit.6:          ; preds = %cond_300_case_1.i.6, %cond_300_case_0.i.6
   %"03.0.i.6" = phi i1 [ %read_bool.i.6, %cond_300_case_1.i.6 ], [ %.fca.2.extract.i.6, %cond_300_case_0.i.6 ]
-  %223 = getelementptr inbounds i8, i8* %190, i64 6
-  %224 = bitcast i8* %223 to i1*
-  store i1 %"03.0.i.6", i1* %224, align 1
-  %225 = getelementptr inbounds i8, i8* %84, i64 168
-  %226 = bitcast i8* %225 to { i1, i64, i1 }*
-  %227 = load { i1, i64, i1 }, { i1, i64, i1 }* %226, align 4
-  %.fca.0.extract.i825.7 = extractvalue { i1, i64, i1 } %227, 0
-  %.fca.1.extract.i826.7 = extractvalue { i1, i64, i1 } %227, 1
-  br i1 %.fca.0.extract.i825.7, label %cond_300_case_1.i.7, label %cond_300_case_0.i.7
+  %220 = getelementptr inbounds i8, i8* %187, i64 6
+  %221 = bitcast i8* %220 to i1*
+  store i1 %"03.0.i.6", i1* %221, align 1
+  %222 = getelementptr inbounds i8, i8* %84, i64 168
+  %223 = bitcast i8* %222 to { i1, i64, i1 }*
+  %224 = load { i1, i64, i1 }, { i1, i64, i1 }* %223, align 4
+  %.fca.0.extract.i899.7 = extractvalue { i1, i64, i1 } %224, 0
+  %.fca.1.extract.i900.7 = extractvalue { i1, i64, i1 } %224, 1
+  br i1 %.fca.0.extract.i899.7, label %cond_300_case_1.i.7, label %cond_300_case_0.i.7
 
 cond_300_case_0.i.7:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.6
-  %.fca.2.extract.i.7 = extractvalue { i1, i64, i1 } %227, 2
+  %.fca.2.extract.i.7 = extractvalue { i1, i64, i1 } %224, 2
   br label %__hugr__.array.__read_bool.3.271.exit.7
 
 cond_300_case_1.i.7:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.6
-  %read_bool.i.7 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.7)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.7)
+  %read_bool.i.7 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.7)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.7)
   br label %__hugr__.array.__read_bool.3.271.exit.7
 
 __hugr__.array.__read_bool.3.271.exit.7:          ; preds = %cond_300_case_1.i.7, %cond_300_case_0.i.7
   %"03.0.i.7" = phi i1 [ %read_bool.i.7, %cond_300_case_1.i.7 ], [ %.fca.2.extract.i.7, %cond_300_case_0.i.7 ]
-  %228 = getelementptr inbounds i8, i8* %190, i64 7
-  %229 = bitcast i8* %228 to i1*
-  store i1 %"03.0.i.7", i1* %229, align 1
-  %230 = getelementptr inbounds i8, i8* %84, i64 192
-  %231 = bitcast i8* %230 to { i1, i64, i1 }*
-  %232 = load { i1, i64, i1 }, { i1, i64, i1 }* %231, align 4
-  %.fca.0.extract.i825.8 = extractvalue { i1, i64, i1 } %232, 0
-  %.fca.1.extract.i826.8 = extractvalue { i1, i64, i1 } %232, 1
-  br i1 %.fca.0.extract.i825.8, label %cond_300_case_1.i.8, label %cond_300_case_0.i.8
+  %225 = getelementptr inbounds i8, i8* %187, i64 7
+  %226 = bitcast i8* %225 to i1*
+  store i1 %"03.0.i.7", i1* %226, align 1
+  %227 = getelementptr inbounds i8, i8* %84, i64 192
+  %228 = bitcast i8* %227 to { i1, i64, i1 }*
+  %229 = load { i1, i64, i1 }, { i1, i64, i1 }* %228, align 4
+  %.fca.0.extract.i899.8 = extractvalue { i1, i64, i1 } %229, 0
+  %.fca.1.extract.i900.8 = extractvalue { i1, i64, i1 } %229, 1
+  br i1 %.fca.0.extract.i899.8, label %cond_300_case_1.i.8, label %cond_300_case_0.i.8
 
 cond_300_case_0.i.8:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.7
-  %.fca.2.extract.i.8 = extractvalue { i1, i64, i1 } %232, 2
+  %.fca.2.extract.i.8 = extractvalue { i1, i64, i1 } %229, 2
   br label %__hugr__.array.__read_bool.3.271.exit.8
 
 cond_300_case_1.i.8:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.7
-  %read_bool.i.8 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.8)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.8)
+  %read_bool.i.8 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.8)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.8)
   br label %__hugr__.array.__read_bool.3.271.exit.8
 
 __hugr__.array.__read_bool.3.271.exit.8:          ; preds = %cond_300_case_1.i.8, %cond_300_case_0.i.8
   %"03.0.i.8" = phi i1 [ %read_bool.i.8, %cond_300_case_1.i.8 ], [ %.fca.2.extract.i.8, %cond_300_case_0.i.8 ]
-  %233 = getelementptr inbounds i8, i8* %190, i64 8
-  %234 = bitcast i8* %233 to i1*
-  store i1 %"03.0.i.8", i1* %234, align 1
-  %235 = getelementptr inbounds i8, i8* %84, i64 216
-  %236 = bitcast i8* %235 to { i1, i64, i1 }*
-  %237 = load { i1, i64, i1 }, { i1, i64, i1 }* %236, align 4
-  %.fca.0.extract.i825.9 = extractvalue { i1, i64, i1 } %237, 0
-  %.fca.1.extract.i826.9 = extractvalue { i1, i64, i1 } %237, 1
-  br i1 %.fca.0.extract.i825.9, label %cond_300_case_1.i.9, label %cond_300_case_0.i.9
+  %230 = getelementptr inbounds i8, i8* %187, i64 8
+  %231 = bitcast i8* %230 to i1*
+  store i1 %"03.0.i.8", i1* %231, align 1
+  %232 = getelementptr inbounds i8, i8* %84, i64 216
+  %233 = bitcast i8* %232 to { i1, i64, i1 }*
+  %234 = load { i1, i64, i1 }, { i1, i64, i1 }* %233, align 4
+  %.fca.0.extract.i899.9 = extractvalue { i1, i64, i1 } %234, 0
+  %.fca.1.extract.i900.9 = extractvalue { i1, i64, i1 } %234, 1
+  br i1 %.fca.0.extract.i899.9, label %cond_300_case_1.i.9, label %cond_300_case_0.i.9
 
 cond_300_case_0.i.9:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.8
-  %.fca.2.extract.i.9 = extractvalue { i1, i64, i1 } %237, 2
+  %.fca.2.extract.i.9 = extractvalue { i1, i64, i1 } %234, 2
   br label %__hugr__.array.__read_bool.3.271.exit.9
 
 cond_300_case_1.i.9:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.8
-  %read_bool.i.9 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.9)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.9)
+  %read_bool.i.9 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.9)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.9)
   br label %__hugr__.array.__read_bool.3.271.exit.9
 
 __hugr__.array.__read_bool.3.271.exit.9:          ; preds = %cond_300_case_1.i.9, %cond_300_case_0.i.9
   %"03.0.i.9" = phi i1 [ %read_bool.i.9, %cond_300_case_1.i.9 ], [ %.fca.2.extract.i.9, %cond_300_case_0.i.9 ]
-  %238 = getelementptr inbounds i8, i8* %190, i64 9
-  %239 = bitcast i8* %238 to i1*
-  store i1 %"03.0.i.9", i1* %239, align 1
+  %235 = getelementptr inbounds i8, i8* %187, i64 9
+  %236 = bitcast i8* %235 to i1*
+  store i1 %"03.0.i.9", i1* %236, align 1
   tail call void @heap_free(i8* nonnull %84)
   tail call void @heap_free(i8* nonnull %86)
-  %240 = load i64, i64* %192, align 4
-  %241 = and i64 %240, 1023
-  store i64 %241, i64* %192, align 4
-  %242 = icmp eq i64 %241, 0
-  br i1 %242, label %__barray_check_none_borrowed.exit831, label %mask_block_err.i830
+  %237 = load i64, i64* %189, align 4
+  %238 = and i64 %237, 1023
+  store i64 %238, i64* %189, align 4
+  %239 = icmp eq i64 %238, 0
+  br i1 %239, label %__barray_check_none_borrowed.exit905, label %mask_block_err.i904
 
-__barray_check_none_borrowed.exit831:             ; preds = %__hugr__.array.__read_bool.3.271.exit.9
+__barray_check_none_borrowed.exit905:             ; preds = %__hugr__.array.__read_bool.3.271.exit.9
   %out_arr_alloca = alloca <{ i32, i32, i1*, i1* }>, align 8
   %x_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 0
   %y_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 1
   %arr_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 2
   %mask_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 3
-  %243 = alloca [10 x i1], align 1
-  %.sub = getelementptr inbounds [10 x i1], [10 x i1]* %243, i64 0, i64 0
-  %244 = bitcast [10 x i1]* %243 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(10) %244, i8 0, i64 10, i1 false)
+  %240 = alloca [10 x i1], align 1
+  %.sub = getelementptr inbounds [10 x i1], [10 x i1]* %240, i64 0, i64 0
+  %241 = bitcast [10 x i1]* %240 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(10) %241, i8 0, i64 10, i1 false)
   store i32 10, i32* %x_ptr, align 8
   store i32 1, i32* %y_ptr, align 4
-  %245 = bitcast i1** %arr_ptr to i8**
-  store i8* %190, i8** %245, align 8
+  %242 = bitcast i1** %arr_ptr to i8**
+  store i8* %187, i8** %242, align 8
   store i1* %.sub, i1** %mask_ptr, align 8
   call void @print_bool_arr(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @res_cs.46C3C4B5.0, i64 0, i64 0), i64 15, <{ i32, i32, i1*, i1* }>* nonnull %out_arr_alloca)
-  br label %__barray_check_bounds.exit839
+  br label %__barray_check_bounds.exit913
 
-mask_block_err.i830:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.9
+mask_block_err.i904:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.9
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit839:                    ; preds = %cond_exit_95, %__barray_check_none_borrowed.exit831
-  %"90_0.sroa.0.0899" = phi i64 [ 0, %__barray_check_none_borrowed.exit831 ], [ %246, %cond_exit_95 ]
-  %246 = add nuw nsw i64 %"90_0.sroa.0.0899", 1
-  %247 = lshr i64 %"90_0.sroa.0.0899", 6
-  %248 = getelementptr inbounds i64, i64* %7, i64 %247
-  %249 = load i64, i64* %248, align 4
-  %250 = and i64 %"90_0.sroa.0.0899", 63
-  %251 = shl nuw i64 1, %250
-  %252 = and i64 %249, %251
-  %.not.i840 = icmp eq i64 %252, 0
-  br i1 %.not.i840, label %panic.i841, label %cond_exit_95
+__barray_check_bounds.exit913:                    ; preds = %cond_exit_95, %__barray_check_none_borrowed.exit905
+  %"90_0.sroa.0.0972" = phi i64 [ 0, %__barray_check_none_borrowed.exit905 ], [ %243, %cond_exit_95 ]
+  %243 = add nuw nsw i64 %"90_0.sroa.0.0972", 1
+  %244 = lshr i64 %"90_0.sroa.0.0972", 6
+  %245 = getelementptr inbounds i64, i64* %7, i64 %244
+  %246 = load i64, i64* %245, align 4
+  %247 = and i64 %"90_0.sroa.0.0972", 63
+  %248 = shl nuw i64 1, %247
+  %249 = and i64 %246, %248
+  %.not.i914 = icmp eq i64 %249, 0
+  br i1 %.not.i914, label %panic.i915, label %cond_exit_95
 
-panic.i841:                                       ; preds = %__barray_check_bounds.exit839
+panic.i915:                                       ; preds = %__barray_check_bounds.exit913
   call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-cond_exit_95:                                     ; preds = %__barray_check_bounds.exit839
-  %253 = xor i64 %249, %251
-  store i64 %253, i64* %248, align 4
-  %254 = getelementptr inbounds i64, i64* %5, i64 %"90_0.sroa.0.0899"
-  store i64 %"90_0.sroa.0.0899", i64* %254, align 4
-  %exitcond912.not = icmp eq i64 %246, 100
-  br i1 %exitcond912.not, label %loop_out164, label %__barray_check_bounds.exit839
+cond_exit_95:                                     ; preds = %__barray_check_bounds.exit913
+  %250 = xor i64 %246, %248
+  store i64 %250, i64* %245, align 4
+  %251 = getelementptr inbounds i64, i64* %5, i64 %"90_0.sroa.0.0972"
+  store i64 %"90_0.sroa.0.0972", i64* %251, align 4
+  %exitcond984.not = icmp eq i64 %243, 100
+  br i1 %exitcond984.not, label %loop_out212, label %__barray_check_bounds.exit913
 
-loop_out164:                                      ; preds = %cond_exit_95
-  %255 = getelementptr inbounds i8, i8* %6, i64 8
-  %256 = bitcast i8* %255 to i64*
-  %257 = load i64, i64* %256, align 4
-  %258 = and i64 %257, 68719476735
-  store i64 %258, i64* %256, align 4
-  %259 = load i64, i64* %7, align 4
-  %260 = icmp eq i64 %259, 0
-  %261 = icmp eq i64 %258, 0
-  %or.cond = select i1 %260, i1 %261, i1 false
-  br i1 %or.cond, label %__barray_check_none_borrowed.exit847, label %mask_block_err.i846
+loop_out212:                                      ; preds = %cond_exit_95
+  %252 = getelementptr inbounds i8, i8* %6, i64 8
+  %253 = bitcast i8* %252 to i64*
+  %254 = load i64, i64* %253, align 4
+  %255 = and i64 %254, 68719476735
+  store i64 %255, i64* %253, align 4
+  %256 = load i64, i64* %7, align 4
+  %257 = icmp eq i64 %256, 0
+  %258 = icmp eq i64 %255, 0
+  %or.cond = select i1 %257, i1 %258, i1 false
+  br i1 %or.cond, label %__barray_check_none_borrowed.exit921, label %mask_block_err.i920
 
-__barray_check_none_borrowed.exit847:             ; preds = %loop_out164
-  %262 = call i8* @heap_alloc(i64 800)
-  %263 = bitcast i8* %262 to i64*
-  %264 = call i8* @heap_alloc(i64 16)
-  %265 = bitcast i8* %264 to i64*
-  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %265, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0i64.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(800) %263, i64* noundef nonnull align 1 dereferenceable(800) %5, i64 800, i1 false)
-  call void @heap_free(i8* %262)
-  %266 = load i64, i64* %256, align 4
-  %267 = and i64 %266, 68719476735
-  store i64 %267, i64* %256, align 4
-  %268 = load i64, i64* %7, align 4
-  %269 = icmp eq i64 %268, 0
-  %270 = icmp eq i64 %267, 0
-  %or.cond914 = select i1 %269, i1 %270, i1 false
-  br i1 %or.cond914, label %__barray_check_none_borrowed.exit852, label %mask_block_err.i851
+__barray_check_none_borrowed.exit921:             ; preds = %loop_out212
+  %259 = call i8* @heap_alloc(i64 800)
+  %260 = bitcast i8* %259 to i64*
+  %261 = call i8* @heap_alloc(i64 16)
+  %262 = bitcast i8* %261 to i64*
+  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %262, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0i64.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(800) %260, i64* noundef nonnull align 1 dereferenceable(800) %5, i64 800, i1 false)
+  call void @heap_free(i8* %259)
+  %263 = load i64, i64* %253, align 4
+  %264 = and i64 %263, 68719476735
+  store i64 %264, i64* %253, align 4
+  %265 = load i64, i64* %7, align 4
+  %266 = icmp eq i64 %265, 0
+  %267 = icmp eq i64 %264, 0
+  %or.cond987 = select i1 %266, i1 %267, i1 false
+  br i1 %or.cond987, label %__barray_check_none_borrowed.exit926, label %mask_block_err.i925
 
-mask_block_err.i846:                              ; preds = %loop_out164
+mask_block_err.i920:                              ; preds = %loop_out212
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit852:             ; preds = %__barray_check_none_borrowed.exit847
-  %out_arr_alloca239 = alloca <{ i32, i32, i64*, i1* }>, align 8
-  %x_ptr240 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 0
-  %y_ptr241 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 1
-  %arr_ptr242 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 2
-  %mask_ptr243 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 3
-  %271 = alloca [100 x i1], align 1
-  %.sub563 = getelementptr inbounds [100 x i1], [100 x i1]* %271, i64 0, i64 0
-  %272 = bitcast [100 x i1]* %271 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %272, i8 0, i64 100, i1 false)
-  store i32 100, i32* %x_ptr240, align 8
-  store i32 1, i32* %y_ptr241, align 4
-  %273 = bitcast i64** %arr_ptr242 to i8**
-  store i8* %4, i8** %273, align 8
-  store i1* %.sub563, i1** %mask_ptr243, align 8
-  call void @print_int_arr(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @res_is.F21393DB.0, i64 0, i64 0), i64 14, <{ i32, i32, i64*, i1* }>* nonnull %out_arr_alloca239)
-  br label %__barray_check_bounds.exit860
+__barray_check_none_borrowed.exit926:             ; preds = %__barray_check_none_borrowed.exit921
+  %out_arr_alloca287 = alloca <{ i32, i32, i64*, i1* }>, align 8
+  %x_ptr288 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 0
+  %y_ptr289 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 1
+  %arr_ptr290 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 2
+  %mask_ptr291 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 3
+  %268 = alloca [100 x i1], align 1
+  %.sub635 = getelementptr inbounds [100 x i1], [100 x i1]* %268, i64 0, i64 0
+  %269 = bitcast [100 x i1]* %268 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %269, i8 0, i64 100, i1 false)
+  store i32 100, i32* %x_ptr288, align 8
+  store i32 1, i32* %y_ptr289, align 4
+  %270 = bitcast i64** %arr_ptr290 to i8**
+  store i8* %4, i8** %270, align 8
+  store i1* %.sub635, i1** %mask_ptr291, align 8
+  call void @print_int_arr(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @res_is.F21393DB.0, i64 0, i64 0), i64 14, <{ i32, i32, i64*, i1* }>* nonnull %out_arr_alloca287)
+  br label %__barray_check_bounds.exit934
 
-mask_block_err.i851:                              ; preds = %__barray_check_none_borrowed.exit847
+mask_block_err.i925:                              ; preds = %__barray_check_none_borrowed.exit921
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit860:                    ; preds = %cond_exit_130, %__barray_check_none_borrowed.exit852
-  %"125_0.sroa.0.0901" = phi i64 [ 0, %__barray_check_none_borrowed.exit852 ], [ %274, %cond_exit_130 ]
-  %274 = add nuw nsw i64 %"125_0.sroa.0.0901", 1
-  %275 = lshr i64 %"125_0.sroa.0.0901", 6
-  %276 = getelementptr inbounds i64, i64* %3, i64 %275
-  %277 = load i64, i64* %276, align 4
-  %278 = and i64 %"125_0.sroa.0.0901", 63
-  %279 = shl nuw i64 1, %278
-  %280 = and i64 %277, %279
-  %.not.i861 = icmp eq i64 %280, 0
-  br i1 %.not.i861, label %panic.i862, label %cond_exit_130
+__barray_check_bounds.exit934:                    ; preds = %cond_exit_130, %__barray_check_none_borrowed.exit926
+  %"125_0.sroa.0.0974" = phi i64 [ 0, %__barray_check_none_borrowed.exit926 ], [ %271, %cond_exit_130 ]
+  %271 = add nuw nsw i64 %"125_0.sroa.0.0974", 1
+  %272 = lshr i64 %"125_0.sroa.0.0974", 6
+  %273 = getelementptr inbounds i64, i64* %3, i64 %272
+  %274 = load i64, i64* %273, align 4
+  %275 = and i64 %"125_0.sroa.0.0974", 63
+  %276 = shl nuw i64 1, %275
+  %277 = and i64 %274, %276
+  %.not.i935 = icmp eq i64 %277, 0
+  br i1 %.not.i935, label %panic.i936, label %cond_exit_130
 
-panic.i862:                                       ; preds = %__barray_check_bounds.exit860
+panic.i936:                                       ; preds = %__barray_check_bounds.exit934
   call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-cond_exit_130:                                    ; preds = %__barray_check_bounds.exit860
-  %281 = sitofp i64 %"125_0.sroa.0.0901" to double
-  %282 = fmul double %281, 6.250000e-02
-  %283 = xor i64 %277, %279
-  store i64 %283, i64* %276, align 4
-  %284 = getelementptr inbounds double, double* %1, i64 %"125_0.sroa.0.0901"
-  store double %282, double* %284, align 8
-  %exitcond913.not = icmp eq i64 %274, 100
-  br i1 %exitcond913.not, label %loop_out251, label %__barray_check_bounds.exit860
+cond_exit_130:                                    ; preds = %__barray_check_bounds.exit934
+  %278 = sitofp i64 %"125_0.sroa.0.0974" to double
+  %279 = fmul double %278, 6.250000e-02
+  %280 = xor i64 %274, %276
+  store i64 %280, i64* %273, align 4
+  %281 = getelementptr inbounds double, double* %1, i64 %"125_0.sroa.0.0974"
+  store double %279, double* %281, align 8
+  %exitcond985.not = icmp eq i64 %271, 100
+  br i1 %exitcond985.not, label %loop_out299, label %__barray_check_bounds.exit934
 
-loop_out251:                                      ; preds = %cond_exit_130
-  %285 = getelementptr inbounds i8, i8* %2, i64 8
-  %286 = bitcast i8* %285 to i64*
-  %287 = load i64, i64* %286, align 4
-  %288 = and i64 %287, 68719476735
-  store i64 %288, i64* %286, align 4
-  %289 = load i64, i64* %3, align 4
-  %290 = icmp eq i64 %289, 0
-  %291 = icmp eq i64 %288, 0
-  %or.cond915 = select i1 %290, i1 %291, i1 false
-  br i1 %or.cond915, label %__barray_check_none_borrowed.exit868, label %mask_block_err.i867
+loop_out299:                                      ; preds = %cond_exit_130
+  %282 = getelementptr inbounds i8, i8* %2, i64 8
+  %283 = bitcast i8* %282 to i64*
+  %284 = load i64, i64* %283, align 4
+  %285 = and i64 %284, 68719476735
+  store i64 %285, i64* %283, align 4
+  %286 = load i64, i64* %3, align 4
+  %287 = icmp eq i64 %286, 0
+  %288 = icmp eq i64 %285, 0
+  %or.cond988 = select i1 %287, i1 %288, i1 false
+  br i1 %or.cond988, label %__barray_check_none_borrowed.exit942, label %mask_block_err.i941
 
-__barray_check_none_borrowed.exit868:             ; preds = %loop_out251
-  %292 = call i8* @heap_alloc(i64 800)
-  %293 = bitcast i8* %292 to double*
-  %294 = call i8* @heap_alloc(i64 16)
-  %295 = bitcast i8* %294 to i64*
-  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %295, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0f64.p0f64.i64(double* noundef nonnull align 1 dereferenceable(800) %293, double* noundef nonnull align 1 dereferenceable(800) %1, i64 800, i1 false)
-  call void @heap_free(i8* %292)
-  %296 = load i64, i64* %286, align 4
-  %297 = and i64 %296, 68719476735
-  store i64 %297, i64* %286, align 4
-  %298 = load i64, i64* %3, align 4
-  %299 = icmp eq i64 %298, 0
-  %300 = icmp eq i64 %297, 0
-  %or.cond916 = select i1 %299, i1 %300, i1 false
-  br i1 %or.cond916, label %__barray_check_none_borrowed.exit873, label %mask_block_err.i872
+__barray_check_none_borrowed.exit942:             ; preds = %loop_out299
+  %289 = call i8* @heap_alloc(i64 800)
+  %290 = bitcast i8* %289 to double*
+  %291 = call i8* @heap_alloc(i64 16)
+  %292 = bitcast i8* %291 to i64*
+  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %292, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0f64.p0f64.i64(double* noundef nonnull align 1 dereferenceable(800) %290, double* noundef nonnull align 1 dereferenceable(800) %1, i64 800, i1 false)
+  call void @heap_free(i8* %289)
+  %293 = load i64, i64* %283, align 4
+  %294 = and i64 %293, 68719476735
+  store i64 %294, i64* %283, align 4
+  %295 = load i64, i64* %3, align 4
+  %296 = icmp eq i64 %295, 0
+  %297 = icmp eq i64 %294, 0
+  %or.cond989 = select i1 %296, i1 %297, i1 false
+  br i1 %or.cond989, label %__barray_check_none_borrowed.exit947, label %mask_block_err.i946
 
-mask_block_err.i867:                              ; preds = %loop_out251
+mask_block_err.i941:                              ; preds = %loop_out299
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit873:             ; preds = %__barray_check_none_borrowed.exit868
-  %out_arr_alloca329 = alloca <{ i32, i32, double*, i1* }>, align 8
-  %x_ptr330 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 0
-  %y_ptr331 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 1
-  %arr_ptr332 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 2
-  %mask_ptr333 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 3
-  %301 = alloca [100 x i1], align 1
-  %.sub664 = getelementptr inbounds [100 x i1], [100 x i1]* %301, i64 0, i64 0
-  %302 = bitcast [100 x i1]* %301 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %302, i8 0, i64 100, i1 false)
-  store i32 100, i32* %x_ptr330, align 8
-  store i32 1, i32* %y_ptr331, align 4
-  %303 = bitcast double** %arr_ptr332 to i8**
-  store i8* %0, i8** %303, align 8
-  store i1* %.sub664, i1** %mask_ptr333, align 8
-  call void @print_float_arr(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @res_fs.CBD4AF54.0, i64 0, i64 0), i64 16, <{ i32, i32, double*, i1* }>* nonnull %out_arr_alloca329)
+__barray_check_none_borrowed.exit947:             ; preds = %__barray_check_none_borrowed.exit942
+  %out_arr_alloca377 = alloca <{ i32, i32, double*, i1* }>, align 8
+  %x_ptr378 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 0
+  %y_ptr379 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 1
+  %arr_ptr380 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 2
+  %mask_ptr381 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 3
+  %298 = alloca [100 x i1], align 1
+  %.sub736 = getelementptr inbounds [100 x i1], [100 x i1]* %298, i64 0, i64 0
+  %299 = bitcast [100 x i1]* %298 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %299, i8 0, i64 100, i1 false)
+  store i32 100, i32* %x_ptr378, align 8
+  store i32 1, i32* %y_ptr379, align 4
+  %300 = bitcast double** %arr_ptr380 to i8**
+  store i8* %0, i8** %300, align 8
+  store i1* %.sub736, i1** %mask_ptr381, align 8
+  call void @print_float_arr(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @res_fs.CBD4AF54.0, i64 0, i64 0), i64 16, <{ i32, i32, double*, i1* }>* nonnull %out_arr_alloca377)
   ret void
 
-mask_block_err.i872:                              ; preds = %__barray_check_none_borrowed.exit868
+mask_block_err.i946:                              ; preds = %__barray_check_none_borrowed.exit942
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 }
@@ -1008,6 +934,8 @@ declare void @panic(i32, i8*) local_unnamed_addr #1
 
 declare void @heap_free(i8*) local_unnamed_addr
 
+declare void @___dec_future_refcount(i64) local_unnamed_addr
+
 declare void @print_bool_arr(i8*, i64, <{ i32, i32, i1*, i1* }>*) local_unnamed_addr
 
 ; Function Attrs: argmemonly mustprogress nofree nounwind willreturn
@@ -1021,8 +949,6 @@ declare void @llvm.memcpy.p0f64.p0f64.i64(double* noalias nocapture writeonly, d
 declare void @print_float_arr(i8*, i64, <{ i32, i32, double*, i1* }>*) local_unnamed_addr
 
 declare i1 @___read_future_bool(i64) local_unnamed_addr
-
-declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 declare i64 @___lazy_measure(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_print_array/x86_64-apple-darwin/print_array_x86_64-apple-darwin
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_print_array/x86_64-apple-darwin/print_array_x86_64-apple-darwin
@@ -6,10 +6,10 @@ target triple = "x86_64-apple-darwin"
 @"e_Array alre.5A300C2A.0" = private constant [57 x i8] c"8EXIT:INT:Array already contains an element at this index"
 @"e_Array elem.E746B1A3.0" = private constant [43 x i8] c"*EXIT:INT:Array element is already borrowed"
 @"e_Some array.A77EF32E.0" = private constant [48 x i8] c"/EXIT:INT:Some array elements have been borrowed"
+@"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @res_cs.46C3C4B5.0 = private constant [16 x i8] c"\0FUSER:BOOLARR:cs"
 @res_is.F21393DB.0 = private constant [15 x i8] c"\0EUSER:INTARR:is"
 @res_fs.CBD4AF54.0 = private constant [17 x i8] c"\10USER:FLOATARR:fs"
-@"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @"e_No more qu.3B2EEBF0.0" = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
 @"e_Expected v.E6312129.0" = private constant [46 x i8] c"-EXIT:INT:Expected variant 1 but got variant 0"
 @"e_Expected v.2F17E0A9.0" = private constant [46 x i8] c"-EXIT:INT:Expected variant 0 but got variant 1"
@@ -34,8 +34,8 @@ alloca_block:
   br label %cond_20_case_1
 
 cond_20_case_1:                                   ; preds = %alloca_block, %cond_exit_20
-  %"15_0.sroa.0.0887" = phi i64 [ 0, %alloca_block ], [ %12, %cond_exit_20 ]
-  %12 = add nuw nsw i64 %"15_0.sroa.0.0887", 1
+  %"15_0.sroa.0.0961" = phi i64 [ 0, %alloca_block ], [ %12, %cond_exit_20 ]
+  %12 = add nuw nsw i64 %"15_0.sroa.0.0961", 1
   %qalloc.i = tail call i64 @___qalloc()
   %not_max.not.i = icmp eq i64 %qalloc.i, -1
   br i1 %not_max.not.i, label %id_bb.i, label %reset_bb.i
@@ -55,10 +55,10 @@ cond_303_case_0.i:                                ; preds = %id_bb.i
   unreachable
 
 __barray_check_bounds.exit:                       ; preds = %id_bb.i
-  %15 = lshr i64 %"15_0.sroa.0.0887", 6
+  %15 = lshr i64 %"15_0.sroa.0.0961", 6
   %16 = getelementptr inbounds i64, i64* %11, i64 %15
   %17 = load i64, i64* %16, align 4
-  %18 = shl nuw nsw i64 1, %"15_0.sroa.0.0887"
+  %18 = shl nuw nsw i64 1, %"15_0.sroa.0.0961"
   %19 = and i64 %17, %18
   %.not.i = icmp eq i64 %19, 0
   br i1 %.not.i, label %panic.i, label %cond_exit_20
@@ -71,7 +71,7 @@ cond_exit_20:                                     ; preds = %__barray_check_boun
   %.fca.1.extract.i = extractvalue { i1, i64 } %14, 1
   %20 = xor i64 %17, %18
   store i64 %20, i64* %16, align 4
-  %21 = getelementptr inbounds i64, i64* %9, i64 %"15_0.sroa.0.0887"
+  %21 = getelementptr inbounds i64, i64* %9, i64 %"15_0.sroa.0.0961"
   store i64 %.fca.1.extract.i, i64* %21, align 4
   %exitcond.not = icmp eq i64 %12, 10
   br i1 %exitcond.not, label %loop_out, label %cond_20_case_1
@@ -79,10 +79,10 @@ cond_exit_20:                                     ; preds = %__barray_check_boun
 loop_out:                                         ; preds = %cond_exit_20
   %22 = load i64, i64* %11, align 4
   %23 = and i64 %22, 1
-  %.not.i781 = icmp eq i64 %23, 0
-  br i1 %.not.i781, label %__barray_mask_borrow.exit, label %panic.i782
+  %.not.i852 = icmp eq i64 %23, 0
+  br i1 %.not.i852, label %__barray_mask_borrow.exit, label %panic.i853
 
-panic.i782:                                       ; preds = %loop_out
+panic.i853:                                       ; preds = %loop_out
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
@@ -93,27 +93,27 @@ __barray_mask_borrow.exit:                        ; preds = %loop_out
   tail call void @___rxy(i64 %25, double 0x400921FB54442D18, double 0.000000e+00)
   %26 = load i64, i64* %11, align 4
   %27 = and i64 %26, 1
-  %.not.i783 = icmp eq i64 %27, 0
-  br i1 %.not.i783, label %panic.i784, label %__barray_mask_return.exit785
+  %.not.i854 = icmp eq i64 %27, 0
+  br i1 %.not.i854, label %panic.i855, label %__barray_mask_return.exit856
 
-panic.i784:                                       ; preds = %__barray_mask_borrow.exit
+panic.i855:                                       ; preds = %__barray_mask_borrow.exit
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit785:                     ; preds = %__barray_mask_borrow.exit
+__barray_mask_return.exit856:                     ; preds = %__barray_mask_borrow.exit
   %28 = xor i64 %26, 1
   store i64 %28, i64* %11, align 4
   store i64 %25, i64* %9, align 4
   %29 = load i64, i64* %11, align 4
   %30 = and i64 %29, 4
-  %.not.i786 = icmp eq i64 %30, 0
-  br i1 %.not.i786, label %__barray_mask_borrow.exit788, label %panic.i787
+  %.not.i857 = icmp eq i64 %30, 0
+  br i1 %.not.i857, label %__barray_mask_borrow.exit859, label %panic.i858
 
-panic.i787:                                       ; preds = %__barray_mask_return.exit785
+panic.i858:                                       ; preds = %__barray_mask_return.exit856
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit788:                     ; preds = %__barray_mask_return.exit785
+__barray_mask_borrow.exit859:                     ; preds = %__barray_mask_return.exit856
   %31 = xor i64 %29, 4
   store i64 %31, i64* %11, align 4
   %32 = getelementptr inbounds i8, i8* %8, i64 16
@@ -122,27 +122,27 @@ __barray_mask_borrow.exit788:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %34, double 0x400921FB54442D18, double 0.000000e+00)
   %35 = load i64, i64* %11, align 4
   %36 = and i64 %35, 4
-  %.not.i789 = icmp eq i64 %36, 0
-  br i1 %.not.i789, label %panic.i790, label %__barray_mask_return.exit791
+  %.not.i860 = icmp eq i64 %36, 0
+  br i1 %.not.i860, label %panic.i861, label %__barray_mask_return.exit862
 
-panic.i790:                                       ; preds = %__barray_mask_borrow.exit788
+panic.i861:                                       ; preds = %__barray_mask_borrow.exit859
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit791:                     ; preds = %__barray_mask_borrow.exit788
+__barray_mask_return.exit862:                     ; preds = %__barray_mask_borrow.exit859
   %37 = xor i64 %35, 4
   store i64 %37, i64* %11, align 4
   store i64 %34, i64* %33, align 4
   %38 = load i64, i64* %11, align 4
   %39 = and i64 %38, 8
-  %.not.i792 = icmp eq i64 %39, 0
-  br i1 %.not.i792, label %__barray_mask_borrow.exit794, label %panic.i793
+  %.not.i863 = icmp eq i64 %39, 0
+  br i1 %.not.i863, label %__barray_mask_borrow.exit865, label %panic.i864
 
-panic.i793:                                       ; preds = %__barray_mask_return.exit791
+panic.i864:                                       ; preds = %__barray_mask_return.exit862
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit794:                     ; preds = %__barray_mask_return.exit791
+__barray_mask_borrow.exit865:                     ; preds = %__barray_mask_return.exit862
   %40 = xor i64 %38, 8
   store i64 %40, i64* %11, align 4
   %41 = getelementptr inbounds i8, i8* %8, i64 24
@@ -151,27 +151,27 @@ __barray_mask_borrow.exit794:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %43, double 0x400921FB54442D18, double 0.000000e+00)
   %44 = load i64, i64* %11, align 4
   %45 = and i64 %44, 8
-  %.not.i795 = icmp eq i64 %45, 0
-  br i1 %.not.i795, label %panic.i796, label %__barray_mask_return.exit797
+  %.not.i866 = icmp eq i64 %45, 0
+  br i1 %.not.i866, label %panic.i867, label %__barray_mask_return.exit868
 
-panic.i796:                                       ; preds = %__barray_mask_borrow.exit794
+panic.i867:                                       ; preds = %__barray_mask_borrow.exit865
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit797:                     ; preds = %__barray_mask_borrow.exit794
+__barray_mask_return.exit868:                     ; preds = %__barray_mask_borrow.exit865
   %46 = xor i64 %44, 8
   store i64 %46, i64* %11, align 4
   store i64 %43, i64* %42, align 4
   %47 = load i64, i64* %11, align 4
   %48 = and i64 %47, 512
-  %.not.i798 = icmp eq i64 %48, 0
-  br i1 %.not.i798, label %__barray_mask_borrow.exit800, label %panic.i799
+  %.not.i869 = icmp eq i64 %48, 0
+  br i1 %.not.i869, label %__barray_mask_borrow.exit871, label %panic.i870
 
-panic.i799:                                       ; preds = %__barray_mask_return.exit797
+panic.i870:                                       ; preds = %__barray_mask_return.exit868
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit800:                     ; preds = %__barray_mask_return.exit797
+__barray_mask_borrow.exit871:                     ; preds = %__barray_mask_return.exit868
   %49 = xor i64 %47, 512
   store i64 %49, i64* %11, align 4
   %50 = getelementptr inbounds i8, i8* %8, i64 72
@@ -180,14 +180,14 @@ __barray_mask_borrow.exit800:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %52, double 0x400921FB54442D18, double 0.000000e+00)
   %53 = load i64, i64* %11, align 4
   %54 = and i64 %53, 512
-  %.not.i801 = icmp eq i64 %54, 0
-  br i1 %.not.i801, label %panic.i802, label %__barray_mask_return.exit803
+  %.not.i872 = icmp eq i64 %54, 0
+  br i1 %.not.i872, label %panic.i873, label %__barray_mask_return.exit874
 
-panic.i802:                                       ; preds = %__barray_mask_borrow.exit800
+panic.i873:                                       ; preds = %__barray_mask_borrow.exit871
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit803:                     ; preds = %__barray_mask_borrow.exit800
+__barray_mask_return.exit874:                     ; preds = %__barray_mask_borrow.exit871
   %55 = xor i64 %53, 512
   store i64 %55, i64* %11, align 4
   store i64 %52, i64* %51, align 4
@@ -223,13 +223,13 @@ mask_block_err.i.i.i:                             ; preds = %mask_block_ok.i.i.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-69:                                               ; preds = %__barray_mask_return.exit803, %cond_exit_443.i
-  %"393_0.sroa.15.0.i889" = phi i64 [ 0, %__barray_mask_return.exit803 ], [ %70, %cond_exit_443.i ]
-  %70 = add nuw nsw i64 %"393_0.sroa.15.0.i889", 1
-  %71 = lshr i64 %"393_0.sroa.15.0.i889", 6
+69:                                               ; preds = %__barray_mask_return.exit874, %cond_exit_443.i
+  %"393_0.sroa.15.0.i963" = phi i64 [ 0, %__barray_mask_return.exit874 ], [ %70, %cond_exit_443.i ]
+  %70 = add nuw nsw i64 %"393_0.sroa.15.0.i963", 1
+  %71 = lshr i64 %"393_0.sroa.15.0.i963", 6
   %72 = getelementptr inbounds i64, i64* %11, i64 %71
   %73 = load i64, i64* %72, align 4
-  %74 = shl nuw nsw i64 1, %"393_0.sroa.15.0.i889"
+  %74 = shl nuw nsw i64 1, %"393_0.sroa.15.0.i963"
   %75 = and i64 %73, %74
   %.not.i99.i.i = icmp eq i64 %75, 0
   br i1 %.not.i99.i.i, label %__barray_check_bounds.exit.i, label %panic.i.i.i
@@ -241,7 +241,7 @@ panic.i.i.i:                                      ; preds = %69
 __barray_check_bounds.exit.i:                     ; preds = %69
   %76 = xor i64 %73, %74
   store i64 %76, i64* %72, align 4
-  %77 = getelementptr inbounds i64, i64* %9, i64 %"393_0.sroa.15.0.i889"
+  %77 = getelementptr inbounds i64, i64* %9, i64 %"393_0.sroa.15.0.i963"
   %78 = load i64, i64* %77, align 4
   %lazy_measure.i = tail call i64 @___lazy_measure(i64 %78)
   tail call void @___qfree(i64 %78)
@@ -259,10 +259,10 @@ cond_exit_443.i:                                  ; preds = %__barray_check_boun
   %"457_054.fca.1.insert.i" = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %lazy_measure.i, 1
   %82 = xor i64 %80, %74
   store i64 %82, i64* %79, align 4
-  %83 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %"393_0.sroa.15.0.i889"
+  %83 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %"393_0.sroa.15.0.i963"
   store { i1, i64, i1 } %"457_054.fca.1.insert.i", { i1, i64, i1 }* %83, align 4
-  %exitcond906.not = icmp eq i64 %70, 10
-  br i1 %exitcond906.not, label %mask_block_ok.i.i.i, label %69
+  %exitcond979.not = icmp eq i64 %70, 10
+  br i1 %exitcond979.not, label %mask_block_ok.i.i.i, label %69
 
 __barray_check_none_borrowed.exit:                ; preds = %"__hugr__.$measure_array$$n(10).367.exit"
   %84 = tail call i8* @heap_alloc(i64 240)
@@ -278,77 +278,77 @@ mask_block_err.i:                                 ; preds = %"__hugr__.$measure_
   unreachable
 
 89:                                               ; preds = %__barray_check_none_borrowed.exit, %__hugr__.const_fun_290.309.exit
-  %storemerge779894 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %107, %__hugr__.const_fun_290.309.exit ]
+  %storemerge850968 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %107, %__hugr__.const_fun_290.309.exit ]
   %90 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %105, %__hugr__.const_fun_290.309.exit ]
-  %91 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %storemerge779894
+  %91 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %storemerge850968
   %92 = load { i1, i64, i1 }, { i1, i64, i1 }* %91, align 4
   %.fca.0.extract118.i = extractvalue { i1, i64, i1 } %92, 0
   %.fca.1.extract119.i = extractvalue { i1, i64, i1 } %92, 1
-  br i1 %.fca.0.extract118.i, label %cond_485_case_1.i, label %cond_exit_485.i
+  br i1 %.fca.0.extract118.i, label %cond_525_case_1.i, label %cond_exit_525.i
 
-cond_485_case_1.i:                                ; preds = %89
+cond_525_case_1.i:                                ; preds = %89
   tail call void @___inc_future_refcount(i64 %.fca.1.extract119.i)
   %93 = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %.fca.1.extract119.i, 1
-  br label %cond_exit_485.i
+  br label %cond_exit_525.i
 
-cond_exit_485.i:                                  ; preds = %cond_485_case_1.i, %89
-  %.pn.i = phi { i1, i64, i1 } [ %93, %cond_485_case_1.i ], [ %92, %89 ]
+cond_exit_525.i:                                  ; preds = %cond_525_case_1.i, %89
+  %.pn.i = phi { i1, i64, i1 } [ %93, %cond_525_case_1.i ], [ %92, %89 ]
   %"04.sroa.6.0.i" = extractvalue { i1, i64, i1 } %.pn.i, 2
   %94 = icmp ult i64 %90, 10
-  br i1 %94, label %95, label %cond_488_case_0.i
+  br i1 %94, label %95, label %cond_528_case_0.i
 
-95:                                               ; preds = %cond_exit_485.i
+95:                                               ; preds = %cond_exit_525.i
   %96 = lshr i64 %90, 6
   %97 = getelementptr inbounds i64, i64* %65, i64 %96
   %98 = load i64, i64* %97, align 4
   %99 = shl nuw nsw i64 1, %90
   %100 = and i64 %98, %99
-  %.not.i.i805 = icmp eq i64 %100, 0
-  br i1 %.not.i.i805, label %cond_488_case_1.i, label %panic.i.i806
+  %.not.i.i876 = icmp eq i64 %100, 0
+  br i1 %.not.i.i876, label %cond_528_case_1.i, label %panic.i.i877
 
-panic.i.i806:                                     ; preds = %95
+panic.i.i877:                                     ; preds = %95
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-cond_488_case_0.i:                                ; preds = %cond_exit_485.i
+cond_528_case_0.i:                                ; preds = %cond_exit_525.i
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.E6312129.0", i64 0, i64 0))
   unreachable
 
-cond_488_case_1.i:                                ; preds = %95
+cond_528_case_1.i:                                ; preds = %95
   %"17.fca.2.insert.i" = insertvalue { i1, i64, i1 } %92, i1 %"04.sroa.6.0.i", 2
   %101 = insertvalue { i1, { i1, i64, i1 } } { i1 true, { i1, i64, i1 } poison }, { i1, i64, i1 } %"17.fca.2.insert.i", 1
   %102 = getelementptr inbounds { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %88, i64 %90
   %103 = getelementptr inbounds { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %102, i64 0, i32 0
   %104 = load i1, i1* %103, align 1
   store { i1, { i1, i64, i1 } } %101, { i1, { i1, i64, i1 } }* %102, align 4
-  br i1 %104, label %cond_489_case_1.i, label %__hugr__.const_fun_290.309.exit
+  br i1 %104, label %cond_529_case_1.i, label %__hugr__.const_fun_290.309.exit
 
-cond_489_case_1.i:                                ; preds = %cond_488_case_1.i
+cond_529_case_1.i:                                ; preds = %cond_528_case_1.i
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.2F17E0A9.0", i64 0, i64 0))
   unreachable
 
-__hugr__.const_fun_290.309.exit:                  ; preds = %cond_488_case_1.i
+__hugr__.const_fun_290.309.exit:                  ; preds = %cond_528_case_1.i
   %105 = add nuw nsw i64 %90, 1
-  %106 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %85, i64 %storemerge779894
+  %106 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %85, i64 %storemerge850968
   store { i1, i64, i1 } %"17.fca.2.insert.i", { i1, i64, i1 }* %106, align 4
-  %107 = add nuw nsw i64 %storemerge779894, 1
-  %exitcond907.not = icmp eq i64 %107, 10
-  br i1 %exitcond907.not, label %mask_block_ok.i810, label %89
+  %107 = add nuw nsw i64 %storemerge850968, 1
+  %exitcond980.not = icmp eq i64 %107, 10
+  br i1 %exitcond980.not, label %mask_block_ok.i881, label %89
 
-mask_block_ok.i810:                               ; preds = %__hugr__.const_fun_290.309.exit
+mask_block_ok.i881:                               ; preds = %__hugr__.const_fun_290.309.exit
   tail call void @heap_free(i8* nonnull %56)
   tail call void @heap_free(i8* %58)
   %108 = load i64, i64* %65, align 4
   %109 = and i64 %108, 1023
   store i64 %109, i64* %65, align 4
   %110 = icmp eq i64 %109, 0
-  br i1 %110, label %__barray_check_none_borrowed.exit812, label %mask_block_err.i811
+  br i1 %110, label %__barray_check_none_borrowed.exit883, label %mask_block_err.i882
 
-mask_block_err.i811:                              ; preds = %mask_block_ok.i810
+mask_block_err.i882:                              ; preds = %mask_block_ok.i881
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit812:             ; preds = %mask_block_ok.i810
+__barray_check_none_borrowed.exit883:             ; preds = %mask_block_ok.i881
   %111 = tail call i8* @heap_alloc(i64 240)
   %112 = bitcast i8* %111 to { i1, i64, i1 }*
   %113 = tail call i8* @heap_alloc(i64 8)
@@ -356,20 +356,20 @@ __barray_check_none_borrowed.exit812:             ; preds = %mask_block_ok.i810
   store i64 0, i64* %114, align 1
   %115 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %88, align 4
   %.fca.0.extract11.i = extractvalue { i1, { i1, i64, i1 } } %115, 0
-  br i1 %.fca.0.extract11.i, label %__hugr__.const_fun_284.290.exit, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i, label %__hugr__.const_fun_284.290.exit, label %cond_570_case_0.i
 
-cond_530_case_0.i:                                ; preds = %__hugr__.const_fun_284.290.exit.8, %__hugr__.const_fun_284.290.exit.7, %__hugr__.const_fun_284.290.exit.6, %__hugr__.const_fun_284.290.exit.5, %__hugr__.const_fun_284.290.exit.4, %__hugr__.const_fun_284.290.exit.3, %__hugr__.const_fun_284.290.exit.2, %__hugr__.const_fun_284.290.exit.1, %__hugr__.const_fun_284.290.exit, %__barray_check_none_borrowed.exit812
+cond_570_case_0.i:                                ; preds = %__hugr__.const_fun_284.290.exit.8, %__hugr__.const_fun_284.290.exit.7, %__hugr__.const_fun_284.290.exit.6, %__hugr__.const_fun_284.290.exit.5, %__hugr__.const_fun_284.290.exit.4, %__hugr__.const_fun_284.290.exit.3, %__hugr__.const_fun_284.290.exit.2, %__hugr__.const_fun_284.290.exit.1, %__hugr__.const_fun_284.290.exit, %__barray_check_none_borrowed.exit883
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.E6312129.0", i64 0, i64 0))
   unreachable
 
-__hugr__.const_fun_284.290.exit:                  ; preds = %__barray_check_none_borrowed.exit812
+__hugr__.const_fun_284.290.exit:                  ; preds = %__barray_check_none_borrowed.exit883
   %116 = extractvalue { i1, { i1, i64, i1 } } %115, 1
   store { i1, i64, i1 } %116, { i1, i64, i1 }* %112, align 4
   %117 = getelementptr inbounds i8, i8* %63, i64 32
   %118 = bitcast i8* %117 to { i1, { i1, i64, i1 } }*
   %119 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %118, align 4
   %.fca.0.extract11.i.1 = extractvalue { i1, { i1, i64, i1 } } %119, 0
-  br i1 %.fca.0.extract11.i.1, label %__hugr__.const_fun_284.290.exit.1, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.1, label %__hugr__.const_fun_284.290.exit.1, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.1:                ; preds = %__hugr__.const_fun_284.290.exit
   %120 = extractvalue { i1, { i1, i64, i1 } } %119, 1
@@ -380,7 +380,7 @@ __hugr__.const_fun_284.290.exit.1:                ; preds = %__hugr__.const_fun_
   %124 = bitcast i8* %123 to { i1, { i1, i64, i1 } }*
   %125 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %124, align 4
   %.fca.0.extract11.i.2 = extractvalue { i1, { i1, i64, i1 } } %125, 0
-  br i1 %.fca.0.extract11.i.2, label %__hugr__.const_fun_284.290.exit.2, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.2, label %__hugr__.const_fun_284.290.exit.2, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.2:                ; preds = %__hugr__.const_fun_284.290.exit.1
   %126 = extractvalue { i1, { i1, i64, i1 } } %125, 1
@@ -391,7 +391,7 @@ __hugr__.const_fun_284.290.exit.2:                ; preds = %__hugr__.const_fun_
   %130 = bitcast i8* %129 to { i1, { i1, i64, i1 } }*
   %131 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %130, align 4
   %.fca.0.extract11.i.3 = extractvalue { i1, { i1, i64, i1 } } %131, 0
-  br i1 %.fca.0.extract11.i.3, label %__hugr__.const_fun_284.290.exit.3, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.3, label %__hugr__.const_fun_284.290.exit.3, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.3:                ; preds = %__hugr__.const_fun_284.290.exit.2
   %132 = extractvalue { i1, { i1, i64, i1 } } %131, 1
@@ -402,7 +402,7 @@ __hugr__.const_fun_284.290.exit.3:                ; preds = %__hugr__.const_fun_
   %136 = bitcast i8* %135 to { i1, { i1, i64, i1 } }*
   %137 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %136, align 4
   %.fca.0.extract11.i.4 = extractvalue { i1, { i1, i64, i1 } } %137, 0
-  br i1 %.fca.0.extract11.i.4, label %__hugr__.const_fun_284.290.exit.4, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.4, label %__hugr__.const_fun_284.290.exit.4, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.4:                ; preds = %__hugr__.const_fun_284.290.exit.3
   %138 = extractvalue { i1, { i1, i64, i1 } } %137, 1
@@ -413,7 +413,7 @@ __hugr__.const_fun_284.290.exit.4:                ; preds = %__hugr__.const_fun_
   %142 = bitcast i8* %141 to { i1, { i1, i64, i1 } }*
   %143 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %142, align 4
   %.fca.0.extract11.i.5 = extractvalue { i1, { i1, i64, i1 } } %143, 0
-  br i1 %.fca.0.extract11.i.5, label %__hugr__.const_fun_284.290.exit.5, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.5, label %__hugr__.const_fun_284.290.exit.5, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.5:                ; preds = %__hugr__.const_fun_284.290.exit.4
   %144 = extractvalue { i1, { i1, i64, i1 } } %143, 1
@@ -424,7 +424,7 @@ __hugr__.const_fun_284.290.exit.5:                ; preds = %__hugr__.const_fun_
   %148 = bitcast i8* %147 to { i1, { i1, i64, i1 } }*
   %149 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %148, align 4
   %.fca.0.extract11.i.6 = extractvalue { i1, { i1, i64, i1 } } %149, 0
-  br i1 %.fca.0.extract11.i.6, label %__hugr__.const_fun_284.290.exit.6, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.6, label %__hugr__.const_fun_284.290.exit.6, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.6:                ; preds = %__hugr__.const_fun_284.290.exit.5
   %150 = extractvalue { i1, { i1, i64, i1 } } %149, 1
@@ -435,7 +435,7 @@ __hugr__.const_fun_284.290.exit.6:                ; preds = %__hugr__.const_fun_
   %154 = bitcast i8* %153 to { i1, { i1, i64, i1 } }*
   %155 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %154, align 4
   %.fca.0.extract11.i.7 = extractvalue { i1, { i1, i64, i1 } } %155, 0
-  br i1 %.fca.0.extract11.i.7, label %__hugr__.const_fun_284.290.exit.7, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.7, label %__hugr__.const_fun_284.290.exit.7, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.7:                ; preds = %__hugr__.const_fun_284.290.exit.6
   %156 = extractvalue { i1, { i1, i64, i1 } } %155, 1
@@ -446,7 +446,7 @@ __hugr__.const_fun_284.290.exit.7:                ; preds = %__hugr__.const_fun_
   %160 = bitcast i8* %159 to { i1, { i1, i64, i1 } }*
   %161 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %160, align 4
   %.fca.0.extract11.i.8 = extractvalue { i1, { i1, i64, i1 } } %161, 0
-  br i1 %.fca.0.extract11.i.8, label %__hugr__.const_fun_284.290.exit.8, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.8, label %__hugr__.const_fun_284.290.exit.8, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.8:                ; preds = %__hugr__.const_fun_284.290.exit.7
   %162 = extractvalue { i1, { i1, i64, i1 } } %161, 1
@@ -457,7 +457,7 @@ __hugr__.const_fun_284.290.exit.8:                ; preds = %__hugr__.const_fun_
   %166 = bitcast i8* %165 to { i1, { i1, i64, i1 } }*
   %167 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %166, align 4
   %.fca.0.extract11.i.9 = extractvalue { i1, { i1, i64, i1 } } %167, 0
-  br i1 %.fca.0.extract11.i.9, label %__hugr__.const_fun_284.290.exit.9, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.9, label %__hugr__.const_fun_284.290.exit.9, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.9:                ; preds = %__hugr__.const_fun_284.290.exit.8
   %168 = extractvalue { i1, { i1, i64, i1 } } %167, 1
@@ -466,548 +466,474 @@ __hugr__.const_fun_284.290.exit.9:                ; preds = %__hugr__.const_fun_
   store { i1, i64, i1 } %168, { i1, i64, i1 }* %170, align 4
   tail call void @heap_free(i8* nonnull %63)
   tail call void @heap_free(i8* nonnull %64)
+  br label %__barray_check_bounds.exit888
+
+cond_165_case_0:                                  ; preds = %cond_exit_165
   %171 = load i64, i64* %114, align 4
-  %172 = and i64 %171, 1023
+  %172 = or i64 %171, -1024
   store i64 %172, i64* %114, align 4
-  %173 = icmp eq i64 %172, 0
-  br i1 %173, label %__barray_check_none_borrowed.exit817, label %mask_block_err.i816
+  %173 = icmp eq i64 %172, -1
+  br i1 %173, label %loop_out139, label %mask_block_err.i886
 
-__barray_check_none_borrowed.exit817:             ; preds = %__hugr__.const_fun_284.290.exit.9
-  %174 = tail call i8* @heap_alloc(i64 0)
-  %175 = tail call i8* @heap_alloc(i64 8)
-  %176 = bitcast i8* %175 to i64*
-  store i64 0, i64* %176, align 1
-  %177 = load { i1, i64, i1 }, { i1, i64, i1 }* %112, align 4
-  %.fca.0.extract.i818 = extractvalue { i1, i64, i1 } %177, 0
-  br i1 %.fca.0.extract.i818, label %cond_543_case_1.i, label %__hugr__.const_fun_175.284.exit
-
-mask_block_err.i816:                              ; preds = %__hugr__.const_fun_284.290.exit.9
-  tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
+mask_block_err.i886:                              ; preds = %cond_165_case_0
+  tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-cond_543_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit817
-  %.fca.1.extract.i819 = extractvalue { i1, i64, i1 } %177, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819)
-  br label %__hugr__.const_fun_175.284.exit
+__barray_check_bounds.exit888:                    ; preds = %__hugr__.const_fun_284.290.exit.9, %cond_exit_165
+  %"167_0.0989" = phi i64 [ 0, %__hugr__.const_fun_284.290.exit.9 ], [ %174, %cond_exit_165 ]
+  %174 = add nuw nsw i64 %"167_0.0989", 1
+  %175 = lshr i64 %"167_0.0989", 6
+  %176 = getelementptr inbounds i64, i64* %114, i64 %175
+  %177 = load i64, i64* %176, align 4
+  %178 = shl nuw nsw i64 1, %"167_0.0989"
+  %179 = and i64 %177, %178
+  %.not = icmp eq i64 %179, 0
+  br i1 %.not, label %__barray_mask_borrow.exit893, label %cond_exit_165
 
-__hugr__.const_fun_175.284.exit:                  ; preds = %__barray_check_none_borrowed.exit817, %cond_543_case_1.i
-  %178 = load { i1, i64, i1 }, { i1, i64, i1 }* %122, align 4
-  %.fca.0.extract.i818.1 = extractvalue { i1, i64, i1 } %178, 0
-  br i1 %.fca.0.extract.i818.1, label %cond_543_case_1.i.1, label %__hugr__.const_fun_175.284.exit.1
+__barray_mask_borrow.exit893:                     ; preds = %__barray_check_bounds.exit888
+  %180 = xor i64 %177, %178
+  store i64 %180, i64* %176, align 4
+  %181 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %112, i64 %"167_0.0989"
+  %182 = load { i1, i64, i1 }, { i1, i64, i1 }* %181, align 4
+  %.fca.0.extract511 = extractvalue { i1, i64, i1 } %182, 0
+  br i1 %.fca.0.extract511, label %cond_501_case_1, label %cond_exit_165
 
-cond_543_case_1.i.1:                              ; preds = %__hugr__.const_fun_175.284.exit
-  %.fca.1.extract.i819.1 = extractvalue { i1, i64, i1 } %178, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.1)
-  br label %__hugr__.const_fun_175.284.exit.1
+cond_exit_165:                                    ; preds = %cond_501_case_1, %__barray_mask_borrow.exit893, %__barray_check_bounds.exit888
+  %183 = icmp ult i64 %"167_0.0989", 9
+  br i1 %183, label %__barray_check_bounds.exit888, label %cond_165_case_0
 
-__hugr__.const_fun_175.284.exit.1:                ; preds = %cond_543_case_1.i.1, %__hugr__.const_fun_175.284.exit
-  %179 = load { i1, i64, i1 }, { i1, i64, i1 }* %128, align 4
-  %.fca.0.extract.i818.2 = extractvalue { i1, i64, i1 } %179, 0
-  br i1 %.fca.0.extract.i818.2, label %cond_543_case_1.i.2, label %__hugr__.const_fun_175.284.exit.2
-
-cond_543_case_1.i.2:                              ; preds = %__hugr__.const_fun_175.284.exit.1
-  %.fca.1.extract.i819.2 = extractvalue { i1, i64, i1 } %179, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.2)
-  br label %__hugr__.const_fun_175.284.exit.2
-
-__hugr__.const_fun_175.284.exit.2:                ; preds = %cond_543_case_1.i.2, %__hugr__.const_fun_175.284.exit.1
-  %180 = load { i1, i64, i1 }, { i1, i64, i1 }* %134, align 4
-  %.fca.0.extract.i818.3 = extractvalue { i1, i64, i1 } %180, 0
-  br i1 %.fca.0.extract.i818.3, label %cond_543_case_1.i.3, label %__hugr__.const_fun_175.284.exit.3
-
-cond_543_case_1.i.3:                              ; preds = %__hugr__.const_fun_175.284.exit.2
-  %.fca.1.extract.i819.3 = extractvalue { i1, i64, i1 } %180, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.3)
-  br label %__hugr__.const_fun_175.284.exit.3
-
-__hugr__.const_fun_175.284.exit.3:                ; preds = %cond_543_case_1.i.3, %__hugr__.const_fun_175.284.exit.2
-  %181 = load { i1, i64, i1 }, { i1, i64, i1 }* %140, align 4
-  %.fca.0.extract.i818.4 = extractvalue { i1, i64, i1 } %181, 0
-  br i1 %.fca.0.extract.i818.4, label %cond_543_case_1.i.4, label %__hugr__.const_fun_175.284.exit.4
-
-cond_543_case_1.i.4:                              ; preds = %__hugr__.const_fun_175.284.exit.3
-  %.fca.1.extract.i819.4 = extractvalue { i1, i64, i1 } %181, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.4)
-  br label %__hugr__.const_fun_175.284.exit.4
-
-__hugr__.const_fun_175.284.exit.4:                ; preds = %cond_543_case_1.i.4, %__hugr__.const_fun_175.284.exit.3
-  %182 = load { i1, i64, i1 }, { i1, i64, i1 }* %146, align 4
-  %.fca.0.extract.i818.5 = extractvalue { i1, i64, i1 } %182, 0
-  br i1 %.fca.0.extract.i818.5, label %cond_543_case_1.i.5, label %__hugr__.const_fun_175.284.exit.5
-
-cond_543_case_1.i.5:                              ; preds = %__hugr__.const_fun_175.284.exit.4
-  %.fca.1.extract.i819.5 = extractvalue { i1, i64, i1 } %182, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.5)
-  br label %__hugr__.const_fun_175.284.exit.5
-
-__hugr__.const_fun_175.284.exit.5:                ; preds = %cond_543_case_1.i.5, %__hugr__.const_fun_175.284.exit.4
-  %183 = load { i1, i64, i1 }, { i1, i64, i1 }* %152, align 4
-  %.fca.0.extract.i818.6 = extractvalue { i1, i64, i1 } %183, 0
-  br i1 %.fca.0.extract.i818.6, label %cond_543_case_1.i.6, label %__hugr__.const_fun_175.284.exit.6
-
-cond_543_case_1.i.6:                              ; preds = %__hugr__.const_fun_175.284.exit.5
-  %.fca.1.extract.i819.6 = extractvalue { i1, i64, i1 } %183, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.6)
-  br label %__hugr__.const_fun_175.284.exit.6
-
-__hugr__.const_fun_175.284.exit.6:                ; preds = %cond_543_case_1.i.6, %__hugr__.const_fun_175.284.exit.5
-  %184 = load { i1, i64, i1 }, { i1, i64, i1 }* %158, align 4
-  %.fca.0.extract.i818.7 = extractvalue { i1, i64, i1 } %184, 0
-  br i1 %.fca.0.extract.i818.7, label %cond_543_case_1.i.7, label %__hugr__.const_fun_175.284.exit.7
-
-cond_543_case_1.i.7:                              ; preds = %__hugr__.const_fun_175.284.exit.6
-  %.fca.1.extract.i819.7 = extractvalue { i1, i64, i1 } %184, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.7)
-  br label %__hugr__.const_fun_175.284.exit.7
-
-__hugr__.const_fun_175.284.exit.7:                ; preds = %cond_543_case_1.i.7, %__hugr__.const_fun_175.284.exit.6
-  %185 = load { i1, i64, i1 }, { i1, i64, i1 }* %164, align 4
-  %.fca.0.extract.i818.8 = extractvalue { i1, i64, i1 } %185, 0
-  br i1 %.fca.0.extract.i818.8, label %cond_543_case_1.i.8, label %__hugr__.const_fun_175.284.exit.8
-
-cond_543_case_1.i.8:                              ; preds = %__hugr__.const_fun_175.284.exit.7
-  %.fca.1.extract.i819.8 = extractvalue { i1, i64, i1 } %185, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.8)
-  br label %__hugr__.const_fun_175.284.exit.8
-
-__hugr__.const_fun_175.284.exit.8:                ; preds = %cond_543_case_1.i.8, %__hugr__.const_fun_175.284.exit.7
-  %186 = load { i1, i64, i1 }, { i1, i64, i1 }* %170, align 4
-  %.fca.0.extract.i818.9 = extractvalue { i1, i64, i1 } %186, 0
-  br i1 %.fca.0.extract.i818.9, label %cond_543_case_1.i.9, label %__hugr__.const_fun_175.284.exit.9
-
-cond_543_case_1.i.9:                              ; preds = %__hugr__.const_fun_175.284.exit.8
-  %.fca.1.extract.i819.9 = extractvalue { i1, i64, i1 } %186, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.9)
-  br label %__hugr__.const_fun_175.284.exit.9
-
-__hugr__.const_fun_175.284.exit.9:                ; preds = %cond_543_case_1.i.9, %__hugr__.const_fun_175.284.exit.8
-  tail call void @heap_free(i8* nonnull %111)
+loop_out139:                                      ; preds = %cond_165_case_0
+  tail call void @heap_free(i8* %111)
   tail call void @heap_free(i8* nonnull %113)
-  tail call void @heap_free(i8* %174)
-  %187 = load i64, i64* %87, align 4
-  %188 = and i64 %187, 1023
-  store i64 %188, i64* %87, align 4
-  %189 = icmp eq i64 %188, 0
-  br i1 %189, label %__barray_check_none_borrowed.exit824, label %mask_block_err.i823
+  %184 = load i64, i64* %87, align 4
+  %185 = and i64 %184, 1023
+  store i64 %185, i64* %87, align 4
+  %186 = icmp eq i64 %185, 0
+  br i1 %186, label %__barray_check_none_borrowed.exit898, label %mask_block_err.i897
 
-__barray_check_none_borrowed.exit824:             ; preds = %__hugr__.const_fun_175.284.exit.9
-  %190 = tail call i8* @heap_alloc(i64 10)
-  %191 = tail call i8* @heap_alloc(i64 8)
-  %192 = bitcast i8* %191 to i64*
-  store i64 0, i64* %192, align 1
-  %193 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
-  %.fca.0.extract.i825 = extractvalue { i1, i64, i1 } %193, 0
-  %.fca.1.extract.i826 = extractvalue { i1, i64, i1 } %193, 1
-  br i1 %.fca.0.extract.i825, label %cond_300_case_1.i, label %cond_300_case_0.i
+__barray_check_none_borrowed.exit898:             ; preds = %loop_out139
+  %187 = tail call i8* @heap_alloc(i64 10)
+  %188 = tail call i8* @heap_alloc(i64 8)
+  %189 = bitcast i8* %188 to i64*
+  store i64 0, i64* %189, align 1
+  %190 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
+  %.fca.0.extract.i899 = extractvalue { i1, i64, i1 } %190, 0
+  %.fca.1.extract.i900 = extractvalue { i1, i64, i1 } %190, 1
+  br i1 %.fca.0.extract.i899, label %cond_300_case_1.i, label %cond_300_case_0.i
 
-mask_block_err.i823:                              ; preds = %__hugr__.const_fun_175.284.exit.9
+mask_block_err.i897:                              ; preds = %loop_out139
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-cond_300_case_0.i:                                ; preds = %__barray_check_none_borrowed.exit824
-  %.fca.2.extract.i = extractvalue { i1, i64, i1 } %193, 2
+cond_501_case_1:                                  ; preds = %__barray_mask_borrow.exit893
+  %.fca.1.extract512 = extractvalue { i1, i64, i1 } %182, 1
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract512)
+  br label %cond_exit_165
+
+cond_300_case_0.i:                                ; preds = %__barray_check_none_borrowed.exit898
+  %.fca.2.extract.i = extractvalue { i1, i64, i1 } %190, 2
   br label %__hugr__.array.__read_bool.3.271.exit
 
-cond_300_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit824
-  %read_bool.i = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826)
+cond_300_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit898
+  %read_bool.i = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900)
   br label %__hugr__.array.__read_bool.3.271.exit
 
 __hugr__.array.__read_bool.3.271.exit:            ; preds = %cond_300_case_0.i, %cond_300_case_1.i
   %"03.0.i" = phi i1 [ %read_bool.i, %cond_300_case_1.i ], [ %.fca.2.extract.i, %cond_300_case_0.i ]
-  %194 = bitcast i8* %190 to i1*
-  store i1 %"03.0.i", i1* %194, align 1
-  %195 = getelementptr inbounds i8, i8* %84, i64 24
-  %196 = bitcast i8* %195 to { i1, i64, i1 }*
-  %197 = load { i1, i64, i1 }, { i1, i64, i1 }* %196, align 4
-  %.fca.0.extract.i825.1 = extractvalue { i1, i64, i1 } %197, 0
-  %.fca.1.extract.i826.1 = extractvalue { i1, i64, i1 } %197, 1
-  br i1 %.fca.0.extract.i825.1, label %cond_300_case_1.i.1, label %cond_300_case_0.i.1
+  %191 = bitcast i8* %187 to i1*
+  store i1 %"03.0.i", i1* %191, align 1
+  %192 = getelementptr inbounds i8, i8* %84, i64 24
+  %193 = bitcast i8* %192 to { i1, i64, i1 }*
+  %194 = load { i1, i64, i1 }, { i1, i64, i1 }* %193, align 4
+  %.fca.0.extract.i899.1 = extractvalue { i1, i64, i1 } %194, 0
+  %.fca.1.extract.i900.1 = extractvalue { i1, i64, i1 } %194, 1
+  br i1 %.fca.0.extract.i899.1, label %cond_300_case_1.i.1, label %cond_300_case_0.i.1
 
 cond_300_case_0.i.1:                              ; preds = %__hugr__.array.__read_bool.3.271.exit
-  %.fca.2.extract.i.1 = extractvalue { i1, i64, i1 } %197, 2
+  %.fca.2.extract.i.1 = extractvalue { i1, i64, i1 } %194, 2
   br label %__hugr__.array.__read_bool.3.271.exit.1
 
 cond_300_case_1.i.1:                              ; preds = %__hugr__.array.__read_bool.3.271.exit
-  %read_bool.i.1 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.1)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.1)
+  %read_bool.i.1 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.1)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.1)
   br label %__hugr__.array.__read_bool.3.271.exit.1
 
 __hugr__.array.__read_bool.3.271.exit.1:          ; preds = %cond_300_case_1.i.1, %cond_300_case_0.i.1
   %"03.0.i.1" = phi i1 [ %read_bool.i.1, %cond_300_case_1.i.1 ], [ %.fca.2.extract.i.1, %cond_300_case_0.i.1 ]
-  %198 = getelementptr inbounds i8, i8* %190, i64 1
-  %199 = bitcast i8* %198 to i1*
-  store i1 %"03.0.i.1", i1* %199, align 1
-  %200 = getelementptr inbounds i8, i8* %84, i64 48
-  %201 = bitcast i8* %200 to { i1, i64, i1 }*
-  %202 = load { i1, i64, i1 }, { i1, i64, i1 }* %201, align 4
-  %.fca.0.extract.i825.2 = extractvalue { i1, i64, i1 } %202, 0
-  %.fca.1.extract.i826.2 = extractvalue { i1, i64, i1 } %202, 1
-  br i1 %.fca.0.extract.i825.2, label %cond_300_case_1.i.2, label %cond_300_case_0.i.2
+  %195 = getelementptr inbounds i8, i8* %187, i64 1
+  %196 = bitcast i8* %195 to i1*
+  store i1 %"03.0.i.1", i1* %196, align 1
+  %197 = getelementptr inbounds i8, i8* %84, i64 48
+  %198 = bitcast i8* %197 to { i1, i64, i1 }*
+  %199 = load { i1, i64, i1 }, { i1, i64, i1 }* %198, align 4
+  %.fca.0.extract.i899.2 = extractvalue { i1, i64, i1 } %199, 0
+  %.fca.1.extract.i900.2 = extractvalue { i1, i64, i1 } %199, 1
+  br i1 %.fca.0.extract.i899.2, label %cond_300_case_1.i.2, label %cond_300_case_0.i.2
 
 cond_300_case_0.i.2:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.1
-  %.fca.2.extract.i.2 = extractvalue { i1, i64, i1 } %202, 2
+  %.fca.2.extract.i.2 = extractvalue { i1, i64, i1 } %199, 2
   br label %__hugr__.array.__read_bool.3.271.exit.2
 
 cond_300_case_1.i.2:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.1
-  %read_bool.i.2 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.2)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.2)
+  %read_bool.i.2 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.2)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.2)
   br label %__hugr__.array.__read_bool.3.271.exit.2
 
 __hugr__.array.__read_bool.3.271.exit.2:          ; preds = %cond_300_case_1.i.2, %cond_300_case_0.i.2
   %"03.0.i.2" = phi i1 [ %read_bool.i.2, %cond_300_case_1.i.2 ], [ %.fca.2.extract.i.2, %cond_300_case_0.i.2 ]
-  %203 = getelementptr inbounds i8, i8* %190, i64 2
-  %204 = bitcast i8* %203 to i1*
-  store i1 %"03.0.i.2", i1* %204, align 1
-  %205 = getelementptr inbounds i8, i8* %84, i64 72
-  %206 = bitcast i8* %205 to { i1, i64, i1 }*
-  %207 = load { i1, i64, i1 }, { i1, i64, i1 }* %206, align 4
-  %.fca.0.extract.i825.3 = extractvalue { i1, i64, i1 } %207, 0
-  %.fca.1.extract.i826.3 = extractvalue { i1, i64, i1 } %207, 1
-  br i1 %.fca.0.extract.i825.3, label %cond_300_case_1.i.3, label %cond_300_case_0.i.3
+  %200 = getelementptr inbounds i8, i8* %187, i64 2
+  %201 = bitcast i8* %200 to i1*
+  store i1 %"03.0.i.2", i1* %201, align 1
+  %202 = getelementptr inbounds i8, i8* %84, i64 72
+  %203 = bitcast i8* %202 to { i1, i64, i1 }*
+  %204 = load { i1, i64, i1 }, { i1, i64, i1 }* %203, align 4
+  %.fca.0.extract.i899.3 = extractvalue { i1, i64, i1 } %204, 0
+  %.fca.1.extract.i900.3 = extractvalue { i1, i64, i1 } %204, 1
+  br i1 %.fca.0.extract.i899.3, label %cond_300_case_1.i.3, label %cond_300_case_0.i.3
 
 cond_300_case_0.i.3:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.2
-  %.fca.2.extract.i.3 = extractvalue { i1, i64, i1 } %207, 2
+  %.fca.2.extract.i.3 = extractvalue { i1, i64, i1 } %204, 2
   br label %__hugr__.array.__read_bool.3.271.exit.3
 
 cond_300_case_1.i.3:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.2
-  %read_bool.i.3 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.3)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.3)
+  %read_bool.i.3 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.3)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.3)
   br label %__hugr__.array.__read_bool.3.271.exit.3
 
 __hugr__.array.__read_bool.3.271.exit.3:          ; preds = %cond_300_case_1.i.3, %cond_300_case_0.i.3
   %"03.0.i.3" = phi i1 [ %read_bool.i.3, %cond_300_case_1.i.3 ], [ %.fca.2.extract.i.3, %cond_300_case_0.i.3 ]
-  %208 = getelementptr inbounds i8, i8* %190, i64 3
-  %209 = bitcast i8* %208 to i1*
-  store i1 %"03.0.i.3", i1* %209, align 1
-  %210 = getelementptr inbounds i8, i8* %84, i64 96
-  %211 = bitcast i8* %210 to { i1, i64, i1 }*
-  %212 = load { i1, i64, i1 }, { i1, i64, i1 }* %211, align 4
-  %.fca.0.extract.i825.4 = extractvalue { i1, i64, i1 } %212, 0
-  %.fca.1.extract.i826.4 = extractvalue { i1, i64, i1 } %212, 1
-  br i1 %.fca.0.extract.i825.4, label %cond_300_case_1.i.4, label %cond_300_case_0.i.4
+  %205 = getelementptr inbounds i8, i8* %187, i64 3
+  %206 = bitcast i8* %205 to i1*
+  store i1 %"03.0.i.3", i1* %206, align 1
+  %207 = getelementptr inbounds i8, i8* %84, i64 96
+  %208 = bitcast i8* %207 to { i1, i64, i1 }*
+  %209 = load { i1, i64, i1 }, { i1, i64, i1 }* %208, align 4
+  %.fca.0.extract.i899.4 = extractvalue { i1, i64, i1 } %209, 0
+  %.fca.1.extract.i900.4 = extractvalue { i1, i64, i1 } %209, 1
+  br i1 %.fca.0.extract.i899.4, label %cond_300_case_1.i.4, label %cond_300_case_0.i.4
 
 cond_300_case_0.i.4:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.3
-  %.fca.2.extract.i.4 = extractvalue { i1, i64, i1 } %212, 2
+  %.fca.2.extract.i.4 = extractvalue { i1, i64, i1 } %209, 2
   br label %__hugr__.array.__read_bool.3.271.exit.4
 
 cond_300_case_1.i.4:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.3
-  %read_bool.i.4 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.4)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.4)
+  %read_bool.i.4 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.4)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.4)
   br label %__hugr__.array.__read_bool.3.271.exit.4
 
 __hugr__.array.__read_bool.3.271.exit.4:          ; preds = %cond_300_case_1.i.4, %cond_300_case_0.i.4
   %"03.0.i.4" = phi i1 [ %read_bool.i.4, %cond_300_case_1.i.4 ], [ %.fca.2.extract.i.4, %cond_300_case_0.i.4 ]
-  %213 = getelementptr inbounds i8, i8* %190, i64 4
-  %214 = bitcast i8* %213 to i1*
-  store i1 %"03.0.i.4", i1* %214, align 1
-  %215 = getelementptr inbounds i8, i8* %84, i64 120
-  %216 = bitcast i8* %215 to { i1, i64, i1 }*
-  %217 = load { i1, i64, i1 }, { i1, i64, i1 }* %216, align 4
-  %.fca.0.extract.i825.5 = extractvalue { i1, i64, i1 } %217, 0
-  %.fca.1.extract.i826.5 = extractvalue { i1, i64, i1 } %217, 1
-  br i1 %.fca.0.extract.i825.5, label %cond_300_case_1.i.5, label %cond_300_case_0.i.5
+  %210 = getelementptr inbounds i8, i8* %187, i64 4
+  %211 = bitcast i8* %210 to i1*
+  store i1 %"03.0.i.4", i1* %211, align 1
+  %212 = getelementptr inbounds i8, i8* %84, i64 120
+  %213 = bitcast i8* %212 to { i1, i64, i1 }*
+  %214 = load { i1, i64, i1 }, { i1, i64, i1 }* %213, align 4
+  %.fca.0.extract.i899.5 = extractvalue { i1, i64, i1 } %214, 0
+  %.fca.1.extract.i900.5 = extractvalue { i1, i64, i1 } %214, 1
+  br i1 %.fca.0.extract.i899.5, label %cond_300_case_1.i.5, label %cond_300_case_0.i.5
 
 cond_300_case_0.i.5:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.4
-  %.fca.2.extract.i.5 = extractvalue { i1, i64, i1 } %217, 2
+  %.fca.2.extract.i.5 = extractvalue { i1, i64, i1 } %214, 2
   br label %__hugr__.array.__read_bool.3.271.exit.5
 
 cond_300_case_1.i.5:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.4
-  %read_bool.i.5 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.5)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.5)
+  %read_bool.i.5 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.5)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.5)
   br label %__hugr__.array.__read_bool.3.271.exit.5
 
 __hugr__.array.__read_bool.3.271.exit.5:          ; preds = %cond_300_case_1.i.5, %cond_300_case_0.i.5
   %"03.0.i.5" = phi i1 [ %read_bool.i.5, %cond_300_case_1.i.5 ], [ %.fca.2.extract.i.5, %cond_300_case_0.i.5 ]
-  %218 = getelementptr inbounds i8, i8* %190, i64 5
-  %219 = bitcast i8* %218 to i1*
-  store i1 %"03.0.i.5", i1* %219, align 1
-  %220 = getelementptr inbounds i8, i8* %84, i64 144
-  %221 = bitcast i8* %220 to { i1, i64, i1 }*
-  %222 = load { i1, i64, i1 }, { i1, i64, i1 }* %221, align 4
-  %.fca.0.extract.i825.6 = extractvalue { i1, i64, i1 } %222, 0
-  %.fca.1.extract.i826.6 = extractvalue { i1, i64, i1 } %222, 1
-  br i1 %.fca.0.extract.i825.6, label %cond_300_case_1.i.6, label %cond_300_case_0.i.6
+  %215 = getelementptr inbounds i8, i8* %187, i64 5
+  %216 = bitcast i8* %215 to i1*
+  store i1 %"03.0.i.5", i1* %216, align 1
+  %217 = getelementptr inbounds i8, i8* %84, i64 144
+  %218 = bitcast i8* %217 to { i1, i64, i1 }*
+  %219 = load { i1, i64, i1 }, { i1, i64, i1 }* %218, align 4
+  %.fca.0.extract.i899.6 = extractvalue { i1, i64, i1 } %219, 0
+  %.fca.1.extract.i900.6 = extractvalue { i1, i64, i1 } %219, 1
+  br i1 %.fca.0.extract.i899.6, label %cond_300_case_1.i.6, label %cond_300_case_0.i.6
 
 cond_300_case_0.i.6:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.5
-  %.fca.2.extract.i.6 = extractvalue { i1, i64, i1 } %222, 2
+  %.fca.2.extract.i.6 = extractvalue { i1, i64, i1 } %219, 2
   br label %__hugr__.array.__read_bool.3.271.exit.6
 
 cond_300_case_1.i.6:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.5
-  %read_bool.i.6 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.6)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.6)
+  %read_bool.i.6 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.6)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.6)
   br label %__hugr__.array.__read_bool.3.271.exit.6
 
 __hugr__.array.__read_bool.3.271.exit.6:          ; preds = %cond_300_case_1.i.6, %cond_300_case_0.i.6
   %"03.0.i.6" = phi i1 [ %read_bool.i.6, %cond_300_case_1.i.6 ], [ %.fca.2.extract.i.6, %cond_300_case_0.i.6 ]
-  %223 = getelementptr inbounds i8, i8* %190, i64 6
-  %224 = bitcast i8* %223 to i1*
-  store i1 %"03.0.i.6", i1* %224, align 1
-  %225 = getelementptr inbounds i8, i8* %84, i64 168
-  %226 = bitcast i8* %225 to { i1, i64, i1 }*
-  %227 = load { i1, i64, i1 }, { i1, i64, i1 }* %226, align 4
-  %.fca.0.extract.i825.7 = extractvalue { i1, i64, i1 } %227, 0
-  %.fca.1.extract.i826.7 = extractvalue { i1, i64, i1 } %227, 1
-  br i1 %.fca.0.extract.i825.7, label %cond_300_case_1.i.7, label %cond_300_case_0.i.7
+  %220 = getelementptr inbounds i8, i8* %187, i64 6
+  %221 = bitcast i8* %220 to i1*
+  store i1 %"03.0.i.6", i1* %221, align 1
+  %222 = getelementptr inbounds i8, i8* %84, i64 168
+  %223 = bitcast i8* %222 to { i1, i64, i1 }*
+  %224 = load { i1, i64, i1 }, { i1, i64, i1 }* %223, align 4
+  %.fca.0.extract.i899.7 = extractvalue { i1, i64, i1 } %224, 0
+  %.fca.1.extract.i900.7 = extractvalue { i1, i64, i1 } %224, 1
+  br i1 %.fca.0.extract.i899.7, label %cond_300_case_1.i.7, label %cond_300_case_0.i.7
 
 cond_300_case_0.i.7:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.6
-  %.fca.2.extract.i.7 = extractvalue { i1, i64, i1 } %227, 2
+  %.fca.2.extract.i.7 = extractvalue { i1, i64, i1 } %224, 2
   br label %__hugr__.array.__read_bool.3.271.exit.7
 
 cond_300_case_1.i.7:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.6
-  %read_bool.i.7 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.7)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.7)
+  %read_bool.i.7 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.7)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.7)
   br label %__hugr__.array.__read_bool.3.271.exit.7
 
 __hugr__.array.__read_bool.3.271.exit.7:          ; preds = %cond_300_case_1.i.7, %cond_300_case_0.i.7
   %"03.0.i.7" = phi i1 [ %read_bool.i.7, %cond_300_case_1.i.7 ], [ %.fca.2.extract.i.7, %cond_300_case_0.i.7 ]
-  %228 = getelementptr inbounds i8, i8* %190, i64 7
-  %229 = bitcast i8* %228 to i1*
-  store i1 %"03.0.i.7", i1* %229, align 1
-  %230 = getelementptr inbounds i8, i8* %84, i64 192
-  %231 = bitcast i8* %230 to { i1, i64, i1 }*
-  %232 = load { i1, i64, i1 }, { i1, i64, i1 }* %231, align 4
-  %.fca.0.extract.i825.8 = extractvalue { i1, i64, i1 } %232, 0
-  %.fca.1.extract.i826.8 = extractvalue { i1, i64, i1 } %232, 1
-  br i1 %.fca.0.extract.i825.8, label %cond_300_case_1.i.8, label %cond_300_case_0.i.8
+  %225 = getelementptr inbounds i8, i8* %187, i64 7
+  %226 = bitcast i8* %225 to i1*
+  store i1 %"03.0.i.7", i1* %226, align 1
+  %227 = getelementptr inbounds i8, i8* %84, i64 192
+  %228 = bitcast i8* %227 to { i1, i64, i1 }*
+  %229 = load { i1, i64, i1 }, { i1, i64, i1 }* %228, align 4
+  %.fca.0.extract.i899.8 = extractvalue { i1, i64, i1 } %229, 0
+  %.fca.1.extract.i900.8 = extractvalue { i1, i64, i1 } %229, 1
+  br i1 %.fca.0.extract.i899.8, label %cond_300_case_1.i.8, label %cond_300_case_0.i.8
 
 cond_300_case_0.i.8:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.7
-  %.fca.2.extract.i.8 = extractvalue { i1, i64, i1 } %232, 2
+  %.fca.2.extract.i.8 = extractvalue { i1, i64, i1 } %229, 2
   br label %__hugr__.array.__read_bool.3.271.exit.8
 
 cond_300_case_1.i.8:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.7
-  %read_bool.i.8 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.8)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.8)
+  %read_bool.i.8 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.8)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.8)
   br label %__hugr__.array.__read_bool.3.271.exit.8
 
 __hugr__.array.__read_bool.3.271.exit.8:          ; preds = %cond_300_case_1.i.8, %cond_300_case_0.i.8
   %"03.0.i.8" = phi i1 [ %read_bool.i.8, %cond_300_case_1.i.8 ], [ %.fca.2.extract.i.8, %cond_300_case_0.i.8 ]
-  %233 = getelementptr inbounds i8, i8* %190, i64 8
-  %234 = bitcast i8* %233 to i1*
-  store i1 %"03.0.i.8", i1* %234, align 1
-  %235 = getelementptr inbounds i8, i8* %84, i64 216
-  %236 = bitcast i8* %235 to { i1, i64, i1 }*
-  %237 = load { i1, i64, i1 }, { i1, i64, i1 }* %236, align 4
-  %.fca.0.extract.i825.9 = extractvalue { i1, i64, i1 } %237, 0
-  %.fca.1.extract.i826.9 = extractvalue { i1, i64, i1 } %237, 1
-  br i1 %.fca.0.extract.i825.9, label %cond_300_case_1.i.9, label %cond_300_case_0.i.9
+  %230 = getelementptr inbounds i8, i8* %187, i64 8
+  %231 = bitcast i8* %230 to i1*
+  store i1 %"03.0.i.8", i1* %231, align 1
+  %232 = getelementptr inbounds i8, i8* %84, i64 216
+  %233 = bitcast i8* %232 to { i1, i64, i1 }*
+  %234 = load { i1, i64, i1 }, { i1, i64, i1 }* %233, align 4
+  %.fca.0.extract.i899.9 = extractvalue { i1, i64, i1 } %234, 0
+  %.fca.1.extract.i900.9 = extractvalue { i1, i64, i1 } %234, 1
+  br i1 %.fca.0.extract.i899.9, label %cond_300_case_1.i.9, label %cond_300_case_0.i.9
 
 cond_300_case_0.i.9:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.8
-  %.fca.2.extract.i.9 = extractvalue { i1, i64, i1 } %237, 2
+  %.fca.2.extract.i.9 = extractvalue { i1, i64, i1 } %234, 2
   br label %__hugr__.array.__read_bool.3.271.exit.9
 
 cond_300_case_1.i.9:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.8
-  %read_bool.i.9 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.9)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.9)
+  %read_bool.i.9 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.9)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.9)
   br label %__hugr__.array.__read_bool.3.271.exit.9
 
 __hugr__.array.__read_bool.3.271.exit.9:          ; preds = %cond_300_case_1.i.9, %cond_300_case_0.i.9
   %"03.0.i.9" = phi i1 [ %read_bool.i.9, %cond_300_case_1.i.9 ], [ %.fca.2.extract.i.9, %cond_300_case_0.i.9 ]
-  %238 = getelementptr inbounds i8, i8* %190, i64 9
-  %239 = bitcast i8* %238 to i1*
-  store i1 %"03.0.i.9", i1* %239, align 1
+  %235 = getelementptr inbounds i8, i8* %187, i64 9
+  %236 = bitcast i8* %235 to i1*
+  store i1 %"03.0.i.9", i1* %236, align 1
   tail call void @heap_free(i8* nonnull %84)
   tail call void @heap_free(i8* nonnull %86)
-  %240 = load i64, i64* %192, align 4
-  %241 = and i64 %240, 1023
-  store i64 %241, i64* %192, align 4
-  %242 = icmp eq i64 %241, 0
-  br i1 %242, label %__barray_check_none_borrowed.exit831, label %mask_block_err.i830
+  %237 = load i64, i64* %189, align 4
+  %238 = and i64 %237, 1023
+  store i64 %238, i64* %189, align 4
+  %239 = icmp eq i64 %238, 0
+  br i1 %239, label %__barray_check_none_borrowed.exit905, label %mask_block_err.i904
 
-__barray_check_none_borrowed.exit831:             ; preds = %__hugr__.array.__read_bool.3.271.exit.9
+__barray_check_none_borrowed.exit905:             ; preds = %__hugr__.array.__read_bool.3.271.exit.9
   %out_arr_alloca = alloca <{ i32, i32, i1*, i1* }>, align 8
   %x_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 0
   %y_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 1
   %arr_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 2
   %mask_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 3
-  %243 = alloca [10 x i1], align 1
-  %.sub = getelementptr inbounds [10 x i1], [10 x i1]* %243, i64 0, i64 0
-  %244 = bitcast [10 x i1]* %243 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(10) %244, i8 0, i64 10, i1 false)
+  %240 = alloca [10 x i1], align 1
+  %.sub = getelementptr inbounds [10 x i1], [10 x i1]* %240, i64 0, i64 0
+  %241 = bitcast [10 x i1]* %240 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(10) %241, i8 0, i64 10, i1 false)
   store i32 10, i32* %x_ptr, align 8
   store i32 1, i32* %y_ptr, align 4
-  %245 = bitcast i1** %arr_ptr to i8**
-  store i8* %190, i8** %245, align 8
+  %242 = bitcast i1** %arr_ptr to i8**
+  store i8* %187, i8** %242, align 8
   store i1* %.sub, i1** %mask_ptr, align 8
   call void @print_bool_arr(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @res_cs.46C3C4B5.0, i64 0, i64 0), i64 15, <{ i32, i32, i1*, i1* }>* nonnull %out_arr_alloca)
-  br label %__barray_check_bounds.exit839
+  br label %__barray_check_bounds.exit913
 
-mask_block_err.i830:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.9
+mask_block_err.i904:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.9
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit839:                    ; preds = %cond_exit_95.1, %__barray_check_none_borrowed.exit831
-  %"90_0.sroa.0.0899" = phi i64 [ 0, %__barray_check_none_borrowed.exit831 ], [ %255, %cond_exit_95.1 ]
-  %246 = or i64 %"90_0.sroa.0.0899", 1
-  %247 = lshr i64 %"90_0.sroa.0.0899", 6
-  %248 = getelementptr inbounds i64, i64* %7, i64 %247
-  %249 = load i64, i64* %248, align 4
-  %250 = and i64 %"90_0.sroa.0.0899", 62
-  %251 = shl nuw i64 1, %250
-  %252 = and i64 %249, %251
-  %.not.i840 = icmp eq i64 %252, 0
-  br i1 %.not.i840, label %panic.i841, label %cond_exit_95
+__barray_check_bounds.exit913:                    ; preds = %cond_exit_95.1, %__barray_check_none_borrowed.exit905
+  %"90_0.sroa.0.0972" = phi i64 [ 0, %__barray_check_none_borrowed.exit905 ], [ %252, %cond_exit_95.1 ]
+  %243 = or i64 %"90_0.sroa.0.0972", 1
+  %244 = lshr i64 %"90_0.sroa.0.0972", 6
+  %245 = getelementptr inbounds i64, i64* %7, i64 %244
+  %246 = load i64, i64* %245, align 4
+  %247 = and i64 %"90_0.sroa.0.0972", 62
+  %248 = shl nuw i64 1, %247
+  %249 = and i64 %246, %248
+  %.not.i914 = icmp eq i64 %249, 0
+  br i1 %.not.i914, label %panic.i915, label %cond_exit_95
 
-panic.i841:                                       ; preds = %cond_exit_95, %__barray_check_bounds.exit839
+panic.i915:                                       ; preds = %cond_exit_95, %__barray_check_bounds.exit913
   call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-cond_exit_95:                                     ; preds = %__barray_check_bounds.exit839
-  %253 = xor i64 %249, %251
-  store i64 %253, i64* %248, align 4
-  %254 = getelementptr inbounds i64, i64* %5, i64 %"90_0.sroa.0.0899"
-  store i64 %"90_0.sroa.0.0899", i64* %254, align 4
-  %255 = add nuw nsw i64 %"90_0.sroa.0.0899", 2
-  %256 = lshr i64 %"90_0.sroa.0.0899", 6
-  %257 = getelementptr inbounds i64, i64* %7, i64 %256
-  %258 = load i64, i64* %257, align 4
-  %259 = and i64 %246, 63
-  %260 = shl nuw i64 1, %259
-  %261 = and i64 %258, %260
-  %.not.i840.1 = icmp eq i64 %261, 0
-  br i1 %.not.i840.1, label %panic.i841, label %cond_exit_95.1
+cond_exit_95:                                     ; preds = %__barray_check_bounds.exit913
+  %250 = xor i64 %246, %248
+  store i64 %250, i64* %245, align 4
+  %251 = getelementptr inbounds i64, i64* %5, i64 %"90_0.sroa.0.0972"
+  store i64 %"90_0.sroa.0.0972", i64* %251, align 4
+  %252 = add nuw nsw i64 %"90_0.sroa.0.0972", 2
+  %253 = lshr i64 %"90_0.sroa.0.0972", 6
+  %254 = getelementptr inbounds i64, i64* %7, i64 %253
+  %255 = load i64, i64* %254, align 4
+  %256 = and i64 %243, 63
+  %257 = shl nuw i64 1, %256
+  %258 = and i64 %255, %257
+  %.not.i914.1 = icmp eq i64 %258, 0
+  br i1 %.not.i914.1, label %panic.i915, label %cond_exit_95.1
 
 cond_exit_95.1:                                   ; preds = %cond_exit_95
-  %262 = xor i64 %258, %260
-  store i64 %262, i64* %257, align 4
-  %263 = getelementptr inbounds i64, i64* %5, i64 %246
-  store i64 %246, i64* %263, align 4
-  %exitcond911.not.1 = icmp eq i64 %255, 100
-  br i1 %exitcond911.not.1, label %loop_out164, label %__barray_check_bounds.exit839
+  %259 = xor i64 %255, %257
+  store i64 %259, i64* %254, align 4
+  %260 = getelementptr inbounds i64, i64* %5, i64 %243
+  store i64 %243, i64* %260, align 4
+  %exitcond983.not.1 = icmp eq i64 %252, 100
+  br i1 %exitcond983.not.1, label %loop_out212, label %__barray_check_bounds.exit913
 
-loop_out164:                                      ; preds = %cond_exit_95.1
-  %264 = getelementptr inbounds i8, i8* %6, i64 8
-  %265 = bitcast i8* %264 to i64*
-  %266 = load i64, i64* %265, align 4
-  %267 = and i64 %266, 68719476735
-  store i64 %267, i64* %265, align 4
-  %268 = load i64, i64* %7, align 4
-  %269 = icmp eq i64 %268, 0
-  %270 = icmp eq i64 %267, 0
-  %or.cond = select i1 %269, i1 %270, i1 false
-  br i1 %or.cond, label %__barray_check_none_borrowed.exit847, label %mask_block_err.i846
+loop_out212:                                      ; preds = %cond_exit_95.1
+  %261 = getelementptr inbounds i8, i8* %6, i64 8
+  %262 = bitcast i8* %261 to i64*
+  %263 = load i64, i64* %262, align 4
+  %264 = and i64 %263, 68719476735
+  store i64 %264, i64* %262, align 4
+  %265 = load i64, i64* %7, align 4
+  %266 = icmp eq i64 %265, 0
+  %267 = icmp eq i64 %264, 0
+  %or.cond = select i1 %266, i1 %267, i1 false
+  br i1 %or.cond, label %__barray_check_none_borrowed.exit921, label %mask_block_err.i920
 
-__barray_check_none_borrowed.exit847:             ; preds = %loop_out164
-  %271 = call i8* @heap_alloc(i64 800)
-  %272 = bitcast i8* %271 to i64*
-  %273 = call i8* @heap_alloc(i64 16)
-  %274 = bitcast i8* %273 to i64*
-  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %274, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0i64.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(800) %272, i64* noundef nonnull align 1 dereferenceable(800) %5, i64 800, i1 false)
-  call void @heap_free(i8* %271)
-  %275 = load i64, i64* %265, align 4
-  %276 = and i64 %275, 68719476735
-  store i64 %276, i64* %265, align 4
-  %277 = load i64, i64* %7, align 4
-  %278 = icmp eq i64 %277, 0
-  %279 = icmp eq i64 %276, 0
-  %or.cond913 = select i1 %278, i1 %279, i1 false
-  br i1 %or.cond913, label %__barray_check_none_borrowed.exit852, label %mask_block_err.i851
+__barray_check_none_borrowed.exit921:             ; preds = %loop_out212
+  %268 = call i8* @heap_alloc(i64 800)
+  %269 = bitcast i8* %268 to i64*
+  %270 = call i8* @heap_alloc(i64 16)
+  %271 = bitcast i8* %270 to i64*
+  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %271, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0i64.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(800) %269, i64* noundef nonnull align 1 dereferenceable(800) %5, i64 800, i1 false)
+  call void @heap_free(i8* %268)
+  %272 = load i64, i64* %262, align 4
+  %273 = and i64 %272, 68719476735
+  store i64 %273, i64* %262, align 4
+  %274 = load i64, i64* %7, align 4
+  %275 = icmp eq i64 %274, 0
+  %276 = icmp eq i64 %273, 0
+  %or.cond986 = select i1 %275, i1 %276, i1 false
+  br i1 %or.cond986, label %__barray_check_none_borrowed.exit926, label %mask_block_err.i925
 
-mask_block_err.i846:                              ; preds = %loop_out164
+mask_block_err.i920:                              ; preds = %loop_out212
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit852:             ; preds = %__barray_check_none_borrowed.exit847
-  %out_arr_alloca239 = alloca <{ i32, i32, i64*, i1* }>, align 8
-  %x_ptr240 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 0
-  %y_ptr241 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 1
-  %arr_ptr242 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 2
-  %mask_ptr243 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 3
-  %280 = alloca [100 x i1], align 1
-  %.sub563 = getelementptr inbounds [100 x i1], [100 x i1]* %280, i64 0, i64 0
-  %281 = bitcast [100 x i1]* %280 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %281, i8 0, i64 100, i1 false)
-  store i32 100, i32* %x_ptr240, align 8
-  store i32 1, i32* %y_ptr241, align 4
-  %282 = bitcast i64** %arr_ptr242 to i8**
-  store i8* %4, i8** %282, align 8
-  store i1* %.sub563, i1** %mask_ptr243, align 8
-  call void @print_int_arr(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @res_is.F21393DB.0, i64 0, i64 0), i64 14, <{ i32, i32, i64*, i1* }>* nonnull %out_arr_alloca239)
-  br label %__barray_check_bounds.exit860
+__barray_check_none_borrowed.exit926:             ; preds = %__barray_check_none_borrowed.exit921
+  %out_arr_alloca287 = alloca <{ i32, i32, i64*, i1* }>, align 8
+  %x_ptr288 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 0
+  %y_ptr289 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 1
+  %arr_ptr290 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 2
+  %mask_ptr291 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 3
+  %277 = alloca [100 x i1], align 1
+  %.sub635 = getelementptr inbounds [100 x i1], [100 x i1]* %277, i64 0, i64 0
+  %278 = bitcast [100 x i1]* %277 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %278, i8 0, i64 100, i1 false)
+  store i32 100, i32* %x_ptr288, align 8
+  store i32 1, i32* %y_ptr289, align 4
+  %279 = bitcast i64** %arr_ptr290 to i8**
+  store i8* %4, i8** %279, align 8
+  store i1* %.sub635, i1** %mask_ptr291, align 8
+  call void @print_int_arr(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @res_is.F21393DB.0, i64 0, i64 0), i64 14, <{ i32, i32, i64*, i1* }>* nonnull %out_arr_alloca287)
+  br label %__barray_check_bounds.exit934
 
-mask_block_err.i851:                              ; preds = %__barray_check_none_borrowed.exit847
+mask_block_err.i925:                              ; preds = %__barray_check_none_borrowed.exit921
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit860:                    ; preds = %cond_exit_130, %__barray_check_none_borrowed.exit852
-  %"125_0.sroa.0.0901" = phi i64 [ 0, %__barray_check_none_borrowed.exit852 ], [ %283, %cond_exit_130 ]
-  %283 = add nuw nsw i64 %"125_0.sroa.0.0901", 1
-  %284 = lshr i64 %"125_0.sroa.0.0901", 6
-  %285 = getelementptr inbounds i64, i64* %3, i64 %284
-  %286 = load i64, i64* %285, align 4
-  %287 = and i64 %"125_0.sroa.0.0901", 63
-  %288 = shl nuw i64 1, %287
-  %289 = and i64 %286, %288
-  %.not.i861 = icmp eq i64 %289, 0
-  br i1 %.not.i861, label %panic.i862, label %cond_exit_130
+__barray_check_bounds.exit934:                    ; preds = %cond_exit_130, %__barray_check_none_borrowed.exit926
+  %"125_0.sroa.0.0974" = phi i64 [ 0, %__barray_check_none_borrowed.exit926 ], [ %280, %cond_exit_130 ]
+  %280 = add nuw nsw i64 %"125_0.sroa.0.0974", 1
+  %281 = lshr i64 %"125_0.sroa.0.0974", 6
+  %282 = getelementptr inbounds i64, i64* %3, i64 %281
+  %283 = load i64, i64* %282, align 4
+  %284 = and i64 %"125_0.sroa.0.0974", 63
+  %285 = shl nuw i64 1, %284
+  %286 = and i64 %283, %285
+  %.not.i935 = icmp eq i64 %286, 0
+  br i1 %.not.i935, label %panic.i936, label %cond_exit_130
 
-panic.i862:                                       ; preds = %__barray_check_bounds.exit860
+panic.i936:                                       ; preds = %__barray_check_bounds.exit934
   call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-cond_exit_130:                                    ; preds = %__barray_check_bounds.exit860
-  %290 = sitofp i64 %"125_0.sroa.0.0901" to double
-  %291 = fmul double %290, 6.250000e-02
-  %292 = xor i64 %286, %288
-  store i64 %292, i64* %285, align 4
-  %293 = getelementptr inbounds double, double* %1, i64 %"125_0.sroa.0.0901"
-  store double %291, double* %293, align 8
-  %exitcond912.not = icmp eq i64 %283, 100
-  br i1 %exitcond912.not, label %loop_out251, label %__barray_check_bounds.exit860
+cond_exit_130:                                    ; preds = %__barray_check_bounds.exit934
+  %287 = sitofp i64 %"125_0.sroa.0.0974" to double
+  %288 = fmul double %287, 6.250000e-02
+  %289 = xor i64 %283, %285
+  store i64 %289, i64* %282, align 4
+  %290 = getelementptr inbounds double, double* %1, i64 %"125_0.sroa.0.0974"
+  store double %288, double* %290, align 8
+  %exitcond984.not = icmp eq i64 %280, 100
+  br i1 %exitcond984.not, label %loop_out299, label %__barray_check_bounds.exit934
 
-loop_out251:                                      ; preds = %cond_exit_130
-  %294 = getelementptr inbounds i8, i8* %2, i64 8
-  %295 = bitcast i8* %294 to i64*
-  %296 = load i64, i64* %295, align 4
-  %297 = and i64 %296, 68719476735
-  store i64 %297, i64* %295, align 4
-  %298 = load i64, i64* %3, align 4
-  %299 = icmp eq i64 %298, 0
-  %300 = icmp eq i64 %297, 0
-  %or.cond914 = select i1 %299, i1 %300, i1 false
-  br i1 %or.cond914, label %__barray_check_none_borrowed.exit868, label %mask_block_err.i867
+loop_out299:                                      ; preds = %cond_exit_130
+  %291 = getelementptr inbounds i8, i8* %2, i64 8
+  %292 = bitcast i8* %291 to i64*
+  %293 = load i64, i64* %292, align 4
+  %294 = and i64 %293, 68719476735
+  store i64 %294, i64* %292, align 4
+  %295 = load i64, i64* %3, align 4
+  %296 = icmp eq i64 %295, 0
+  %297 = icmp eq i64 %294, 0
+  %or.cond987 = select i1 %296, i1 %297, i1 false
+  br i1 %or.cond987, label %__barray_check_none_borrowed.exit942, label %mask_block_err.i941
 
-__barray_check_none_borrowed.exit868:             ; preds = %loop_out251
-  %301 = call i8* @heap_alloc(i64 800)
-  %302 = bitcast i8* %301 to double*
-  %303 = call i8* @heap_alloc(i64 16)
-  %304 = bitcast i8* %303 to i64*
-  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %304, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0f64.p0f64.i64(double* noundef nonnull align 1 dereferenceable(800) %302, double* noundef nonnull align 1 dereferenceable(800) %1, i64 800, i1 false)
-  call void @heap_free(i8* %301)
-  %305 = load i64, i64* %295, align 4
-  %306 = and i64 %305, 68719476735
-  store i64 %306, i64* %295, align 4
-  %307 = load i64, i64* %3, align 4
-  %308 = icmp eq i64 %307, 0
-  %309 = icmp eq i64 %306, 0
-  %or.cond915 = select i1 %308, i1 %309, i1 false
-  br i1 %or.cond915, label %__barray_check_none_borrowed.exit873, label %mask_block_err.i872
+__barray_check_none_borrowed.exit942:             ; preds = %loop_out299
+  %298 = call i8* @heap_alloc(i64 800)
+  %299 = bitcast i8* %298 to double*
+  %300 = call i8* @heap_alloc(i64 16)
+  %301 = bitcast i8* %300 to i64*
+  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %301, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0f64.p0f64.i64(double* noundef nonnull align 1 dereferenceable(800) %299, double* noundef nonnull align 1 dereferenceable(800) %1, i64 800, i1 false)
+  call void @heap_free(i8* %298)
+  %302 = load i64, i64* %292, align 4
+  %303 = and i64 %302, 68719476735
+  store i64 %303, i64* %292, align 4
+  %304 = load i64, i64* %3, align 4
+  %305 = icmp eq i64 %304, 0
+  %306 = icmp eq i64 %303, 0
+  %or.cond988 = select i1 %305, i1 %306, i1 false
+  br i1 %or.cond988, label %__barray_check_none_borrowed.exit947, label %mask_block_err.i946
 
-mask_block_err.i867:                              ; preds = %loop_out251
+mask_block_err.i941:                              ; preds = %loop_out299
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit873:             ; preds = %__barray_check_none_borrowed.exit868
-  %out_arr_alloca329 = alloca <{ i32, i32, double*, i1* }>, align 8
-  %x_ptr330 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 0
-  %y_ptr331 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 1
-  %arr_ptr332 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 2
-  %mask_ptr333 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 3
-  %310 = alloca [100 x i1], align 1
-  %.sub664 = getelementptr inbounds [100 x i1], [100 x i1]* %310, i64 0, i64 0
-  %311 = bitcast [100 x i1]* %310 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %311, i8 0, i64 100, i1 false)
-  store i32 100, i32* %x_ptr330, align 8
-  store i32 1, i32* %y_ptr331, align 4
-  %312 = bitcast double** %arr_ptr332 to i8**
-  store i8* %0, i8** %312, align 8
-  store i1* %.sub664, i1** %mask_ptr333, align 8
-  call void @print_float_arr(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @res_fs.CBD4AF54.0, i64 0, i64 0), i64 16, <{ i32, i32, double*, i1* }>* nonnull %out_arr_alloca329)
+__barray_check_none_borrowed.exit947:             ; preds = %__barray_check_none_borrowed.exit942
+  %out_arr_alloca377 = alloca <{ i32, i32, double*, i1* }>, align 8
+  %x_ptr378 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 0
+  %y_ptr379 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 1
+  %arr_ptr380 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 2
+  %mask_ptr381 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 3
+  %307 = alloca [100 x i1], align 1
+  %.sub736 = getelementptr inbounds [100 x i1], [100 x i1]* %307, i64 0, i64 0
+  %308 = bitcast [100 x i1]* %307 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %308, i8 0, i64 100, i1 false)
+  store i32 100, i32* %x_ptr378, align 8
+  store i32 1, i32* %y_ptr379, align 4
+  %309 = bitcast double** %arr_ptr380 to i8**
+  store i8* %0, i8** %309, align 8
+  store i1* %.sub736, i1** %mask_ptr381, align 8
+  call void @print_float_arr(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @res_fs.CBD4AF54.0, i64 0, i64 0), i64 16, <{ i32, i32, double*, i1* }>* nonnull %out_arr_alloca377)
   ret void
 
-mask_block_err.i872:                              ; preds = %__barray_check_none_borrowed.exit868
+mask_block_err.i946:                              ; preds = %__barray_check_none_borrowed.exit942
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 }
@@ -1022,6 +948,8 @@ declare void @panic(i32, i8*) local_unnamed_addr #1
 
 declare void @heap_free(i8*) local_unnamed_addr
 
+declare void @___dec_future_refcount(i64) local_unnamed_addr
+
 declare void @print_bool_arr(i8*, i64, <{ i32, i32, i1*, i1* }>*) local_unnamed_addr
 
 ; Function Attrs: argmemonly mustprogress nofree nounwind willreturn
@@ -1035,8 +963,6 @@ declare void @llvm.memcpy.p0f64.p0f64.i64(double* noalias nocapture writeonly, d
 declare void @print_float_arr(i8*, i64, <{ i32, i32, double*, i1* }>*) local_unnamed_addr
 
 declare i1 @___read_future_bool(i64) local_unnamed_addr
-
-declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 declare i64 @___lazy_measure(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_print_array/x86_64-unknown-linux-gnu/print_array_x86_64-unknown-linux-gnu
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_print_array/x86_64-unknown-linux-gnu/print_array_x86_64-unknown-linux-gnu
@@ -6,10 +6,10 @@ target triple = "x86_64-unknown-linux-gnu"
 @"e_Array alre.5A300C2A.0" = private constant [57 x i8] c"8EXIT:INT:Array already contains an element at this index"
 @"e_Array elem.E746B1A3.0" = private constant [43 x i8] c"*EXIT:INT:Array element is already borrowed"
 @"e_Some array.A77EF32E.0" = private constant [48 x i8] c"/EXIT:INT:Some array elements have been borrowed"
+@"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @res_cs.46C3C4B5.0 = private constant [16 x i8] c"\0FUSER:BOOLARR:cs"
 @res_is.F21393DB.0 = private constant [15 x i8] c"\0EUSER:INTARR:is"
 @res_fs.CBD4AF54.0 = private constant [17 x i8] c"\10USER:FLOATARR:fs"
-@"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @"e_No more qu.3B2EEBF0.0" = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
 @"e_Expected v.E6312129.0" = private constant [46 x i8] c"-EXIT:INT:Expected variant 1 but got variant 0"
 @"e_Expected v.2F17E0A9.0" = private constant [46 x i8] c"-EXIT:INT:Expected variant 0 but got variant 1"
@@ -34,8 +34,8 @@ alloca_block:
   br label %cond_20_case_1
 
 cond_20_case_1:                                   ; preds = %alloca_block, %cond_exit_20
-  %"15_0.sroa.0.0887" = phi i64 [ 0, %alloca_block ], [ %12, %cond_exit_20 ]
-  %12 = add nuw nsw i64 %"15_0.sroa.0.0887", 1
+  %"15_0.sroa.0.0961" = phi i64 [ 0, %alloca_block ], [ %12, %cond_exit_20 ]
+  %12 = add nuw nsw i64 %"15_0.sroa.0.0961", 1
   %qalloc.i = tail call i64 @___qalloc()
   %not_max.not.i = icmp eq i64 %qalloc.i, -1
   br i1 %not_max.not.i, label %id_bb.i, label %reset_bb.i
@@ -55,10 +55,10 @@ cond_303_case_0.i:                                ; preds = %id_bb.i
   unreachable
 
 __barray_check_bounds.exit:                       ; preds = %id_bb.i
-  %15 = lshr i64 %"15_0.sroa.0.0887", 6
+  %15 = lshr i64 %"15_0.sroa.0.0961", 6
   %16 = getelementptr inbounds i64, i64* %11, i64 %15
   %17 = load i64, i64* %16, align 4
-  %18 = shl nuw nsw i64 1, %"15_0.sroa.0.0887"
+  %18 = shl nuw nsw i64 1, %"15_0.sroa.0.0961"
   %19 = and i64 %17, %18
   %.not.i = icmp eq i64 %19, 0
   br i1 %.not.i, label %panic.i, label %cond_exit_20
@@ -71,7 +71,7 @@ cond_exit_20:                                     ; preds = %__barray_check_boun
   %.fca.1.extract.i = extractvalue { i1, i64 } %14, 1
   %20 = xor i64 %17, %18
   store i64 %20, i64* %16, align 4
-  %21 = getelementptr inbounds i64, i64* %9, i64 %"15_0.sroa.0.0887"
+  %21 = getelementptr inbounds i64, i64* %9, i64 %"15_0.sroa.0.0961"
   store i64 %.fca.1.extract.i, i64* %21, align 4
   %exitcond.not = icmp eq i64 %12, 10
   br i1 %exitcond.not, label %loop_out, label %cond_20_case_1
@@ -79,10 +79,10 @@ cond_exit_20:                                     ; preds = %__barray_check_boun
 loop_out:                                         ; preds = %cond_exit_20
   %22 = load i64, i64* %11, align 4
   %23 = and i64 %22, 1
-  %.not.i781 = icmp eq i64 %23, 0
-  br i1 %.not.i781, label %__barray_mask_borrow.exit, label %panic.i782
+  %.not.i852 = icmp eq i64 %23, 0
+  br i1 %.not.i852, label %__barray_mask_borrow.exit, label %panic.i853
 
-panic.i782:                                       ; preds = %loop_out
+panic.i853:                                       ; preds = %loop_out
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
@@ -93,27 +93,27 @@ __barray_mask_borrow.exit:                        ; preds = %loop_out
   tail call void @___rxy(i64 %25, double 0x400921FB54442D18, double 0.000000e+00)
   %26 = load i64, i64* %11, align 4
   %27 = and i64 %26, 1
-  %.not.i783 = icmp eq i64 %27, 0
-  br i1 %.not.i783, label %panic.i784, label %__barray_mask_return.exit785
+  %.not.i854 = icmp eq i64 %27, 0
+  br i1 %.not.i854, label %panic.i855, label %__barray_mask_return.exit856
 
-panic.i784:                                       ; preds = %__barray_mask_borrow.exit
+panic.i855:                                       ; preds = %__barray_mask_borrow.exit
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit785:                     ; preds = %__barray_mask_borrow.exit
+__barray_mask_return.exit856:                     ; preds = %__barray_mask_borrow.exit
   %28 = xor i64 %26, 1
   store i64 %28, i64* %11, align 4
   store i64 %25, i64* %9, align 4
   %29 = load i64, i64* %11, align 4
   %30 = and i64 %29, 4
-  %.not.i786 = icmp eq i64 %30, 0
-  br i1 %.not.i786, label %__barray_mask_borrow.exit788, label %panic.i787
+  %.not.i857 = icmp eq i64 %30, 0
+  br i1 %.not.i857, label %__barray_mask_borrow.exit859, label %panic.i858
 
-panic.i787:                                       ; preds = %__barray_mask_return.exit785
+panic.i858:                                       ; preds = %__barray_mask_return.exit856
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit788:                     ; preds = %__barray_mask_return.exit785
+__barray_mask_borrow.exit859:                     ; preds = %__barray_mask_return.exit856
   %31 = xor i64 %29, 4
   store i64 %31, i64* %11, align 4
   %32 = getelementptr inbounds i8, i8* %8, i64 16
@@ -122,27 +122,27 @@ __barray_mask_borrow.exit788:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %34, double 0x400921FB54442D18, double 0.000000e+00)
   %35 = load i64, i64* %11, align 4
   %36 = and i64 %35, 4
-  %.not.i789 = icmp eq i64 %36, 0
-  br i1 %.not.i789, label %panic.i790, label %__barray_mask_return.exit791
+  %.not.i860 = icmp eq i64 %36, 0
+  br i1 %.not.i860, label %panic.i861, label %__barray_mask_return.exit862
 
-panic.i790:                                       ; preds = %__barray_mask_borrow.exit788
+panic.i861:                                       ; preds = %__barray_mask_borrow.exit859
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit791:                     ; preds = %__barray_mask_borrow.exit788
+__barray_mask_return.exit862:                     ; preds = %__barray_mask_borrow.exit859
   %37 = xor i64 %35, 4
   store i64 %37, i64* %11, align 4
   store i64 %34, i64* %33, align 4
   %38 = load i64, i64* %11, align 4
   %39 = and i64 %38, 8
-  %.not.i792 = icmp eq i64 %39, 0
-  br i1 %.not.i792, label %__barray_mask_borrow.exit794, label %panic.i793
+  %.not.i863 = icmp eq i64 %39, 0
+  br i1 %.not.i863, label %__barray_mask_borrow.exit865, label %panic.i864
 
-panic.i793:                                       ; preds = %__barray_mask_return.exit791
+panic.i864:                                       ; preds = %__barray_mask_return.exit862
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit794:                     ; preds = %__barray_mask_return.exit791
+__barray_mask_borrow.exit865:                     ; preds = %__barray_mask_return.exit862
   %40 = xor i64 %38, 8
   store i64 %40, i64* %11, align 4
   %41 = getelementptr inbounds i8, i8* %8, i64 24
@@ -151,27 +151,27 @@ __barray_mask_borrow.exit794:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %43, double 0x400921FB54442D18, double 0.000000e+00)
   %44 = load i64, i64* %11, align 4
   %45 = and i64 %44, 8
-  %.not.i795 = icmp eq i64 %45, 0
-  br i1 %.not.i795, label %panic.i796, label %__barray_mask_return.exit797
+  %.not.i866 = icmp eq i64 %45, 0
+  br i1 %.not.i866, label %panic.i867, label %__barray_mask_return.exit868
 
-panic.i796:                                       ; preds = %__barray_mask_borrow.exit794
+panic.i867:                                       ; preds = %__barray_mask_borrow.exit865
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit797:                     ; preds = %__barray_mask_borrow.exit794
+__barray_mask_return.exit868:                     ; preds = %__barray_mask_borrow.exit865
   %46 = xor i64 %44, 8
   store i64 %46, i64* %11, align 4
   store i64 %43, i64* %42, align 4
   %47 = load i64, i64* %11, align 4
   %48 = and i64 %47, 512
-  %.not.i798 = icmp eq i64 %48, 0
-  br i1 %.not.i798, label %__barray_mask_borrow.exit800, label %panic.i799
+  %.not.i869 = icmp eq i64 %48, 0
+  br i1 %.not.i869, label %__barray_mask_borrow.exit871, label %panic.i870
 
-panic.i799:                                       ; preds = %__barray_mask_return.exit797
+panic.i870:                                       ; preds = %__barray_mask_return.exit868
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit800:                     ; preds = %__barray_mask_return.exit797
+__barray_mask_borrow.exit871:                     ; preds = %__barray_mask_return.exit868
   %49 = xor i64 %47, 512
   store i64 %49, i64* %11, align 4
   %50 = getelementptr inbounds i8, i8* %8, i64 72
@@ -180,14 +180,14 @@ __barray_mask_borrow.exit800:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %52, double 0x400921FB54442D18, double 0.000000e+00)
   %53 = load i64, i64* %11, align 4
   %54 = and i64 %53, 512
-  %.not.i801 = icmp eq i64 %54, 0
-  br i1 %.not.i801, label %panic.i802, label %__barray_mask_return.exit803
+  %.not.i872 = icmp eq i64 %54, 0
+  br i1 %.not.i872, label %panic.i873, label %__barray_mask_return.exit874
 
-panic.i802:                                       ; preds = %__barray_mask_borrow.exit800
+panic.i873:                                       ; preds = %__barray_mask_borrow.exit871
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit803:                     ; preds = %__barray_mask_borrow.exit800
+__barray_mask_return.exit874:                     ; preds = %__barray_mask_borrow.exit871
   %55 = xor i64 %53, 512
   store i64 %55, i64* %11, align 4
   store i64 %52, i64* %51, align 4
@@ -223,13 +223,13 @@ mask_block_err.i.i.i:                             ; preds = %mask_block_ok.i.i.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-69:                                               ; preds = %__barray_mask_return.exit803, %cond_exit_443.i
-  %"393_0.sroa.15.0.i889" = phi i64 [ 0, %__barray_mask_return.exit803 ], [ %70, %cond_exit_443.i ]
-  %70 = add nuw nsw i64 %"393_0.sroa.15.0.i889", 1
-  %71 = lshr i64 %"393_0.sroa.15.0.i889", 6
+69:                                               ; preds = %__barray_mask_return.exit874, %cond_exit_443.i
+  %"393_0.sroa.15.0.i963" = phi i64 [ 0, %__barray_mask_return.exit874 ], [ %70, %cond_exit_443.i ]
+  %70 = add nuw nsw i64 %"393_0.sroa.15.0.i963", 1
+  %71 = lshr i64 %"393_0.sroa.15.0.i963", 6
   %72 = getelementptr inbounds i64, i64* %11, i64 %71
   %73 = load i64, i64* %72, align 4
-  %74 = shl nuw nsw i64 1, %"393_0.sroa.15.0.i889"
+  %74 = shl nuw nsw i64 1, %"393_0.sroa.15.0.i963"
   %75 = and i64 %73, %74
   %.not.i99.i.i = icmp eq i64 %75, 0
   br i1 %.not.i99.i.i, label %__barray_check_bounds.exit.i, label %panic.i.i.i
@@ -241,7 +241,7 @@ panic.i.i.i:                                      ; preds = %69
 __barray_check_bounds.exit.i:                     ; preds = %69
   %76 = xor i64 %73, %74
   store i64 %76, i64* %72, align 4
-  %77 = getelementptr inbounds i64, i64* %9, i64 %"393_0.sroa.15.0.i889"
+  %77 = getelementptr inbounds i64, i64* %9, i64 %"393_0.sroa.15.0.i963"
   %78 = load i64, i64* %77, align 4
   %lazy_measure.i = tail call i64 @___lazy_measure(i64 %78)
   tail call void @___qfree(i64 %78)
@@ -259,10 +259,10 @@ cond_exit_443.i:                                  ; preds = %__barray_check_boun
   %"457_054.fca.1.insert.i" = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %lazy_measure.i, 1
   %82 = xor i64 %80, %74
   store i64 %82, i64* %79, align 4
-  %83 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %"393_0.sroa.15.0.i889"
+  %83 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %"393_0.sroa.15.0.i963"
   store { i1, i64, i1 } %"457_054.fca.1.insert.i", { i1, i64, i1 }* %83, align 4
-  %exitcond906.not = icmp eq i64 %70, 10
-  br i1 %exitcond906.not, label %mask_block_ok.i.i.i, label %69
+  %exitcond979.not = icmp eq i64 %70, 10
+  br i1 %exitcond979.not, label %mask_block_ok.i.i.i, label %69
 
 __barray_check_none_borrowed.exit:                ; preds = %"__hugr__.$measure_array$$n(10).367.exit"
   %84 = tail call i8* @heap_alloc(i64 240)
@@ -278,77 +278,77 @@ mask_block_err.i:                                 ; preds = %"__hugr__.$measure_
   unreachable
 
 89:                                               ; preds = %__barray_check_none_borrowed.exit, %__hugr__.const_fun_290.309.exit
-  %storemerge779894 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %107, %__hugr__.const_fun_290.309.exit ]
+  %storemerge850968 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %107, %__hugr__.const_fun_290.309.exit ]
   %90 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %105, %__hugr__.const_fun_290.309.exit ]
-  %91 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %storemerge779894
+  %91 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %storemerge850968
   %92 = load { i1, i64, i1 }, { i1, i64, i1 }* %91, align 4
   %.fca.0.extract118.i = extractvalue { i1, i64, i1 } %92, 0
   %.fca.1.extract119.i = extractvalue { i1, i64, i1 } %92, 1
-  br i1 %.fca.0.extract118.i, label %cond_485_case_1.i, label %cond_exit_485.i
+  br i1 %.fca.0.extract118.i, label %cond_525_case_1.i, label %cond_exit_525.i
 
-cond_485_case_1.i:                                ; preds = %89
+cond_525_case_1.i:                                ; preds = %89
   tail call void @___inc_future_refcount(i64 %.fca.1.extract119.i)
   %93 = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %.fca.1.extract119.i, 1
-  br label %cond_exit_485.i
+  br label %cond_exit_525.i
 
-cond_exit_485.i:                                  ; preds = %cond_485_case_1.i, %89
-  %.pn.i = phi { i1, i64, i1 } [ %93, %cond_485_case_1.i ], [ %92, %89 ]
+cond_exit_525.i:                                  ; preds = %cond_525_case_1.i, %89
+  %.pn.i = phi { i1, i64, i1 } [ %93, %cond_525_case_1.i ], [ %92, %89 ]
   %"04.sroa.6.0.i" = extractvalue { i1, i64, i1 } %.pn.i, 2
   %94 = icmp ult i64 %90, 10
-  br i1 %94, label %95, label %cond_488_case_0.i
+  br i1 %94, label %95, label %cond_528_case_0.i
 
-95:                                               ; preds = %cond_exit_485.i
+95:                                               ; preds = %cond_exit_525.i
   %96 = lshr i64 %90, 6
   %97 = getelementptr inbounds i64, i64* %65, i64 %96
   %98 = load i64, i64* %97, align 4
   %99 = shl nuw nsw i64 1, %90
   %100 = and i64 %98, %99
-  %.not.i.i805 = icmp eq i64 %100, 0
-  br i1 %.not.i.i805, label %cond_488_case_1.i, label %panic.i.i806
+  %.not.i.i876 = icmp eq i64 %100, 0
+  br i1 %.not.i.i876, label %cond_528_case_1.i, label %panic.i.i877
 
-panic.i.i806:                                     ; preds = %95
+panic.i.i877:                                     ; preds = %95
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-cond_488_case_0.i:                                ; preds = %cond_exit_485.i
+cond_528_case_0.i:                                ; preds = %cond_exit_525.i
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.E6312129.0", i64 0, i64 0))
   unreachable
 
-cond_488_case_1.i:                                ; preds = %95
+cond_528_case_1.i:                                ; preds = %95
   %"17.fca.2.insert.i" = insertvalue { i1, i64, i1 } %92, i1 %"04.sroa.6.0.i", 2
   %101 = insertvalue { i1, { i1, i64, i1 } } { i1 true, { i1, i64, i1 } poison }, { i1, i64, i1 } %"17.fca.2.insert.i", 1
   %102 = getelementptr inbounds { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %88, i64 %90
   %103 = getelementptr inbounds { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %102, i64 0, i32 0
   %104 = load i1, i1* %103, align 1
   store { i1, { i1, i64, i1 } } %101, { i1, { i1, i64, i1 } }* %102, align 4
-  br i1 %104, label %cond_489_case_1.i, label %__hugr__.const_fun_290.309.exit
+  br i1 %104, label %cond_529_case_1.i, label %__hugr__.const_fun_290.309.exit
 
-cond_489_case_1.i:                                ; preds = %cond_488_case_1.i
+cond_529_case_1.i:                                ; preds = %cond_528_case_1.i
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.2F17E0A9.0", i64 0, i64 0))
   unreachable
 
-__hugr__.const_fun_290.309.exit:                  ; preds = %cond_488_case_1.i
+__hugr__.const_fun_290.309.exit:                  ; preds = %cond_528_case_1.i
   %105 = add nuw nsw i64 %90, 1
-  %106 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %85, i64 %storemerge779894
+  %106 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %85, i64 %storemerge850968
   store { i1, i64, i1 } %"17.fca.2.insert.i", { i1, i64, i1 }* %106, align 4
-  %107 = add nuw nsw i64 %storemerge779894, 1
-  %exitcond907.not = icmp eq i64 %107, 10
-  br i1 %exitcond907.not, label %mask_block_ok.i810, label %89
+  %107 = add nuw nsw i64 %storemerge850968, 1
+  %exitcond980.not = icmp eq i64 %107, 10
+  br i1 %exitcond980.not, label %mask_block_ok.i881, label %89
 
-mask_block_ok.i810:                               ; preds = %__hugr__.const_fun_290.309.exit
+mask_block_ok.i881:                               ; preds = %__hugr__.const_fun_290.309.exit
   tail call void @heap_free(i8* nonnull %56)
   tail call void @heap_free(i8* %58)
   %108 = load i64, i64* %65, align 4
   %109 = and i64 %108, 1023
   store i64 %109, i64* %65, align 4
   %110 = icmp eq i64 %109, 0
-  br i1 %110, label %__barray_check_none_borrowed.exit812, label %mask_block_err.i811
+  br i1 %110, label %__barray_check_none_borrowed.exit883, label %mask_block_err.i882
 
-mask_block_err.i811:                              ; preds = %mask_block_ok.i810
+mask_block_err.i882:                              ; preds = %mask_block_ok.i881
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit812:             ; preds = %mask_block_ok.i810
+__barray_check_none_borrowed.exit883:             ; preds = %mask_block_ok.i881
   %111 = tail call i8* @heap_alloc(i64 240)
   %112 = bitcast i8* %111 to { i1, i64, i1 }*
   %113 = tail call i8* @heap_alloc(i64 8)
@@ -356,20 +356,20 @@ __barray_check_none_borrowed.exit812:             ; preds = %mask_block_ok.i810
   store i64 0, i64* %114, align 1
   %115 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %88, align 4
   %.fca.0.extract11.i = extractvalue { i1, { i1, i64, i1 } } %115, 0
-  br i1 %.fca.0.extract11.i, label %__hugr__.const_fun_284.290.exit, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i, label %__hugr__.const_fun_284.290.exit, label %cond_570_case_0.i
 
-cond_530_case_0.i:                                ; preds = %__hugr__.const_fun_284.290.exit.8, %__hugr__.const_fun_284.290.exit.7, %__hugr__.const_fun_284.290.exit.6, %__hugr__.const_fun_284.290.exit.5, %__hugr__.const_fun_284.290.exit.4, %__hugr__.const_fun_284.290.exit.3, %__hugr__.const_fun_284.290.exit.2, %__hugr__.const_fun_284.290.exit.1, %__hugr__.const_fun_284.290.exit, %__barray_check_none_borrowed.exit812
+cond_570_case_0.i:                                ; preds = %__hugr__.const_fun_284.290.exit.8, %__hugr__.const_fun_284.290.exit.7, %__hugr__.const_fun_284.290.exit.6, %__hugr__.const_fun_284.290.exit.5, %__hugr__.const_fun_284.290.exit.4, %__hugr__.const_fun_284.290.exit.3, %__hugr__.const_fun_284.290.exit.2, %__hugr__.const_fun_284.290.exit.1, %__hugr__.const_fun_284.290.exit, %__barray_check_none_borrowed.exit883
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.E6312129.0", i64 0, i64 0))
   unreachable
 
-__hugr__.const_fun_284.290.exit:                  ; preds = %__barray_check_none_borrowed.exit812
+__hugr__.const_fun_284.290.exit:                  ; preds = %__barray_check_none_borrowed.exit883
   %116 = extractvalue { i1, { i1, i64, i1 } } %115, 1
   store { i1, i64, i1 } %116, { i1, i64, i1 }* %112, align 4
   %117 = getelementptr inbounds i8, i8* %63, i64 32
   %118 = bitcast i8* %117 to { i1, { i1, i64, i1 } }*
   %119 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %118, align 4
   %.fca.0.extract11.i.1 = extractvalue { i1, { i1, i64, i1 } } %119, 0
-  br i1 %.fca.0.extract11.i.1, label %__hugr__.const_fun_284.290.exit.1, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.1, label %__hugr__.const_fun_284.290.exit.1, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.1:                ; preds = %__hugr__.const_fun_284.290.exit
   %120 = extractvalue { i1, { i1, i64, i1 } } %119, 1
@@ -380,7 +380,7 @@ __hugr__.const_fun_284.290.exit.1:                ; preds = %__hugr__.const_fun_
   %124 = bitcast i8* %123 to { i1, { i1, i64, i1 } }*
   %125 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %124, align 4
   %.fca.0.extract11.i.2 = extractvalue { i1, { i1, i64, i1 } } %125, 0
-  br i1 %.fca.0.extract11.i.2, label %__hugr__.const_fun_284.290.exit.2, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.2, label %__hugr__.const_fun_284.290.exit.2, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.2:                ; preds = %__hugr__.const_fun_284.290.exit.1
   %126 = extractvalue { i1, { i1, i64, i1 } } %125, 1
@@ -391,7 +391,7 @@ __hugr__.const_fun_284.290.exit.2:                ; preds = %__hugr__.const_fun_
   %130 = bitcast i8* %129 to { i1, { i1, i64, i1 } }*
   %131 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %130, align 4
   %.fca.0.extract11.i.3 = extractvalue { i1, { i1, i64, i1 } } %131, 0
-  br i1 %.fca.0.extract11.i.3, label %__hugr__.const_fun_284.290.exit.3, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.3, label %__hugr__.const_fun_284.290.exit.3, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.3:                ; preds = %__hugr__.const_fun_284.290.exit.2
   %132 = extractvalue { i1, { i1, i64, i1 } } %131, 1
@@ -402,7 +402,7 @@ __hugr__.const_fun_284.290.exit.3:                ; preds = %__hugr__.const_fun_
   %136 = bitcast i8* %135 to { i1, { i1, i64, i1 } }*
   %137 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %136, align 4
   %.fca.0.extract11.i.4 = extractvalue { i1, { i1, i64, i1 } } %137, 0
-  br i1 %.fca.0.extract11.i.4, label %__hugr__.const_fun_284.290.exit.4, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.4, label %__hugr__.const_fun_284.290.exit.4, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.4:                ; preds = %__hugr__.const_fun_284.290.exit.3
   %138 = extractvalue { i1, { i1, i64, i1 } } %137, 1
@@ -413,7 +413,7 @@ __hugr__.const_fun_284.290.exit.4:                ; preds = %__hugr__.const_fun_
   %142 = bitcast i8* %141 to { i1, { i1, i64, i1 } }*
   %143 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %142, align 4
   %.fca.0.extract11.i.5 = extractvalue { i1, { i1, i64, i1 } } %143, 0
-  br i1 %.fca.0.extract11.i.5, label %__hugr__.const_fun_284.290.exit.5, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.5, label %__hugr__.const_fun_284.290.exit.5, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.5:                ; preds = %__hugr__.const_fun_284.290.exit.4
   %144 = extractvalue { i1, { i1, i64, i1 } } %143, 1
@@ -424,7 +424,7 @@ __hugr__.const_fun_284.290.exit.5:                ; preds = %__hugr__.const_fun_
   %148 = bitcast i8* %147 to { i1, { i1, i64, i1 } }*
   %149 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %148, align 4
   %.fca.0.extract11.i.6 = extractvalue { i1, { i1, i64, i1 } } %149, 0
-  br i1 %.fca.0.extract11.i.6, label %__hugr__.const_fun_284.290.exit.6, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.6, label %__hugr__.const_fun_284.290.exit.6, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.6:                ; preds = %__hugr__.const_fun_284.290.exit.5
   %150 = extractvalue { i1, { i1, i64, i1 } } %149, 1
@@ -435,7 +435,7 @@ __hugr__.const_fun_284.290.exit.6:                ; preds = %__hugr__.const_fun_
   %154 = bitcast i8* %153 to { i1, { i1, i64, i1 } }*
   %155 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %154, align 4
   %.fca.0.extract11.i.7 = extractvalue { i1, { i1, i64, i1 } } %155, 0
-  br i1 %.fca.0.extract11.i.7, label %__hugr__.const_fun_284.290.exit.7, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.7, label %__hugr__.const_fun_284.290.exit.7, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.7:                ; preds = %__hugr__.const_fun_284.290.exit.6
   %156 = extractvalue { i1, { i1, i64, i1 } } %155, 1
@@ -446,7 +446,7 @@ __hugr__.const_fun_284.290.exit.7:                ; preds = %__hugr__.const_fun_
   %160 = bitcast i8* %159 to { i1, { i1, i64, i1 } }*
   %161 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %160, align 4
   %.fca.0.extract11.i.8 = extractvalue { i1, { i1, i64, i1 } } %161, 0
-  br i1 %.fca.0.extract11.i.8, label %__hugr__.const_fun_284.290.exit.8, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.8, label %__hugr__.const_fun_284.290.exit.8, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.8:                ; preds = %__hugr__.const_fun_284.290.exit.7
   %162 = extractvalue { i1, { i1, i64, i1 } } %161, 1
@@ -457,7 +457,7 @@ __hugr__.const_fun_284.290.exit.8:                ; preds = %__hugr__.const_fun_
   %166 = bitcast i8* %165 to { i1, { i1, i64, i1 } }*
   %167 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %166, align 4
   %.fca.0.extract11.i.9 = extractvalue { i1, { i1, i64, i1 } } %167, 0
-  br i1 %.fca.0.extract11.i.9, label %__hugr__.const_fun_284.290.exit.9, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.9, label %__hugr__.const_fun_284.290.exit.9, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.9:                ; preds = %__hugr__.const_fun_284.290.exit.8
   %168 = extractvalue { i1, { i1, i64, i1 } } %167, 1
@@ -466,548 +466,474 @@ __hugr__.const_fun_284.290.exit.9:                ; preds = %__hugr__.const_fun_
   store { i1, i64, i1 } %168, { i1, i64, i1 }* %170, align 4
   tail call void @heap_free(i8* nonnull %63)
   tail call void @heap_free(i8* nonnull %64)
+  br label %__barray_check_bounds.exit888
+
+cond_165_case_0:                                  ; preds = %cond_exit_165
   %171 = load i64, i64* %114, align 4
-  %172 = and i64 %171, 1023
+  %172 = or i64 %171, -1024
   store i64 %172, i64* %114, align 4
-  %173 = icmp eq i64 %172, 0
-  br i1 %173, label %__barray_check_none_borrowed.exit817, label %mask_block_err.i816
+  %173 = icmp eq i64 %172, -1
+  br i1 %173, label %loop_out139, label %mask_block_err.i886
 
-__barray_check_none_borrowed.exit817:             ; preds = %__hugr__.const_fun_284.290.exit.9
-  %174 = tail call i8* @heap_alloc(i64 0)
-  %175 = tail call i8* @heap_alloc(i64 8)
-  %176 = bitcast i8* %175 to i64*
-  store i64 0, i64* %176, align 1
-  %177 = load { i1, i64, i1 }, { i1, i64, i1 }* %112, align 4
-  %.fca.0.extract.i818 = extractvalue { i1, i64, i1 } %177, 0
-  br i1 %.fca.0.extract.i818, label %cond_543_case_1.i, label %__hugr__.const_fun_175.284.exit
-
-mask_block_err.i816:                              ; preds = %__hugr__.const_fun_284.290.exit.9
-  tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
+mask_block_err.i886:                              ; preds = %cond_165_case_0
+  tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-cond_543_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit817
-  %.fca.1.extract.i819 = extractvalue { i1, i64, i1 } %177, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819)
-  br label %__hugr__.const_fun_175.284.exit
+__barray_check_bounds.exit888:                    ; preds = %__hugr__.const_fun_284.290.exit.9, %cond_exit_165
+  %"167_0.0989" = phi i64 [ 0, %__hugr__.const_fun_284.290.exit.9 ], [ %174, %cond_exit_165 ]
+  %174 = add nuw nsw i64 %"167_0.0989", 1
+  %175 = lshr i64 %"167_0.0989", 6
+  %176 = getelementptr inbounds i64, i64* %114, i64 %175
+  %177 = load i64, i64* %176, align 4
+  %178 = shl nuw nsw i64 1, %"167_0.0989"
+  %179 = and i64 %177, %178
+  %.not = icmp eq i64 %179, 0
+  br i1 %.not, label %__barray_mask_borrow.exit893, label %cond_exit_165
 
-__hugr__.const_fun_175.284.exit:                  ; preds = %__barray_check_none_borrowed.exit817, %cond_543_case_1.i
-  %178 = load { i1, i64, i1 }, { i1, i64, i1 }* %122, align 4
-  %.fca.0.extract.i818.1 = extractvalue { i1, i64, i1 } %178, 0
-  br i1 %.fca.0.extract.i818.1, label %cond_543_case_1.i.1, label %__hugr__.const_fun_175.284.exit.1
+__barray_mask_borrow.exit893:                     ; preds = %__barray_check_bounds.exit888
+  %180 = xor i64 %177, %178
+  store i64 %180, i64* %176, align 4
+  %181 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %112, i64 %"167_0.0989"
+  %182 = load { i1, i64, i1 }, { i1, i64, i1 }* %181, align 4
+  %.fca.0.extract511 = extractvalue { i1, i64, i1 } %182, 0
+  br i1 %.fca.0.extract511, label %cond_501_case_1, label %cond_exit_165
 
-cond_543_case_1.i.1:                              ; preds = %__hugr__.const_fun_175.284.exit
-  %.fca.1.extract.i819.1 = extractvalue { i1, i64, i1 } %178, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.1)
-  br label %__hugr__.const_fun_175.284.exit.1
+cond_exit_165:                                    ; preds = %cond_501_case_1, %__barray_mask_borrow.exit893, %__barray_check_bounds.exit888
+  %183 = icmp ult i64 %"167_0.0989", 9
+  br i1 %183, label %__barray_check_bounds.exit888, label %cond_165_case_0
 
-__hugr__.const_fun_175.284.exit.1:                ; preds = %cond_543_case_1.i.1, %__hugr__.const_fun_175.284.exit
-  %179 = load { i1, i64, i1 }, { i1, i64, i1 }* %128, align 4
-  %.fca.0.extract.i818.2 = extractvalue { i1, i64, i1 } %179, 0
-  br i1 %.fca.0.extract.i818.2, label %cond_543_case_1.i.2, label %__hugr__.const_fun_175.284.exit.2
-
-cond_543_case_1.i.2:                              ; preds = %__hugr__.const_fun_175.284.exit.1
-  %.fca.1.extract.i819.2 = extractvalue { i1, i64, i1 } %179, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.2)
-  br label %__hugr__.const_fun_175.284.exit.2
-
-__hugr__.const_fun_175.284.exit.2:                ; preds = %cond_543_case_1.i.2, %__hugr__.const_fun_175.284.exit.1
-  %180 = load { i1, i64, i1 }, { i1, i64, i1 }* %134, align 4
-  %.fca.0.extract.i818.3 = extractvalue { i1, i64, i1 } %180, 0
-  br i1 %.fca.0.extract.i818.3, label %cond_543_case_1.i.3, label %__hugr__.const_fun_175.284.exit.3
-
-cond_543_case_1.i.3:                              ; preds = %__hugr__.const_fun_175.284.exit.2
-  %.fca.1.extract.i819.3 = extractvalue { i1, i64, i1 } %180, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.3)
-  br label %__hugr__.const_fun_175.284.exit.3
-
-__hugr__.const_fun_175.284.exit.3:                ; preds = %cond_543_case_1.i.3, %__hugr__.const_fun_175.284.exit.2
-  %181 = load { i1, i64, i1 }, { i1, i64, i1 }* %140, align 4
-  %.fca.0.extract.i818.4 = extractvalue { i1, i64, i1 } %181, 0
-  br i1 %.fca.0.extract.i818.4, label %cond_543_case_1.i.4, label %__hugr__.const_fun_175.284.exit.4
-
-cond_543_case_1.i.4:                              ; preds = %__hugr__.const_fun_175.284.exit.3
-  %.fca.1.extract.i819.4 = extractvalue { i1, i64, i1 } %181, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.4)
-  br label %__hugr__.const_fun_175.284.exit.4
-
-__hugr__.const_fun_175.284.exit.4:                ; preds = %cond_543_case_1.i.4, %__hugr__.const_fun_175.284.exit.3
-  %182 = load { i1, i64, i1 }, { i1, i64, i1 }* %146, align 4
-  %.fca.0.extract.i818.5 = extractvalue { i1, i64, i1 } %182, 0
-  br i1 %.fca.0.extract.i818.5, label %cond_543_case_1.i.5, label %__hugr__.const_fun_175.284.exit.5
-
-cond_543_case_1.i.5:                              ; preds = %__hugr__.const_fun_175.284.exit.4
-  %.fca.1.extract.i819.5 = extractvalue { i1, i64, i1 } %182, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.5)
-  br label %__hugr__.const_fun_175.284.exit.5
-
-__hugr__.const_fun_175.284.exit.5:                ; preds = %cond_543_case_1.i.5, %__hugr__.const_fun_175.284.exit.4
-  %183 = load { i1, i64, i1 }, { i1, i64, i1 }* %152, align 4
-  %.fca.0.extract.i818.6 = extractvalue { i1, i64, i1 } %183, 0
-  br i1 %.fca.0.extract.i818.6, label %cond_543_case_1.i.6, label %__hugr__.const_fun_175.284.exit.6
-
-cond_543_case_1.i.6:                              ; preds = %__hugr__.const_fun_175.284.exit.5
-  %.fca.1.extract.i819.6 = extractvalue { i1, i64, i1 } %183, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.6)
-  br label %__hugr__.const_fun_175.284.exit.6
-
-__hugr__.const_fun_175.284.exit.6:                ; preds = %cond_543_case_1.i.6, %__hugr__.const_fun_175.284.exit.5
-  %184 = load { i1, i64, i1 }, { i1, i64, i1 }* %158, align 4
-  %.fca.0.extract.i818.7 = extractvalue { i1, i64, i1 } %184, 0
-  br i1 %.fca.0.extract.i818.7, label %cond_543_case_1.i.7, label %__hugr__.const_fun_175.284.exit.7
-
-cond_543_case_1.i.7:                              ; preds = %__hugr__.const_fun_175.284.exit.6
-  %.fca.1.extract.i819.7 = extractvalue { i1, i64, i1 } %184, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.7)
-  br label %__hugr__.const_fun_175.284.exit.7
-
-__hugr__.const_fun_175.284.exit.7:                ; preds = %cond_543_case_1.i.7, %__hugr__.const_fun_175.284.exit.6
-  %185 = load { i1, i64, i1 }, { i1, i64, i1 }* %164, align 4
-  %.fca.0.extract.i818.8 = extractvalue { i1, i64, i1 } %185, 0
-  br i1 %.fca.0.extract.i818.8, label %cond_543_case_1.i.8, label %__hugr__.const_fun_175.284.exit.8
-
-cond_543_case_1.i.8:                              ; preds = %__hugr__.const_fun_175.284.exit.7
-  %.fca.1.extract.i819.8 = extractvalue { i1, i64, i1 } %185, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.8)
-  br label %__hugr__.const_fun_175.284.exit.8
-
-__hugr__.const_fun_175.284.exit.8:                ; preds = %cond_543_case_1.i.8, %__hugr__.const_fun_175.284.exit.7
-  %186 = load { i1, i64, i1 }, { i1, i64, i1 }* %170, align 4
-  %.fca.0.extract.i818.9 = extractvalue { i1, i64, i1 } %186, 0
-  br i1 %.fca.0.extract.i818.9, label %cond_543_case_1.i.9, label %__hugr__.const_fun_175.284.exit.9
-
-cond_543_case_1.i.9:                              ; preds = %__hugr__.const_fun_175.284.exit.8
-  %.fca.1.extract.i819.9 = extractvalue { i1, i64, i1 } %186, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.9)
-  br label %__hugr__.const_fun_175.284.exit.9
-
-__hugr__.const_fun_175.284.exit.9:                ; preds = %cond_543_case_1.i.9, %__hugr__.const_fun_175.284.exit.8
-  tail call void @heap_free(i8* nonnull %111)
+loop_out139:                                      ; preds = %cond_165_case_0
+  tail call void @heap_free(i8* %111)
   tail call void @heap_free(i8* nonnull %113)
-  tail call void @heap_free(i8* %174)
-  %187 = load i64, i64* %87, align 4
-  %188 = and i64 %187, 1023
-  store i64 %188, i64* %87, align 4
-  %189 = icmp eq i64 %188, 0
-  br i1 %189, label %__barray_check_none_borrowed.exit824, label %mask_block_err.i823
+  %184 = load i64, i64* %87, align 4
+  %185 = and i64 %184, 1023
+  store i64 %185, i64* %87, align 4
+  %186 = icmp eq i64 %185, 0
+  br i1 %186, label %__barray_check_none_borrowed.exit898, label %mask_block_err.i897
 
-__barray_check_none_borrowed.exit824:             ; preds = %__hugr__.const_fun_175.284.exit.9
-  %190 = tail call i8* @heap_alloc(i64 10)
-  %191 = tail call i8* @heap_alloc(i64 8)
-  %192 = bitcast i8* %191 to i64*
-  store i64 0, i64* %192, align 1
-  %193 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
-  %.fca.0.extract.i825 = extractvalue { i1, i64, i1 } %193, 0
-  %.fca.1.extract.i826 = extractvalue { i1, i64, i1 } %193, 1
-  br i1 %.fca.0.extract.i825, label %cond_300_case_1.i, label %cond_300_case_0.i
+__barray_check_none_borrowed.exit898:             ; preds = %loop_out139
+  %187 = tail call i8* @heap_alloc(i64 10)
+  %188 = tail call i8* @heap_alloc(i64 8)
+  %189 = bitcast i8* %188 to i64*
+  store i64 0, i64* %189, align 1
+  %190 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
+  %.fca.0.extract.i899 = extractvalue { i1, i64, i1 } %190, 0
+  %.fca.1.extract.i900 = extractvalue { i1, i64, i1 } %190, 1
+  br i1 %.fca.0.extract.i899, label %cond_300_case_1.i, label %cond_300_case_0.i
 
-mask_block_err.i823:                              ; preds = %__hugr__.const_fun_175.284.exit.9
+mask_block_err.i897:                              ; preds = %loop_out139
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-cond_300_case_0.i:                                ; preds = %__barray_check_none_borrowed.exit824
-  %.fca.2.extract.i = extractvalue { i1, i64, i1 } %193, 2
+cond_501_case_1:                                  ; preds = %__barray_mask_borrow.exit893
+  %.fca.1.extract512 = extractvalue { i1, i64, i1 } %182, 1
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract512)
+  br label %cond_exit_165
+
+cond_300_case_0.i:                                ; preds = %__barray_check_none_borrowed.exit898
+  %.fca.2.extract.i = extractvalue { i1, i64, i1 } %190, 2
   br label %__hugr__.array.__read_bool.3.271.exit
 
-cond_300_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit824
-  %read_bool.i = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826)
+cond_300_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit898
+  %read_bool.i = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900)
   br label %__hugr__.array.__read_bool.3.271.exit
 
 __hugr__.array.__read_bool.3.271.exit:            ; preds = %cond_300_case_0.i, %cond_300_case_1.i
   %"03.0.i" = phi i1 [ %read_bool.i, %cond_300_case_1.i ], [ %.fca.2.extract.i, %cond_300_case_0.i ]
-  %194 = bitcast i8* %190 to i1*
-  store i1 %"03.0.i", i1* %194, align 1
-  %195 = getelementptr inbounds i8, i8* %84, i64 24
-  %196 = bitcast i8* %195 to { i1, i64, i1 }*
-  %197 = load { i1, i64, i1 }, { i1, i64, i1 }* %196, align 4
-  %.fca.0.extract.i825.1 = extractvalue { i1, i64, i1 } %197, 0
-  %.fca.1.extract.i826.1 = extractvalue { i1, i64, i1 } %197, 1
-  br i1 %.fca.0.extract.i825.1, label %cond_300_case_1.i.1, label %cond_300_case_0.i.1
+  %191 = bitcast i8* %187 to i1*
+  store i1 %"03.0.i", i1* %191, align 1
+  %192 = getelementptr inbounds i8, i8* %84, i64 24
+  %193 = bitcast i8* %192 to { i1, i64, i1 }*
+  %194 = load { i1, i64, i1 }, { i1, i64, i1 }* %193, align 4
+  %.fca.0.extract.i899.1 = extractvalue { i1, i64, i1 } %194, 0
+  %.fca.1.extract.i900.1 = extractvalue { i1, i64, i1 } %194, 1
+  br i1 %.fca.0.extract.i899.1, label %cond_300_case_1.i.1, label %cond_300_case_0.i.1
 
 cond_300_case_0.i.1:                              ; preds = %__hugr__.array.__read_bool.3.271.exit
-  %.fca.2.extract.i.1 = extractvalue { i1, i64, i1 } %197, 2
+  %.fca.2.extract.i.1 = extractvalue { i1, i64, i1 } %194, 2
   br label %__hugr__.array.__read_bool.3.271.exit.1
 
 cond_300_case_1.i.1:                              ; preds = %__hugr__.array.__read_bool.3.271.exit
-  %read_bool.i.1 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.1)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.1)
+  %read_bool.i.1 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.1)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.1)
   br label %__hugr__.array.__read_bool.3.271.exit.1
 
 __hugr__.array.__read_bool.3.271.exit.1:          ; preds = %cond_300_case_1.i.1, %cond_300_case_0.i.1
   %"03.0.i.1" = phi i1 [ %read_bool.i.1, %cond_300_case_1.i.1 ], [ %.fca.2.extract.i.1, %cond_300_case_0.i.1 ]
-  %198 = getelementptr inbounds i8, i8* %190, i64 1
-  %199 = bitcast i8* %198 to i1*
-  store i1 %"03.0.i.1", i1* %199, align 1
-  %200 = getelementptr inbounds i8, i8* %84, i64 48
-  %201 = bitcast i8* %200 to { i1, i64, i1 }*
-  %202 = load { i1, i64, i1 }, { i1, i64, i1 }* %201, align 4
-  %.fca.0.extract.i825.2 = extractvalue { i1, i64, i1 } %202, 0
-  %.fca.1.extract.i826.2 = extractvalue { i1, i64, i1 } %202, 1
-  br i1 %.fca.0.extract.i825.2, label %cond_300_case_1.i.2, label %cond_300_case_0.i.2
+  %195 = getelementptr inbounds i8, i8* %187, i64 1
+  %196 = bitcast i8* %195 to i1*
+  store i1 %"03.0.i.1", i1* %196, align 1
+  %197 = getelementptr inbounds i8, i8* %84, i64 48
+  %198 = bitcast i8* %197 to { i1, i64, i1 }*
+  %199 = load { i1, i64, i1 }, { i1, i64, i1 }* %198, align 4
+  %.fca.0.extract.i899.2 = extractvalue { i1, i64, i1 } %199, 0
+  %.fca.1.extract.i900.2 = extractvalue { i1, i64, i1 } %199, 1
+  br i1 %.fca.0.extract.i899.2, label %cond_300_case_1.i.2, label %cond_300_case_0.i.2
 
 cond_300_case_0.i.2:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.1
-  %.fca.2.extract.i.2 = extractvalue { i1, i64, i1 } %202, 2
+  %.fca.2.extract.i.2 = extractvalue { i1, i64, i1 } %199, 2
   br label %__hugr__.array.__read_bool.3.271.exit.2
 
 cond_300_case_1.i.2:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.1
-  %read_bool.i.2 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.2)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.2)
+  %read_bool.i.2 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.2)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.2)
   br label %__hugr__.array.__read_bool.3.271.exit.2
 
 __hugr__.array.__read_bool.3.271.exit.2:          ; preds = %cond_300_case_1.i.2, %cond_300_case_0.i.2
   %"03.0.i.2" = phi i1 [ %read_bool.i.2, %cond_300_case_1.i.2 ], [ %.fca.2.extract.i.2, %cond_300_case_0.i.2 ]
-  %203 = getelementptr inbounds i8, i8* %190, i64 2
-  %204 = bitcast i8* %203 to i1*
-  store i1 %"03.0.i.2", i1* %204, align 1
-  %205 = getelementptr inbounds i8, i8* %84, i64 72
-  %206 = bitcast i8* %205 to { i1, i64, i1 }*
-  %207 = load { i1, i64, i1 }, { i1, i64, i1 }* %206, align 4
-  %.fca.0.extract.i825.3 = extractvalue { i1, i64, i1 } %207, 0
-  %.fca.1.extract.i826.3 = extractvalue { i1, i64, i1 } %207, 1
-  br i1 %.fca.0.extract.i825.3, label %cond_300_case_1.i.3, label %cond_300_case_0.i.3
+  %200 = getelementptr inbounds i8, i8* %187, i64 2
+  %201 = bitcast i8* %200 to i1*
+  store i1 %"03.0.i.2", i1* %201, align 1
+  %202 = getelementptr inbounds i8, i8* %84, i64 72
+  %203 = bitcast i8* %202 to { i1, i64, i1 }*
+  %204 = load { i1, i64, i1 }, { i1, i64, i1 }* %203, align 4
+  %.fca.0.extract.i899.3 = extractvalue { i1, i64, i1 } %204, 0
+  %.fca.1.extract.i900.3 = extractvalue { i1, i64, i1 } %204, 1
+  br i1 %.fca.0.extract.i899.3, label %cond_300_case_1.i.3, label %cond_300_case_0.i.3
 
 cond_300_case_0.i.3:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.2
-  %.fca.2.extract.i.3 = extractvalue { i1, i64, i1 } %207, 2
+  %.fca.2.extract.i.3 = extractvalue { i1, i64, i1 } %204, 2
   br label %__hugr__.array.__read_bool.3.271.exit.3
 
 cond_300_case_1.i.3:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.2
-  %read_bool.i.3 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.3)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.3)
+  %read_bool.i.3 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.3)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.3)
   br label %__hugr__.array.__read_bool.3.271.exit.3
 
 __hugr__.array.__read_bool.3.271.exit.3:          ; preds = %cond_300_case_1.i.3, %cond_300_case_0.i.3
   %"03.0.i.3" = phi i1 [ %read_bool.i.3, %cond_300_case_1.i.3 ], [ %.fca.2.extract.i.3, %cond_300_case_0.i.3 ]
-  %208 = getelementptr inbounds i8, i8* %190, i64 3
-  %209 = bitcast i8* %208 to i1*
-  store i1 %"03.0.i.3", i1* %209, align 1
-  %210 = getelementptr inbounds i8, i8* %84, i64 96
-  %211 = bitcast i8* %210 to { i1, i64, i1 }*
-  %212 = load { i1, i64, i1 }, { i1, i64, i1 }* %211, align 4
-  %.fca.0.extract.i825.4 = extractvalue { i1, i64, i1 } %212, 0
-  %.fca.1.extract.i826.4 = extractvalue { i1, i64, i1 } %212, 1
-  br i1 %.fca.0.extract.i825.4, label %cond_300_case_1.i.4, label %cond_300_case_0.i.4
+  %205 = getelementptr inbounds i8, i8* %187, i64 3
+  %206 = bitcast i8* %205 to i1*
+  store i1 %"03.0.i.3", i1* %206, align 1
+  %207 = getelementptr inbounds i8, i8* %84, i64 96
+  %208 = bitcast i8* %207 to { i1, i64, i1 }*
+  %209 = load { i1, i64, i1 }, { i1, i64, i1 }* %208, align 4
+  %.fca.0.extract.i899.4 = extractvalue { i1, i64, i1 } %209, 0
+  %.fca.1.extract.i900.4 = extractvalue { i1, i64, i1 } %209, 1
+  br i1 %.fca.0.extract.i899.4, label %cond_300_case_1.i.4, label %cond_300_case_0.i.4
 
 cond_300_case_0.i.4:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.3
-  %.fca.2.extract.i.4 = extractvalue { i1, i64, i1 } %212, 2
+  %.fca.2.extract.i.4 = extractvalue { i1, i64, i1 } %209, 2
   br label %__hugr__.array.__read_bool.3.271.exit.4
 
 cond_300_case_1.i.4:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.3
-  %read_bool.i.4 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.4)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.4)
+  %read_bool.i.4 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.4)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.4)
   br label %__hugr__.array.__read_bool.3.271.exit.4
 
 __hugr__.array.__read_bool.3.271.exit.4:          ; preds = %cond_300_case_1.i.4, %cond_300_case_0.i.4
   %"03.0.i.4" = phi i1 [ %read_bool.i.4, %cond_300_case_1.i.4 ], [ %.fca.2.extract.i.4, %cond_300_case_0.i.4 ]
-  %213 = getelementptr inbounds i8, i8* %190, i64 4
-  %214 = bitcast i8* %213 to i1*
-  store i1 %"03.0.i.4", i1* %214, align 1
-  %215 = getelementptr inbounds i8, i8* %84, i64 120
-  %216 = bitcast i8* %215 to { i1, i64, i1 }*
-  %217 = load { i1, i64, i1 }, { i1, i64, i1 }* %216, align 4
-  %.fca.0.extract.i825.5 = extractvalue { i1, i64, i1 } %217, 0
-  %.fca.1.extract.i826.5 = extractvalue { i1, i64, i1 } %217, 1
-  br i1 %.fca.0.extract.i825.5, label %cond_300_case_1.i.5, label %cond_300_case_0.i.5
+  %210 = getelementptr inbounds i8, i8* %187, i64 4
+  %211 = bitcast i8* %210 to i1*
+  store i1 %"03.0.i.4", i1* %211, align 1
+  %212 = getelementptr inbounds i8, i8* %84, i64 120
+  %213 = bitcast i8* %212 to { i1, i64, i1 }*
+  %214 = load { i1, i64, i1 }, { i1, i64, i1 }* %213, align 4
+  %.fca.0.extract.i899.5 = extractvalue { i1, i64, i1 } %214, 0
+  %.fca.1.extract.i900.5 = extractvalue { i1, i64, i1 } %214, 1
+  br i1 %.fca.0.extract.i899.5, label %cond_300_case_1.i.5, label %cond_300_case_0.i.5
 
 cond_300_case_0.i.5:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.4
-  %.fca.2.extract.i.5 = extractvalue { i1, i64, i1 } %217, 2
+  %.fca.2.extract.i.5 = extractvalue { i1, i64, i1 } %214, 2
   br label %__hugr__.array.__read_bool.3.271.exit.5
 
 cond_300_case_1.i.5:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.4
-  %read_bool.i.5 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.5)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.5)
+  %read_bool.i.5 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.5)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.5)
   br label %__hugr__.array.__read_bool.3.271.exit.5
 
 __hugr__.array.__read_bool.3.271.exit.5:          ; preds = %cond_300_case_1.i.5, %cond_300_case_0.i.5
   %"03.0.i.5" = phi i1 [ %read_bool.i.5, %cond_300_case_1.i.5 ], [ %.fca.2.extract.i.5, %cond_300_case_0.i.5 ]
-  %218 = getelementptr inbounds i8, i8* %190, i64 5
-  %219 = bitcast i8* %218 to i1*
-  store i1 %"03.0.i.5", i1* %219, align 1
-  %220 = getelementptr inbounds i8, i8* %84, i64 144
-  %221 = bitcast i8* %220 to { i1, i64, i1 }*
-  %222 = load { i1, i64, i1 }, { i1, i64, i1 }* %221, align 4
-  %.fca.0.extract.i825.6 = extractvalue { i1, i64, i1 } %222, 0
-  %.fca.1.extract.i826.6 = extractvalue { i1, i64, i1 } %222, 1
-  br i1 %.fca.0.extract.i825.6, label %cond_300_case_1.i.6, label %cond_300_case_0.i.6
+  %215 = getelementptr inbounds i8, i8* %187, i64 5
+  %216 = bitcast i8* %215 to i1*
+  store i1 %"03.0.i.5", i1* %216, align 1
+  %217 = getelementptr inbounds i8, i8* %84, i64 144
+  %218 = bitcast i8* %217 to { i1, i64, i1 }*
+  %219 = load { i1, i64, i1 }, { i1, i64, i1 }* %218, align 4
+  %.fca.0.extract.i899.6 = extractvalue { i1, i64, i1 } %219, 0
+  %.fca.1.extract.i900.6 = extractvalue { i1, i64, i1 } %219, 1
+  br i1 %.fca.0.extract.i899.6, label %cond_300_case_1.i.6, label %cond_300_case_0.i.6
 
 cond_300_case_0.i.6:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.5
-  %.fca.2.extract.i.6 = extractvalue { i1, i64, i1 } %222, 2
+  %.fca.2.extract.i.6 = extractvalue { i1, i64, i1 } %219, 2
   br label %__hugr__.array.__read_bool.3.271.exit.6
 
 cond_300_case_1.i.6:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.5
-  %read_bool.i.6 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.6)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.6)
+  %read_bool.i.6 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.6)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.6)
   br label %__hugr__.array.__read_bool.3.271.exit.6
 
 __hugr__.array.__read_bool.3.271.exit.6:          ; preds = %cond_300_case_1.i.6, %cond_300_case_0.i.6
   %"03.0.i.6" = phi i1 [ %read_bool.i.6, %cond_300_case_1.i.6 ], [ %.fca.2.extract.i.6, %cond_300_case_0.i.6 ]
-  %223 = getelementptr inbounds i8, i8* %190, i64 6
-  %224 = bitcast i8* %223 to i1*
-  store i1 %"03.0.i.6", i1* %224, align 1
-  %225 = getelementptr inbounds i8, i8* %84, i64 168
-  %226 = bitcast i8* %225 to { i1, i64, i1 }*
-  %227 = load { i1, i64, i1 }, { i1, i64, i1 }* %226, align 4
-  %.fca.0.extract.i825.7 = extractvalue { i1, i64, i1 } %227, 0
-  %.fca.1.extract.i826.7 = extractvalue { i1, i64, i1 } %227, 1
-  br i1 %.fca.0.extract.i825.7, label %cond_300_case_1.i.7, label %cond_300_case_0.i.7
+  %220 = getelementptr inbounds i8, i8* %187, i64 6
+  %221 = bitcast i8* %220 to i1*
+  store i1 %"03.0.i.6", i1* %221, align 1
+  %222 = getelementptr inbounds i8, i8* %84, i64 168
+  %223 = bitcast i8* %222 to { i1, i64, i1 }*
+  %224 = load { i1, i64, i1 }, { i1, i64, i1 }* %223, align 4
+  %.fca.0.extract.i899.7 = extractvalue { i1, i64, i1 } %224, 0
+  %.fca.1.extract.i900.7 = extractvalue { i1, i64, i1 } %224, 1
+  br i1 %.fca.0.extract.i899.7, label %cond_300_case_1.i.7, label %cond_300_case_0.i.7
 
 cond_300_case_0.i.7:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.6
-  %.fca.2.extract.i.7 = extractvalue { i1, i64, i1 } %227, 2
+  %.fca.2.extract.i.7 = extractvalue { i1, i64, i1 } %224, 2
   br label %__hugr__.array.__read_bool.3.271.exit.7
 
 cond_300_case_1.i.7:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.6
-  %read_bool.i.7 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.7)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.7)
+  %read_bool.i.7 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.7)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.7)
   br label %__hugr__.array.__read_bool.3.271.exit.7
 
 __hugr__.array.__read_bool.3.271.exit.7:          ; preds = %cond_300_case_1.i.7, %cond_300_case_0.i.7
   %"03.0.i.7" = phi i1 [ %read_bool.i.7, %cond_300_case_1.i.7 ], [ %.fca.2.extract.i.7, %cond_300_case_0.i.7 ]
-  %228 = getelementptr inbounds i8, i8* %190, i64 7
-  %229 = bitcast i8* %228 to i1*
-  store i1 %"03.0.i.7", i1* %229, align 1
-  %230 = getelementptr inbounds i8, i8* %84, i64 192
-  %231 = bitcast i8* %230 to { i1, i64, i1 }*
-  %232 = load { i1, i64, i1 }, { i1, i64, i1 }* %231, align 4
-  %.fca.0.extract.i825.8 = extractvalue { i1, i64, i1 } %232, 0
-  %.fca.1.extract.i826.8 = extractvalue { i1, i64, i1 } %232, 1
-  br i1 %.fca.0.extract.i825.8, label %cond_300_case_1.i.8, label %cond_300_case_0.i.8
+  %225 = getelementptr inbounds i8, i8* %187, i64 7
+  %226 = bitcast i8* %225 to i1*
+  store i1 %"03.0.i.7", i1* %226, align 1
+  %227 = getelementptr inbounds i8, i8* %84, i64 192
+  %228 = bitcast i8* %227 to { i1, i64, i1 }*
+  %229 = load { i1, i64, i1 }, { i1, i64, i1 }* %228, align 4
+  %.fca.0.extract.i899.8 = extractvalue { i1, i64, i1 } %229, 0
+  %.fca.1.extract.i900.8 = extractvalue { i1, i64, i1 } %229, 1
+  br i1 %.fca.0.extract.i899.8, label %cond_300_case_1.i.8, label %cond_300_case_0.i.8
 
 cond_300_case_0.i.8:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.7
-  %.fca.2.extract.i.8 = extractvalue { i1, i64, i1 } %232, 2
+  %.fca.2.extract.i.8 = extractvalue { i1, i64, i1 } %229, 2
   br label %__hugr__.array.__read_bool.3.271.exit.8
 
 cond_300_case_1.i.8:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.7
-  %read_bool.i.8 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.8)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.8)
+  %read_bool.i.8 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.8)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.8)
   br label %__hugr__.array.__read_bool.3.271.exit.8
 
 __hugr__.array.__read_bool.3.271.exit.8:          ; preds = %cond_300_case_1.i.8, %cond_300_case_0.i.8
   %"03.0.i.8" = phi i1 [ %read_bool.i.8, %cond_300_case_1.i.8 ], [ %.fca.2.extract.i.8, %cond_300_case_0.i.8 ]
-  %233 = getelementptr inbounds i8, i8* %190, i64 8
-  %234 = bitcast i8* %233 to i1*
-  store i1 %"03.0.i.8", i1* %234, align 1
-  %235 = getelementptr inbounds i8, i8* %84, i64 216
-  %236 = bitcast i8* %235 to { i1, i64, i1 }*
-  %237 = load { i1, i64, i1 }, { i1, i64, i1 }* %236, align 4
-  %.fca.0.extract.i825.9 = extractvalue { i1, i64, i1 } %237, 0
-  %.fca.1.extract.i826.9 = extractvalue { i1, i64, i1 } %237, 1
-  br i1 %.fca.0.extract.i825.9, label %cond_300_case_1.i.9, label %cond_300_case_0.i.9
+  %230 = getelementptr inbounds i8, i8* %187, i64 8
+  %231 = bitcast i8* %230 to i1*
+  store i1 %"03.0.i.8", i1* %231, align 1
+  %232 = getelementptr inbounds i8, i8* %84, i64 216
+  %233 = bitcast i8* %232 to { i1, i64, i1 }*
+  %234 = load { i1, i64, i1 }, { i1, i64, i1 }* %233, align 4
+  %.fca.0.extract.i899.9 = extractvalue { i1, i64, i1 } %234, 0
+  %.fca.1.extract.i900.9 = extractvalue { i1, i64, i1 } %234, 1
+  br i1 %.fca.0.extract.i899.9, label %cond_300_case_1.i.9, label %cond_300_case_0.i.9
 
 cond_300_case_0.i.9:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.8
-  %.fca.2.extract.i.9 = extractvalue { i1, i64, i1 } %237, 2
+  %.fca.2.extract.i.9 = extractvalue { i1, i64, i1 } %234, 2
   br label %__hugr__.array.__read_bool.3.271.exit.9
 
 cond_300_case_1.i.9:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.8
-  %read_bool.i.9 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.9)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.9)
+  %read_bool.i.9 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.9)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.9)
   br label %__hugr__.array.__read_bool.3.271.exit.9
 
 __hugr__.array.__read_bool.3.271.exit.9:          ; preds = %cond_300_case_1.i.9, %cond_300_case_0.i.9
   %"03.0.i.9" = phi i1 [ %read_bool.i.9, %cond_300_case_1.i.9 ], [ %.fca.2.extract.i.9, %cond_300_case_0.i.9 ]
-  %238 = getelementptr inbounds i8, i8* %190, i64 9
-  %239 = bitcast i8* %238 to i1*
-  store i1 %"03.0.i.9", i1* %239, align 1
+  %235 = getelementptr inbounds i8, i8* %187, i64 9
+  %236 = bitcast i8* %235 to i1*
+  store i1 %"03.0.i.9", i1* %236, align 1
   tail call void @heap_free(i8* nonnull %84)
   tail call void @heap_free(i8* nonnull %86)
-  %240 = load i64, i64* %192, align 4
-  %241 = and i64 %240, 1023
-  store i64 %241, i64* %192, align 4
-  %242 = icmp eq i64 %241, 0
-  br i1 %242, label %__barray_check_none_borrowed.exit831, label %mask_block_err.i830
+  %237 = load i64, i64* %189, align 4
+  %238 = and i64 %237, 1023
+  store i64 %238, i64* %189, align 4
+  %239 = icmp eq i64 %238, 0
+  br i1 %239, label %__barray_check_none_borrowed.exit905, label %mask_block_err.i904
 
-__barray_check_none_borrowed.exit831:             ; preds = %__hugr__.array.__read_bool.3.271.exit.9
+__barray_check_none_borrowed.exit905:             ; preds = %__hugr__.array.__read_bool.3.271.exit.9
   %out_arr_alloca = alloca <{ i32, i32, i1*, i1* }>, align 8
   %x_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 0
   %y_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 1
   %arr_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 2
   %mask_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 3
-  %243 = alloca [10 x i1], align 1
-  %.sub = getelementptr inbounds [10 x i1], [10 x i1]* %243, i64 0, i64 0
-  %244 = bitcast [10 x i1]* %243 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(10) %244, i8 0, i64 10, i1 false)
+  %240 = alloca [10 x i1], align 1
+  %.sub = getelementptr inbounds [10 x i1], [10 x i1]* %240, i64 0, i64 0
+  %241 = bitcast [10 x i1]* %240 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(10) %241, i8 0, i64 10, i1 false)
   store i32 10, i32* %x_ptr, align 8
   store i32 1, i32* %y_ptr, align 4
-  %245 = bitcast i1** %arr_ptr to i8**
-  store i8* %190, i8** %245, align 8
+  %242 = bitcast i1** %arr_ptr to i8**
+  store i8* %187, i8** %242, align 8
   store i1* %.sub, i1** %mask_ptr, align 8
   call void @print_bool_arr(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @res_cs.46C3C4B5.0, i64 0, i64 0), i64 15, <{ i32, i32, i1*, i1* }>* nonnull %out_arr_alloca)
-  br label %__barray_check_bounds.exit839
+  br label %__barray_check_bounds.exit913
 
-mask_block_err.i830:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.9
+mask_block_err.i904:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.9
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit839:                    ; preds = %cond_exit_95.1, %__barray_check_none_borrowed.exit831
-  %"90_0.sroa.0.0899" = phi i64 [ 0, %__barray_check_none_borrowed.exit831 ], [ %255, %cond_exit_95.1 ]
-  %246 = or i64 %"90_0.sroa.0.0899", 1
-  %247 = lshr i64 %"90_0.sroa.0.0899", 6
-  %248 = getelementptr inbounds i64, i64* %7, i64 %247
-  %249 = load i64, i64* %248, align 4
-  %250 = and i64 %"90_0.sroa.0.0899", 62
-  %251 = shl nuw i64 1, %250
-  %252 = and i64 %249, %251
-  %.not.i840 = icmp eq i64 %252, 0
-  br i1 %.not.i840, label %panic.i841, label %cond_exit_95
+__barray_check_bounds.exit913:                    ; preds = %cond_exit_95.1, %__barray_check_none_borrowed.exit905
+  %"90_0.sroa.0.0972" = phi i64 [ 0, %__barray_check_none_borrowed.exit905 ], [ %252, %cond_exit_95.1 ]
+  %243 = or i64 %"90_0.sroa.0.0972", 1
+  %244 = lshr i64 %"90_0.sroa.0.0972", 6
+  %245 = getelementptr inbounds i64, i64* %7, i64 %244
+  %246 = load i64, i64* %245, align 4
+  %247 = and i64 %"90_0.sroa.0.0972", 62
+  %248 = shl nuw i64 1, %247
+  %249 = and i64 %246, %248
+  %.not.i914 = icmp eq i64 %249, 0
+  br i1 %.not.i914, label %panic.i915, label %cond_exit_95
 
-panic.i841:                                       ; preds = %cond_exit_95, %__barray_check_bounds.exit839
+panic.i915:                                       ; preds = %cond_exit_95, %__barray_check_bounds.exit913
   call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-cond_exit_95:                                     ; preds = %__barray_check_bounds.exit839
-  %253 = xor i64 %249, %251
-  store i64 %253, i64* %248, align 4
-  %254 = getelementptr inbounds i64, i64* %5, i64 %"90_0.sroa.0.0899"
-  store i64 %"90_0.sroa.0.0899", i64* %254, align 4
-  %255 = add nuw nsw i64 %"90_0.sroa.0.0899", 2
-  %256 = lshr i64 %"90_0.sroa.0.0899", 6
-  %257 = getelementptr inbounds i64, i64* %7, i64 %256
-  %258 = load i64, i64* %257, align 4
-  %259 = and i64 %246, 63
-  %260 = shl nuw i64 1, %259
-  %261 = and i64 %258, %260
-  %.not.i840.1 = icmp eq i64 %261, 0
-  br i1 %.not.i840.1, label %panic.i841, label %cond_exit_95.1
+cond_exit_95:                                     ; preds = %__barray_check_bounds.exit913
+  %250 = xor i64 %246, %248
+  store i64 %250, i64* %245, align 4
+  %251 = getelementptr inbounds i64, i64* %5, i64 %"90_0.sroa.0.0972"
+  store i64 %"90_0.sroa.0.0972", i64* %251, align 4
+  %252 = add nuw nsw i64 %"90_0.sroa.0.0972", 2
+  %253 = lshr i64 %"90_0.sroa.0.0972", 6
+  %254 = getelementptr inbounds i64, i64* %7, i64 %253
+  %255 = load i64, i64* %254, align 4
+  %256 = and i64 %243, 63
+  %257 = shl nuw i64 1, %256
+  %258 = and i64 %255, %257
+  %.not.i914.1 = icmp eq i64 %258, 0
+  br i1 %.not.i914.1, label %panic.i915, label %cond_exit_95.1
 
 cond_exit_95.1:                                   ; preds = %cond_exit_95
-  %262 = xor i64 %258, %260
-  store i64 %262, i64* %257, align 4
-  %263 = getelementptr inbounds i64, i64* %5, i64 %246
-  store i64 %246, i64* %263, align 4
-  %exitcond911.not.1 = icmp eq i64 %255, 100
-  br i1 %exitcond911.not.1, label %loop_out164, label %__barray_check_bounds.exit839
+  %259 = xor i64 %255, %257
+  store i64 %259, i64* %254, align 4
+  %260 = getelementptr inbounds i64, i64* %5, i64 %243
+  store i64 %243, i64* %260, align 4
+  %exitcond983.not.1 = icmp eq i64 %252, 100
+  br i1 %exitcond983.not.1, label %loop_out212, label %__barray_check_bounds.exit913
 
-loop_out164:                                      ; preds = %cond_exit_95.1
-  %264 = getelementptr inbounds i8, i8* %6, i64 8
-  %265 = bitcast i8* %264 to i64*
-  %266 = load i64, i64* %265, align 4
-  %267 = and i64 %266, 68719476735
-  store i64 %267, i64* %265, align 4
-  %268 = load i64, i64* %7, align 4
-  %269 = icmp eq i64 %268, 0
-  %270 = icmp eq i64 %267, 0
-  %or.cond = select i1 %269, i1 %270, i1 false
-  br i1 %or.cond, label %__barray_check_none_borrowed.exit847, label %mask_block_err.i846
+loop_out212:                                      ; preds = %cond_exit_95.1
+  %261 = getelementptr inbounds i8, i8* %6, i64 8
+  %262 = bitcast i8* %261 to i64*
+  %263 = load i64, i64* %262, align 4
+  %264 = and i64 %263, 68719476735
+  store i64 %264, i64* %262, align 4
+  %265 = load i64, i64* %7, align 4
+  %266 = icmp eq i64 %265, 0
+  %267 = icmp eq i64 %264, 0
+  %or.cond = select i1 %266, i1 %267, i1 false
+  br i1 %or.cond, label %__barray_check_none_borrowed.exit921, label %mask_block_err.i920
 
-__barray_check_none_borrowed.exit847:             ; preds = %loop_out164
-  %271 = call i8* @heap_alloc(i64 800)
-  %272 = bitcast i8* %271 to i64*
-  %273 = call i8* @heap_alloc(i64 16)
-  %274 = bitcast i8* %273 to i64*
-  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %274, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0i64.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(800) %272, i64* noundef nonnull align 1 dereferenceable(800) %5, i64 800, i1 false)
-  call void @heap_free(i8* %271)
-  %275 = load i64, i64* %265, align 4
-  %276 = and i64 %275, 68719476735
-  store i64 %276, i64* %265, align 4
-  %277 = load i64, i64* %7, align 4
-  %278 = icmp eq i64 %277, 0
-  %279 = icmp eq i64 %276, 0
-  %or.cond913 = select i1 %278, i1 %279, i1 false
-  br i1 %or.cond913, label %__barray_check_none_borrowed.exit852, label %mask_block_err.i851
+__barray_check_none_borrowed.exit921:             ; preds = %loop_out212
+  %268 = call i8* @heap_alloc(i64 800)
+  %269 = bitcast i8* %268 to i64*
+  %270 = call i8* @heap_alloc(i64 16)
+  %271 = bitcast i8* %270 to i64*
+  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %271, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0i64.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(800) %269, i64* noundef nonnull align 1 dereferenceable(800) %5, i64 800, i1 false)
+  call void @heap_free(i8* %268)
+  %272 = load i64, i64* %262, align 4
+  %273 = and i64 %272, 68719476735
+  store i64 %273, i64* %262, align 4
+  %274 = load i64, i64* %7, align 4
+  %275 = icmp eq i64 %274, 0
+  %276 = icmp eq i64 %273, 0
+  %or.cond986 = select i1 %275, i1 %276, i1 false
+  br i1 %or.cond986, label %__barray_check_none_borrowed.exit926, label %mask_block_err.i925
 
-mask_block_err.i846:                              ; preds = %loop_out164
+mask_block_err.i920:                              ; preds = %loop_out212
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit852:             ; preds = %__barray_check_none_borrowed.exit847
-  %out_arr_alloca239 = alloca <{ i32, i32, i64*, i1* }>, align 8
-  %x_ptr240 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 0
-  %y_ptr241 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 1
-  %arr_ptr242 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 2
-  %mask_ptr243 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 3
-  %280 = alloca [100 x i1], align 1
-  %.sub563 = getelementptr inbounds [100 x i1], [100 x i1]* %280, i64 0, i64 0
-  %281 = bitcast [100 x i1]* %280 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %281, i8 0, i64 100, i1 false)
-  store i32 100, i32* %x_ptr240, align 8
-  store i32 1, i32* %y_ptr241, align 4
-  %282 = bitcast i64** %arr_ptr242 to i8**
-  store i8* %4, i8** %282, align 8
-  store i1* %.sub563, i1** %mask_ptr243, align 8
-  call void @print_int_arr(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @res_is.F21393DB.0, i64 0, i64 0), i64 14, <{ i32, i32, i64*, i1* }>* nonnull %out_arr_alloca239)
-  br label %__barray_check_bounds.exit860
+__barray_check_none_borrowed.exit926:             ; preds = %__barray_check_none_borrowed.exit921
+  %out_arr_alloca287 = alloca <{ i32, i32, i64*, i1* }>, align 8
+  %x_ptr288 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 0
+  %y_ptr289 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 1
+  %arr_ptr290 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 2
+  %mask_ptr291 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 3
+  %277 = alloca [100 x i1], align 1
+  %.sub635 = getelementptr inbounds [100 x i1], [100 x i1]* %277, i64 0, i64 0
+  %278 = bitcast [100 x i1]* %277 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %278, i8 0, i64 100, i1 false)
+  store i32 100, i32* %x_ptr288, align 8
+  store i32 1, i32* %y_ptr289, align 4
+  %279 = bitcast i64** %arr_ptr290 to i8**
+  store i8* %4, i8** %279, align 8
+  store i1* %.sub635, i1** %mask_ptr291, align 8
+  call void @print_int_arr(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @res_is.F21393DB.0, i64 0, i64 0), i64 14, <{ i32, i32, i64*, i1* }>* nonnull %out_arr_alloca287)
+  br label %__barray_check_bounds.exit934
 
-mask_block_err.i851:                              ; preds = %__barray_check_none_borrowed.exit847
+mask_block_err.i925:                              ; preds = %__barray_check_none_borrowed.exit921
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit860:                    ; preds = %cond_exit_130, %__barray_check_none_borrowed.exit852
-  %"125_0.sroa.0.0901" = phi i64 [ 0, %__barray_check_none_borrowed.exit852 ], [ %283, %cond_exit_130 ]
-  %283 = add nuw nsw i64 %"125_0.sroa.0.0901", 1
-  %284 = lshr i64 %"125_0.sroa.0.0901", 6
-  %285 = getelementptr inbounds i64, i64* %3, i64 %284
-  %286 = load i64, i64* %285, align 4
-  %287 = and i64 %"125_0.sroa.0.0901", 63
-  %288 = shl nuw i64 1, %287
-  %289 = and i64 %286, %288
-  %.not.i861 = icmp eq i64 %289, 0
-  br i1 %.not.i861, label %panic.i862, label %cond_exit_130
+__barray_check_bounds.exit934:                    ; preds = %cond_exit_130, %__barray_check_none_borrowed.exit926
+  %"125_0.sroa.0.0974" = phi i64 [ 0, %__barray_check_none_borrowed.exit926 ], [ %280, %cond_exit_130 ]
+  %280 = add nuw nsw i64 %"125_0.sroa.0.0974", 1
+  %281 = lshr i64 %"125_0.sroa.0.0974", 6
+  %282 = getelementptr inbounds i64, i64* %3, i64 %281
+  %283 = load i64, i64* %282, align 4
+  %284 = and i64 %"125_0.sroa.0.0974", 63
+  %285 = shl nuw i64 1, %284
+  %286 = and i64 %283, %285
+  %.not.i935 = icmp eq i64 %286, 0
+  br i1 %.not.i935, label %panic.i936, label %cond_exit_130
 
-panic.i862:                                       ; preds = %__barray_check_bounds.exit860
+panic.i936:                                       ; preds = %__barray_check_bounds.exit934
   call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-cond_exit_130:                                    ; preds = %__barray_check_bounds.exit860
-  %290 = sitofp i64 %"125_0.sroa.0.0901" to double
-  %291 = fmul double %290, 6.250000e-02
-  %292 = xor i64 %286, %288
-  store i64 %292, i64* %285, align 4
-  %293 = getelementptr inbounds double, double* %1, i64 %"125_0.sroa.0.0901"
-  store double %291, double* %293, align 8
-  %exitcond912.not = icmp eq i64 %283, 100
-  br i1 %exitcond912.not, label %loop_out251, label %__barray_check_bounds.exit860
+cond_exit_130:                                    ; preds = %__barray_check_bounds.exit934
+  %287 = sitofp i64 %"125_0.sroa.0.0974" to double
+  %288 = fmul double %287, 6.250000e-02
+  %289 = xor i64 %283, %285
+  store i64 %289, i64* %282, align 4
+  %290 = getelementptr inbounds double, double* %1, i64 %"125_0.sroa.0.0974"
+  store double %288, double* %290, align 8
+  %exitcond984.not = icmp eq i64 %280, 100
+  br i1 %exitcond984.not, label %loop_out299, label %__barray_check_bounds.exit934
 
-loop_out251:                                      ; preds = %cond_exit_130
-  %294 = getelementptr inbounds i8, i8* %2, i64 8
-  %295 = bitcast i8* %294 to i64*
-  %296 = load i64, i64* %295, align 4
-  %297 = and i64 %296, 68719476735
-  store i64 %297, i64* %295, align 4
-  %298 = load i64, i64* %3, align 4
-  %299 = icmp eq i64 %298, 0
-  %300 = icmp eq i64 %297, 0
-  %or.cond914 = select i1 %299, i1 %300, i1 false
-  br i1 %or.cond914, label %__barray_check_none_borrowed.exit868, label %mask_block_err.i867
+loop_out299:                                      ; preds = %cond_exit_130
+  %291 = getelementptr inbounds i8, i8* %2, i64 8
+  %292 = bitcast i8* %291 to i64*
+  %293 = load i64, i64* %292, align 4
+  %294 = and i64 %293, 68719476735
+  store i64 %294, i64* %292, align 4
+  %295 = load i64, i64* %3, align 4
+  %296 = icmp eq i64 %295, 0
+  %297 = icmp eq i64 %294, 0
+  %or.cond987 = select i1 %296, i1 %297, i1 false
+  br i1 %or.cond987, label %__barray_check_none_borrowed.exit942, label %mask_block_err.i941
 
-__barray_check_none_borrowed.exit868:             ; preds = %loop_out251
-  %301 = call i8* @heap_alloc(i64 800)
-  %302 = bitcast i8* %301 to double*
-  %303 = call i8* @heap_alloc(i64 16)
-  %304 = bitcast i8* %303 to i64*
-  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %304, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0f64.p0f64.i64(double* noundef nonnull align 1 dereferenceable(800) %302, double* noundef nonnull align 1 dereferenceable(800) %1, i64 800, i1 false)
-  call void @heap_free(i8* %301)
-  %305 = load i64, i64* %295, align 4
-  %306 = and i64 %305, 68719476735
-  store i64 %306, i64* %295, align 4
-  %307 = load i64, i64* %3, align 4
-  %308 = icmp eq i64 %307, 0
-  %309 = icmp eq i64 %306, 0
-  %or.cond915 = select i1 %308, i1 %309, i1 false
-  br i1 %or.cond915, label %__barray_check_none_borrowed.exit873, label %mask_block_err.i872
+__barray_check_none_borrowed.exit942:             ; preds = %loop_out299
+  %298 = call i8* @heap_alloc(i64 800)
+  %299 = bitcast i8* %298 to double*
+  %300 = call i8* @heap_alloc(i64 16)
+  %301 = bitcast i8* %300 to i64*
+  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %301, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0f64.p0f64.i64(double* noundef nonnull align 1 dereferenceable(800) %299, double* noundef nonnull align 1 dereferenceable(800) %1, i64 800, i1 false)
+  call void @heap_free(i8* %298)
+  %302 = load i64, i64* %292, align 4
+  %303 = and i64 %302, 68719476735
+  store i64 %303, i64* %292, align 4
+  %304 = load i64, i64* %3, align 4
+  %305 = icmp eq i64 %304, 0
+  %306 = icmp eq i64 %303, 0
+  %or.cond988 = select i1 %305, i1 %306, i1 false
+  br i1 %or.cond988, label %__barray_check_none_borrowed.exit947, label %mask_block_err.i946
 
-mask_block_err.i867:                              ; preds = %loop_out251
+mask_block_err.i941:                              ; preds = %loop_out299
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit873:             ; preds = %__barray_check_none_borrowed.exit868
-  %out_arr_alloca329 = alloca <{ i32, i32, double*, i1* }>, align 8
-  %x_ptr330 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 0
-  %y_ptr331 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 1
-  %arr_ptr332 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 2
-  %mask_ptr333 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 3
-  %310 = alloca [100 x i1], align 1
-  %.sub664 = getelementptr inbounds [100 x i1], [100 x i1]* %310, i64 0, i64 0
-  %311 = bitcast [100 x i1]* %310 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %311, i8 0, i64 100, i1 false)
-  store i32 100, i32* %x_ptr330, align 8
-  store i32 1, i32* %y_ptr331, align 4
-  %312 = bitcast double** %arr_ptr332 to i8**
-  store i8* %0, i8** %312, align 8
-  store i1* %.sub664, i1** %mask_ptr333, align 8
-  call void @print_float_arr(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @res_fs.CBD4AF54.0, i64 0, i64 0), i64 16, <{ i32, i32, double*, i1* }>* nonnull %out_arr_alloca329)
+__barray_check_none_borrowed.exit947:             ; preds = %__barray_check_none_borrowed.exit942
+  %out_arr_alloca377 = alloca <{ i32, i32, double*, i1* }>, align 8
+  %x_ptr378 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 0
+  %y_ptr379 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 1
+  %arr_ptr380 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 2
+  %mask_ptr381 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 3
+  %307 = alloca [100 x i1], align 1
+  %.sub736 = getelementptr inbounds [100 x i1], [100 x i1]* %307, i64 0, i64 0
+  %308 = bitcast [100 x i1]* %307 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %308, i8 0, i64 100, i1 false)
+  store i32 100, i32* %x_ptr378, align 8
+  store i32 1, i32* %y_ptr379, align 4
+  %309 = bitcast double** %arr_ptr380 to i8**
+  store i8* %0, i8** %309, align 8
+  store i1* %.sub736, i1** %mask_ptr381, align 8
+  call void @print_float_arr(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @res_fs.CBD4AF54.0, i64 0, i64 0), i64 16, <{ i32, i32, double*, i1* }>* nonnull %out_arr_alloca377)
   ret void
 
-mask_block_err.i872:                              ; preds = %__barray_check_none_borrowed.exit868
+mask_block_err.i946:                              ; preds = %__barray_check_none_borrowed.exit942
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 }
@@ -1022,6 +948,8 @@ declare void @panic(i32, i8*) local_unnamed_addr #1
 
 declare void @heap_free(i8*) local_unnamed_addr
 
+declare void @___dec_future_refcount(i64) local_unnamed_addr
+
 declare void @print_bool_arr(i8*, i64, <{ i32, i32, i1*, i1* }>*) local_unnamed_addr
 
 ; Function Attrs: argmemonly mustprogress nofree nounwind willreturn
@@ -1035,8 +963,6 @@ declare void @llvm.memcpy.p0f64.p0f64.i64(double* noalias nocapture writeonly, d
 declare void @print_float_arr(i8*, i64, <{ i32, i32, double*, i1* }>*) local_unnamed_addr
 
 declare i1 @___read_future_bool(i64) local_unnamed_addr
-
-declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 declare i64 @___lazy_measure(i64) local_unnamed_addr
 

--- a/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_print_array/x86_64-windows-msvc/print_array_x86_64-windows-msvc
+++ b/qis-compiler/python/tests/snapshots/test_basic_generation/test_llvm_print_array/x86_64-windows-msvc/print_array_x86_64-windows-msvc
@@ -6,10 +6,10 @@ target triple = "x86_64-windows-msvc"
 @"e_Array alre.5A300C2A.0" = private constant [57 x i8] c"8EXIT:INT:Array already contains an element at this index"
 @"e_Array elem.E746B1A3.0" = private constant [43 x i8] c"*EXIT:INT:Array element is already borrowed"
 @"e_Some array.A77EF32E.0" = private constant [48 x i8] c"/EXIT:INT:Some array elements have been borrowed"
+@"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @res_cs.46C3C4B5.0 = private constant [16 x i8] c"\0FUSER:BOOLARR:cs"
 @res_is.F21393DB.0 = private constant [15 x i8] c"\0EUSER:INTARR:is"
 @res_fs.CBD4AF54.0 = private constant [17 x i8] c"\10USER:FLOATARR:fs"
-@"e_Array cont.EFA5AC45.0" = private constant [70 x i8] c"EEXIT:INT:Array contains non-borrowed elements and cannot be discarded"
 @"e_No more qu.3B2EEBF0.0" = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
 @"e_Expected v.E6312129.0" = private constant [46 x i8] c"-EXIT:INT:Expected variant 1 but got variant 0"
 @"e_Expected v.2F17E0A9.0" = private constant [46 x i8] c"-EXIT:INT:Expected variant 0 but got variant 1"
@@ -34,8 +34,8 @@ alloca_block:
   br label %cond_20_case_1
 
 cond_20_case_1:                                   ; preds = %alloca_block, %cond_exit_20
-  %"15_0.sroa.0.0887" = phi i64 [ 0, %alloca_block ], [ %12, %cond_exit_20 ]
-  %12 = add nuw nsw i64 %"15_0.sroa.0.0887", 1
+  %"15_0.sroa.0.0961" = phi i64 [ 0, %alloca_block ], [ %12, %cond_exit_20 ]
+  %12 = add nuw nsw i64 %"15_0.sroa.0.0961", 1
   %qalloc.i = tail call i64 @___qalloc()
   %not_max.not.i = icmp eq i64 %qalloc.i, -1
   br i1 %not_max.not.i, label %id_bb.i, label %reset_bb.i
@@ -55,10 +55,10 @@ cond_303_case_0.i:                                ; preds = %id_bb.i
   unreachable
 
 __barray_check_bounds.exit:                       ; preds = %id_bb.i
-  %15 = lshr i64 %"15_0.sroa.0.0887", 6
+  %15 = lshr i64 %"15_0.sroa.0.0961", 6
   %16 = getelementptr inbounds i64, i64* %11, i64 %15
   %17 = load i64, i64* %16, align 4
-  %18 = shl nuw nsw i64 1, %"15_0.sroa.0.0887"
+  %18 = shl nuw nsw i64 1, %"15_0.sroa.0.0961"
   %19 = and i64 %17, %18
   %.not.i = icmp eq i64 %19, 0
   br i1 %.not.i, label %panic.i, label %cond_exit_20
@@ -71,7 +71,7 @@ cond_exit_20:                                     ; preds = %__barray_check_boun
   %.fca.1.extract.i = extractvalue { i1, i64 } %14, 1
   %20 = xor i64 %17, %18
   store i64 %20, i64* %16, align 4
-  %21 = getelementptr inbounds i64, i64* %9, i64 %"15_0.sroa.0.0887"
+  %21 = getelementptr inbounds i64, i64* %9, i64 %"15_0.sroa.0.0961"
   store i64 %.fca.1.extract.i, i64* %21, align 4
   %exitcond.not = icmp eq i64 %12, 10
   br i1 %exitcond.not, label %loop_out, label %cond_20_case_1
@@ -79,10 +79,10 @@ cond_exit_20:                                     ; preds = %__barray_check_boun
 loop_out:                                         ; preds = %cond_exit_20
   %22 = load i64, i64* %11, align 4
   %23 = and i64 %22, 1
-  %.not.i781 = icmp eq i64 %23, 0
-  br i1 %.not.i781, label %__barray_mask_borrow.exit, label %panic.i782
+  %.not.i852 = icmp eq i64 %23, 0
+  br i1 %.not.i852, label %__barray_mask_borrow.exit, label %panic.i853
 
-panic.i782:                                       ; preds = %loop_out
+panic.i853:                                       ; preds = %loop_out
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
@@ -93,27 +93,27 @@ __barray_mask_borrow.exit:                        ; preds = %loop_out
   tail call void @___rxy(i64 %25, double 0x400921FB54442D18, double 0.000000e+00)
   %26 = load i64, i64* %11, align 4
   %27 = and i64 %26, 1
-  %.not.i783 = icmp eq i64 %27, 0
-  br i1 %.not.i783, label %panic.i784, label %__barray_mask_return.exit785
+  %.not.i854 = icmp eq i64 %27, 0
+  br i1 %.not.i854, label %panic.i855, label %__barray_mask_return.exit856
 
-panic.i784:                                       ; preds = %__barray_mask_borrow.exit
+panic.i855:                                       ; preds = %__barray_mask_borrow.exit
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit785:                     ; preds = %__barray_mask_borrow.exit
+__barray_mask_return.exit856:                     ; preds = %__barray_mask_borrow.exit
   %28 = xor i64 %26, 1
   store i64 %28, i64* %11, align 4
   store i64 %25, i64* %9, align 4
   %29 = load i64, i64* %11, align 4
   %30 = and i64 %29, 4
-  %.not.i786 = icmp eq i64 %30, 0
-  br i1 %.not.i786, label %__barray_mask_borrow.exit788, label %panic.i787
+  %.not.i857 = icmp eq i64 %30, 0
+  br i1 %.not.i857, label %__barray_mask_borrow.exit859, label %panic.i858
 
-panic.i787:                                       ; preds = %__barray_mask_return.exit785
+panic.i858:                                       ; preds = %__barray_mask_return.exit856
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit788:                     ; preds = %__barray_mask_return.exit785
+__barray_mask_borrow.exit859:                     ; preds = %__barray_mask_return.exit856
   %31 = xor i64 %29, 4
   store i64 %31, i64* %11, align 4
   %32 = getelementptr inbounds i8, i8* %8, i64 16
@@ -122,27 +122,27 @@ __barray_mask_borrow.exit788:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %34, double 0x400921FB54442D18, double 0.000000e+00)
   %35 = load i64, i64* %11, align 4
   %36 = and i64 %35, 4
-  %.not.i789 = icmp eq i64 %36, 0
-  br i1 %.not.i789, label %panic.i790, label %__barray_mask_return.exit791
+  %.not.i860 = icmp eq i64 %36, 0
+  br i1 %.not.i860, label %panic.i861, label %__barray_mask_return.exit862
 
-panic.i790:                                       ; preds = %__barray_mask_borrow.exit788
+panic.i861:                                       ; preds = %__barray_mask_borrow.exit859
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit791:                     ; preds = %__barray_mask_borrow.exit788
+__barray_mask_return.exit862:                     ; preds = %__barray_mask_borrow.exit859
   %37 = xor i64 %35, 4
   store i64 %37, i64* %11, align 4
   store i64 %34, i64* %33, align 4
   %38 = load i64, i64* %11, align 4
   %39 = and i64 %38, 8
-  %.not.i792 = icmp eq i64 %39, 0
-  br i1 %.not.i792, label %__barray_mask_borrow.exit794, label %panic.i793
+  %.not.i863 = icmp eq i64 %39, 0
+  br i1 %.not.i863, label %__barray_mask_borrow.exit865, label %panic.i864
 
-panic.i793:                                       ; preds = %__barray_mask_return.exit791
+panic.i864:                                       ; preds = %__barray_mask_return.exit862
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit794:                     ; preds = %__barray_mask_return.exit791
+__barray_mask_borrow.exit865:                     ; preds = %__barray_mask_return.exit862
   %40 = xor i64 %38, 8
   store i64 %40, i64* %11, align 4
   %41 = getelementptr inbounds i8, i8* %8, i64 24
@@ -151,27 +151,27 @@ __barray_mask_borrow.exit794:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %43, double 0x400921FB54442D18, double 0.000000e+00)
   %44 = load i64, i64* %11, align 4
   %45 = and i64 %44, 8
-  %.not.i795 = icmp eq i64 %45, 0
-  br i1 %.not.i795, label %panic.i796, label %__barray_mask_return.exit797
+  %.not.i866 = icmp eq i64 %45, 0
+  br i1 %.not.i866, label %panic.i867, label %__barray_mask_return.exit868
 
-panic.i796:                                       ; preds = %__barray_mask_borrow.exit794
+panic.i867:                                       ; preds = %__barray_mask_borrow.exit865
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit797:                     ; preds = %__barray_mask_borrow.exit794
+__barray_mask_return.exit868:                     ; preds = %__barray_mask_borrow.exit865
   %46 = xor i64 %44, 8
   store i64 %46, i64* %11, align 4
   store i64 %43, i64* %42, align 4
   %47 = load i64, i64* %11, align 4
   %48 = and i64 %47, 512
-  %.not.i798 = icmp eq i64 %48, 0
-  br i1 %.not.i798, label %__barray_mask_borrow.exit800, label %panic.i799
+  %.not.i869 = icmp eq i64 %48, 0
+  br i1 %.not.i869, label %__barray_mask_borrow.exit871, label %panic.i870
 
-panic.i799:                                       ; preds = %__barray_mask_return.exit797
+panic.i870:                                       ; preds = %__barray_mask_return.exit868
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_borrow.exit800:                     ; preds = %__barray_mask_return.exit797
+__barray_mask_borrow.exit871:                     ; preds = %__barray_mask_return.exit868
   %49 = xor i64 %47, 512
   store i64 %49, i64* %11, align 4
   %50 = getelementptr inbounds i8, i8* %8, i64 72
@@ -180,14 +180,14 @@ __barray_mask_borrow.exit800:                     ; preds = %__barray_mask_retur
   tail call void @___rxy(i64 %52, double 0x400921FB54442D18, double 0.000000e+00)
   %53 = load i64, i64* %11, align 4
   %54 = and i64 %53, 512
-  %.not.i801 = icmp eq i64 %54, 0
-  br i1 %.not.i801, label %panic.i802, label %__barray_mask_return.exit803
+  %.not.i872 = icmp eq i64 %54, 0
+  br i1 %.not.i872, label %panic.i873, label %__barray_mask_return.exit874
 
-panic.i802:                                       ; preds = %__barray_mask_borrow.exit800
+panic.i873:                                       ; preds = %__barray_mask_borrow.exit871
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-__barray_mask_return.exit803:                     ; preds = %__barray_mask_borrow.exit800
+__barray_mask_return.exit874:                     ; preds = %__barray_mask_borrow.exit871
   %55 = xor i64 %53, 512
   store i64 %55, i64* %11, align 4
   store i64 %52, i64* %51, align 4
@@ -223,13 +223,13 @@ mask_block_err.i.i.i:                             ; preds = %mask_block_ok.i.i.i
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-69:                                               ; preds = %__barray_mask_return.exit803, %cond_exit_443.i
-  %"393_0.sroa.15.0.i889" = phi i64 [ 0, %__barray_mask_return.exit803 ], [ %70, %cond_exit_443.i ]
-  %70 = add nuw nsw i64 %"393_0.sroa.15.0.i889", 1
-  %71 = lshr i64 %"393_0.sroa.15.0.i889", 6
+69:                                               ; preds = %__barray_mask_return.exit874, %cond_exit_443.i
+  %"393_0.sroa.15.0.i963" = phi i64 [ 0, %__barray_mask_return.exit874 ], [ %70, %cond_exit_443.i ]
+  %70 = add nuw nsw i64 %"393_0.sroa.15.0.i963", 1
+  %71 = lshr i64 %"393_0.sroa.15.0.i963", 6
   %72 = getelementptr inbounds i64, i64* %11, i64 %71
   %73 = load i64, i64* %72, align 4
-  %74 = shl nuw nsw i64 1, %"393_0.sroa.15.0.i889"
+  %74 = shl nuw nsw i64 1, %"393_0.sroa.15.0.i963"
   %75 = and i64 %73, %74
   %.not.i99.i.i = icmp eq i64 %75, 0
   br i1 %.not.i99.i.i, label %__barray_check_bounds.exit.i, label %panic.i.i.i
@@ -241,7 +241,7 @@ panic.i.i.i:                                      ; preds = %69
 __barray_check_bounds.exit.i:                     ; preds = %69
   %76 = xor i64 %73, %74
   store i64 %76, i64* %72, align 4
-  %77 = getelementptr inbounds i64, i64* %9, i64 %"393_0.sroa.15.0.i889"
+  %77 = getelementptr inbounds i64, i64* %9, i64 %"393_0.sroa.15.0.i963"
   %78 = load i64, i64* %77, align 4
   %lazy_measure.i = tail call i64 @___lazy_measure(i64 %78)
   tail call void @___qfree(i64 %78)
@@ -259,10 +259,10 @@ cond_exit_443.i:                                  ; preds = %__barray_check_boun
   %"457_054.fca.1.insert.i" = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %lazy_measure.i, 1
   %82 = xor i64 %80, %74
   store i64 %82, i64* %79, align 4
-  %83 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %"393_0.sroa.15.0.i889"
+  %83 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %"393_0.sroa.15.0.i963"
   store { i1, i64, i1 } %"457_054.fca.1.insert.i", { i1, i64, i1 }* %83, align 4
-  %exitcond906.not = icmp eq i64 %70, 10
-  br i1 %exitcond906.not, label %mask_block_ok.i.i.i, label %69
+  %exitcond979.not = icmp eq i64 %70, 10
+  br i1 %exitcond979.not, label %mask_block_ok.i.i.i, label %69
 
 __barray_check_none_borrowed.exit:                ; preds = %"__hugr__.$measure_array$$n(10).367.exit"
   %84 = tail call i8* @heap_alloc(i64 240)
@@ -278,77 +278,77 @@ mask_block_err.i:                                 ; preds = %"__hugr__.$measure_
   unreachable
 
 89:                                               ; preds = %__barray_check_none_borrowed.exit, %__hugr__.const_fun_290.309.exit
-  %storemerge779894 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %107, %__hugr__.const_fun_290.309.exit ]
+  %storemerge850968 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %107, %__hugr__.const_fun_290.309.exit ]
   %90 = phi i64 [ 0, %__barray_check_none_borrowed.exit ], [ %105, %__hugr__.const_fun_290.309.exit ]
-  %91 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %storemerge779894
+  %91 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %57, i64 %storemerge850968
   %92 = load { i1, i64, i1 }, { i1, i64, i1 }* %91, align 4
   %.fca.0.extract118.i = extractvalue { i1, i64, i1 } %92, 0
   %.fca.1.extract119.i = extractvalue { i1, i64, i1 } %92, 1
-  br i1 %.fca.0.extract118.i, label %cond_485_case_1.i, label %cond_exit_485.i
+  br i1 %.fca.0.extract118.i, label %cond_525_case_1.i, label %cond_exit_525.i
 
-cond_485_case_1.i:                                ; preds = %89
+cond_525_case_1.i:                                ; preds = %89
   tail call void @___inc_future_refcount(i64 %.fca.1.extract119.i)
   %93 = insertvalue { i1, i64, i1 } { i1 true, i64 poison, i1 poison }, i64 %.fca.1.extract119.i, 1
-  br label %cond_exit_485.i
+  br label %cond_exit_525.i
 
-cond_exit_485.i:                                  ; preds = %cond_485_case_1.i, %89
-  %.pn.i = phi { i1, i64, i1 } [ %93, %cond_485_case_1.i ], [ %92, %89 ]
+cond_exit_525.i:                                  ; preds = %cond_525_case_1.i, %89
+  %.pn.i = phi { i1, i64, i1 } [ %93, %cond_525_case_1.i ], [ %92, %89 ]
   %"04.sroa.6.0.i" = extractvalue { i1, i64, i1 } %.pn.i, 2
   %94 = icmp ult i64 %90, 10
-  br i1 %94, label %95, label %cond_488_case_0.i
+  br i1 %94, label %95, label %cond_528_case_0.i
 
-95:                                               ; preds = %cond_exit_485.i
+95:                                               ; preds = %cond_exit_525.i
   %96 = lshr i64 %90, 6
   %97 = getelementptr inbounds i64, i64* %65, i64 %96
   %98 = load i64, i64* %97, align 4
   %99 = shl nuw nsw i64 1, %90
   %100 = and i64 %98, %99
-  %.not.i.i805 = icmp eq i64 %100, 0
-  br i1 %.not.i.i805, label %cond_488_case_1.i, label %panic.i.i806
+  %.not.i.i876 = icmp eq i64 %100, 0
+  br i1 %.not.i.i876, label %cond_528_case_1.i, label %panic.i.i877
 
-panic.i.i806:                                     ; preds = %95
+panic.i.i877:                                     ; preds = %95
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @"e_Array elem.E746B1A3.0", i64 0, i64 0))
   unreachable
 
-cond_488_case_0.i:                                ; preds = %cond_exit_485.i
+cond_528_case_0.i:                                ; preds = %cond_exit_525.i
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.E6312129.0", i64 0, i64 0))
   unreachable
 
-cond_488_case_1.i:                                ; preds = %95
+cond_528_case_1.i:                                ; preds = %95
   %"17.fca.2.insert.i" = insertvalue { i1, i64, i1 } %92, i1 %"04.sroa.6.0.i", 2
   %101 = insertvalue { i1, { i1, i64, i1 } } { i1 true, { i1, i64, i1 } poison }, { i1, i64, i1 } %"17.fca.2.insert.i", 1
   %102 = getelementptr inbounds { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %88, i64 %90
   %103 = getelementptr inbounds { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %102, i64 0, i32 0
   %104 = load i1, i1* %103, align 1
   store { i1, { i1, i64, i1 } } %101, { i1, { i1, i64, i1 } }* %102, align 4
-  br i1 %104, label %cond_489_case_1.i, label %__hugr__.const_fun_290.309.exit
+  br i1 %104, label %cond_529_case_1.i, label %__hugr__.const_fun_290.309.exit
 
-cond_489_case_1.i:                                ; preds = %cond_488_case_1.i
+cond_529_case_1.i:                                ; preds = %cond_528_case_1.i
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.2F17E0A9.0", i64 0, i64 0))
   unreachable
 
-__hugr__.const_fun_290.309.exit:                  ; preds = %cond_488_case_1.i
+__hugr__.const_fun_290.309.exit:                  ; preds = %cond_528_case_1.i
   %105 = add nuw nsw i64 %90, 1
-  %106 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %85, i64 %storemerge779894
+  %106 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %85, i64 %storemerge850968
   store { i1, i64, i1 } %"17.fca.2.insert.i", { i1, i64, i1 }* %106, align 4
-  %107 = add nuw nsw i64 %storemerge779894, 1
-  %exitcond907.not = icmp eq i64 %107, 10
-  br i1 %exitcond907.not, label %mask_block_ok.i810, label %89
+  %107 = add nuw nsw i64 %storemerge850968, 1
+  %exitcond980.not = icmp eq i64 %107, 10
+  br i1 %exitcond980.not, label %mask_block_ok.i881, label %89
 
-mask_block_ok.i810:                               ; preds = %__hugr__.const_fun_290.309.exit
+mask_block_ok.i881:                               ; preds = %__hugr__.const_fun_290.309.exit
   tail call void @heap_free(i8* nonnull %56)
   tail call void @heap_free(i8* %58)
   %108 = load i64, i64* %65, align 4
   %109 = and i64 %108, 1023
   store i64 %109, i64* %65, align 4
   %110 = icmp eq i64 %109, 0
-  br i1 %110, label %__barray_check_none_borrowed.exit812, label %mask_block_err.i811
+  br i1 %110, label %__barray_check_none_borrowed.exit883, label %mask_block_err.i882
 
-mask_block_err.i811:                              ; preds = %mask_block_ok.i810
+mask_block_err.i882:                              ; preds = %mask_block_ok.i881
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit812:             ; preds = %mask_block_ok.i810
+__barray_check_none_borrowed.exit883:             ; preds = %mask_block_ok.i881
   %111 = tail call i8* @heap_alloc(i64 240)
   %112 = bitcast i8* %111 to { i1, i64, i1 }*
   %113 = tail call i8* @heap_alloc(i64 8)
@@ -356,20 +356,20 @@ __barray_check_none_borrowed.exit812:             ; preds = %mask_block_ok.i810
   store i64 0, i64* %114, align 1
   %115 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %88, align 4
   %.fca.0.extract11.i = extractvalue { i1, { i1, i64, i1 } } %115, 0
-  br i1 %.fca.0.extract11.i, label %__hugr__.const_fun_284.290.exit, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i, label %__hugr__.const_fun_284.290.exit, label %cond_570_case_0.i
 
-cond_530_case_0.i:                                ; preds = %__hugr__.const_fun_284.290.exit.8, %__hugr__.const_fun_284.290.exit.7, %__hugr__.const_fun_284.290.exit.6, %__hugr__.const_fun_284.290.exit.5, %__hugr__.const_fun_284.290.exit.4, %__hugr__.const_fun_284.290.exit.3, %__hugr__.const_fun_284.290.exit.2, %__hugr__.const_fun_284.290.exit.1, %__hugr__.const_fun_284.290.exit, %__barray_check_none_borrowed.exit812
+cond_570_case_0.i:                                ; preds = %__hugr__.const_fun_284.290.exit.8, %__hugr__.const_fun_284.290.exit.7, %__hugr__.const_fun_284.290.exit.6, %__hugr__.const_fun_284.290.exit.5, %__hugr__.const_fun_284.290.exit.4, %__hugr__.const_fun_284.290.exit.3, %__hugr__.const_fun_284.290.exit.2, %__hugr__.const_fun_284.290.exit.1, %__hugr__.const_fun_284.290.exit, %__barray_check_none_borrowed.exit883
   tail call void @panic(i32 1001, i8* getelementptr inbounds ([46 x i8], [46 x i8]* @"e_Expected v.E6312129.0", i64 0, i64 0))
   unreachable
 
-__hugr__.const_fun_284.290.exit:                  ; preds = %__barray_check_none_borrowed.exit812
+__hugr__.const_fun_284.290.exit:                  ; preds = %__barray_check_none_borrowed.exit883
   %116 = extractvalue { i1, { i1, i64, i1 } } %115, 1
   store { i1, i64, i1 } %116, { i1, i64, i1 }* %112, align 4
   %117 = getelementptr inbounds i8, i8* %63, i64 32
   %118 = bitcast i8* %117 to { i1, { i1, i64, i1 } }*
   %119 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %118, align 4
   %.fca.0.extract11.i.1 = extractvalue { i1, { i1, i64, i1 } } %119, 0
-  br i1 %.fca.0.extract11.i.1, label %__hugr__.const_fun_284.290.exit.1, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.1, label %__hugr__.const_fun_284.290.exit.1, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.1:                ; preds = %__hugr__.const_fun_284.290.exit
   %120 = extractvalue { i1, { i1, i64, i1 } } %119, 1
@@ -380,7 +380,7 @@ __hugr__.const_fun_284.290.exit.1:                ; preds = %__hugr__.const_fun_
   %124 = bitcast i8* %123 to { i1, { i1, i64, i1 } }*
   %125 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %124, align 4
   %.fca.0.extract11.i.2 = extractvalue { i1, { i1, i64, i1 } } %125, 0
-  br i1 %.fca.0.extract11.i.2, label %__hugr__.const_fun_284.290.exit.2, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.2, label %__hugr__.const_fun_284.290.exit.2, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.2:                ; preds = %__hugr__.const_fun_284.290.exit.1
   %126 = extractvalue { i1, { i1, i64, i1 } } %125, 1
@@ -391,7 +391,7 @@ __hugr__.const_fun_284.290.exit.2:                ; preds = %__hugr__.const_fun_
   %130 = bitcast i8* %129 to { i1, { i1, i64, i1 } }*
   %131 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %130, align 4
   %.fca.0.extract11.i.3 = extractvalue { i1, { i1, i64, i1 } } %131, 0
-  br i1 %.fca.0.extract11.i.3, label %__hugr__.const_fun_284.290.exit.3, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.3, label %__hugr__.const_fun_284.290.exit.3, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.3:                ; preds = %__hugr__.const_fun_284.290.exit.2
   %132 = extractvalue { i1, { i1, i64, i1 } } %131, 1
@@ -402,7 +402,7 @@ __hugr__.const_fun_284.290.exit.3:                ; preds = %__hugr__.const_fun_
   %136 = bitcast i8* %135 to { i1, { i1, i64, i1 } }*
   %137 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %136, align 4
   %.fca.0.extract11.i.4 = extractvalue { i1, { i1, i64, i1 } } %137, 0
-  br i1 %.fca.0.extract11.i.4, label %__hugr__.const_fun_284.290.exit.4, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.4, label %__hugr__.const_fun_284.290.exit.4, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.4:                ; preds = %__hugr__.const_fun_284.290.exit.3
   %138 = extractvalue { i1, { i1, i64, i1 } } %137, 1
@@ -413,7 +413,7 @@ __hugr__.const_fun_284.290.exit.4:                ; preds = %__hugr__.const_fun_
   %142 = bitcast i8* %141 to { i1, { i1, i64, i1 } }*
   %143 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %142, align 4
   %.fca.0.extract11.i.5 = extractvalue { i1, { i1, i64, i1 } } %143, 0
-  br i1 %.fca.0.extract11.i.5, label %__hugr__.const_fun_284.290.exit.5, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.5, label %__hugr__.const_fun_284.290.exit.5, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.5:                ; preds = %__hugr__.const_fun_284.290.exit.4
   %144 = extractvalue { i1, { i1, i64, i1 } } %143, 1
@@ -424,7 +424,7 @@ __hugr__.const_fun_284.290.exit.5:                ; preds = %__hugr__.const_fun_
   %148 = bitcast i8* %147 to { i1, { i1, i64, i1 } }*
   %149 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %148, align 4
   %.fca.0.extract11.i.6 = extractvalue { i1, { i1, i64, i1 } } %149, 0
-  br i1 %.fca.0.extract11.i.6, label %__hugr__.const_fun_284.290.exit.6, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.6, label %__hugr__.const_fun_284.290.exit.6, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.6:                ; preds = %__hugr__.const_fun_284.290.exit.5
   %150 = extractvalue { i1, { i1, i64, i1 } } %149, 1
@@ -435,7 +435,7 @@ __hugr__.const_fun_284.290.exit.6:                ; preds = %__hugr__.const_fun_
   %154 = bitcast i8* %153 to { i1, { i1, i64, i1 } }*
   %155 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %154, align 4
   %.fca.0.extract11.i.7 = extractvalue { i1, { i1, i64, i1 } } %155, 0
-  br i1 %.fca.0.extract11.i.7, label %__hugr__.const_fun_284.290.exit.7, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.7, label %__hugr__.const_fun_284.290.exit.7, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.7:                ; preds = %__hugr__.const_fun_284.290.exit.6
   %156 = extractvalue { i1, { i1, i64, i1 } } %155, 1
@@ -446,7 +446,7 @@ __hugr__.const_fun_284.290.exit.7:                ; preds = %__hugr__.const_fun_
   %160 = bitcast i8* %159 to { i1, { i1, i64, i1 } }*
   %161 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %160, align 4
   %.fca.0.extract11.i.8 = extractvalue { i1, { i1, i64, i1 } } %161, 0
-  br i1 %.fca.0.extract11.i.8, label %__hugr__.const_fun_284.290.exit.8, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.8, label %__hugr__.const_fun_284.290.exit.8, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.8:                ; preds = %__hugr__.const_fun_284.290.exit.7
   %162 = extractvalue { i1, { i1, i64, i1 } } %161, 1
@@ -457,7 +457,7 @@ __hugr__.const_fun_284.290.exit.8:                ; preds = %__hugr__.const_fun_
   %166 = bitcast i8* %165 to { i1, { i1, i64, i1 } }*
   %167 = load { i1, { i1, i64, i1 } }, { i1, { i1, i64, i1 } }* %166, align 4
   %.fca.0.extract11.i.9 = extractvalue { i1, { i1, i64, i1 } } %167, 0
-  br i1 %.fca.0.extract11.i.9, label %__hugr__.const_fun_284.290.exit.9, label %cond_530_case_0.i
+  br i1 %.fca.0.extract11.i.9, label %__hugr__.const_fun_284.290.exit.9, label %cond_570_case_0.i
 
 __hugr__.const_fun_284.290.exit.9:                ; preds = %__hugr__.const_fun_284.290.exit.8
   %168 = extractvalue { i1, { i1, i64, i1 } } %167, 1
@@ -466,548 +466,474 @@ __hugr__.const_fun_284.290.exit.9:                ; preds = %__hugr__.const_fun_
   store { i1, i64, i1 } %168, { i1, i64, i1 }* %170, align 4
   tail call void @heap_free(i8* nonnull %63)
   tail call void @heap_free(i8* nonnull %64)
+  br label %__barray_check_bounds.exit888
+
+cond_165_case_0:                                  ; preds = %cond_exit_165
   %171 = load i64, i64* %114, align 4
-  %172 = and i64 %171, 1023
+  %172 = or i64 %171, -1024
   store i64 %172, i64* %114, align 4
-  %173 = icmp eq i64 %172, 0
-  br i1 %173, label %__barray_check_none_borrowed.exit817, label %mask_block_err.i816
+  %173 = icmp eq i64 %172, -1
+  br i1 %173, label %loop_out139, label %mask_block_err.i886
 
-__barray_check_none_borrowed.exit817:             ; preds = %__hugr__.const_fun_284.290.exit.9
-  %174 = tail call i8* @heap_alloc(i64 0)
-  %175 = tail call i8* @heap_alloc(i64 8)
-  %176 = bitcast i8* %175 to i64*
-  store i64 0, i64* %176, align 1
-  %177 = load { i1, i64, i1 }, { i1, i64, i1 }* %112, align 4
-  %.fca.0.extract.i818 = extractvalue { i1, i64, i1 } %177, 0
-  br i1 %.fca.0.extract.i818, label %cond_543_case_1.i, label %__hugr__.const_fun_175.284.exit
-
-mask_block_err.i816:                              ; preds = %__hugr__.const_fun_284.290.exit.9
-  tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
+mask_block_err.i886:                              ; preds = %cond_165_case_0
+  tail call void @panic(i32 1002, i8* getelementptr inbounds ([70 x i8], [70 x i8]* @"e_Array cont.EFA5AC45.0", i64 0, i64 0))
   unreachable
 
-cond_543_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit817
-  %.fca.1.extract.i819 = extractvalue { i1, i64, i1 } %177, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819)
-  br label %__hugr__.const_fun_175.284.exit
+__barray_check_bounds.exit888:                    ; preds = %__hugr__.const_fun_284.290.exit.9, %cond_exit_165
+  %"167_0.0989" = phi i64 [ 0, %__hugr__.const_fun_284.290.exit.9 ], [ %174, %cond_exit_165 ]
+  %174 = add nuw nsw i64 %"167_0.0989", 1
+  %175 = lshr i64 %"167_0.0989", 6
+  %176 = getelementptr inbounds i64, i64* %114, i64 %175
+  %177 = load i64, i64* %176, align 4
+  %178 = shl nuw nsw i64 1, %"167_0.0989"
+  %179 = and i64 %177, %178
+  %.not = icmp eq i64 %179, 0
+  br i1 %.not, label %__barray_mask_borrow.exit893, label %cond_exit_165
 
-__hugr__.const_fun_175.284.exit:                  ; preds = %__barray_check_none_borrowed.exit817, %cond_543_case_1.i
-  %178 = load { i1, i64, i1 }, { i1, i64, i1 }* %122, align 4
-  %.fca.0.extract.i818.1 = extractvalue { i1, i64, i1 } %178, 0
-  br i1 %.fca.0.extract.i818.1, label %cond_543_case_1.i.1, label %__hugr__.const_fun_175.284.exit.1
+__barray_mask_borrow.exit893:                     ; preds = %__barray_check_bounds.exit888
+  %180 = xor i64 %177, %178
+  store i64 %180, i64* %176, align 4
+  %181 = getelementptr inbounds { i1, i64, i1 }, { i1, i64, i1 }* %112, i64 %"167_0.0989"
+  %182 = load { i1, i64, i1 }, { i1, i64, i1 }* %181, align 4
+  %.fca.0.extract511 = extractvalue { i1, i64, i1 } %182, 0
+  br i1 %.fca.0.extract511, label %cond_501_case_1, label %cond_exit_165
 
-cond_543_case_1.i.1:                              ; preds = %__hugr__.const_fun_175.284.exit
-  %.fca.1.extract.i819.1 = extractvalue { i1, i64, i1 } %178, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.1)
-  br label %__hugr__.const_fun_175.284.exit.1
+cond_exit_165:                                    ; preds = %cond_501_case_1, %__barray_mask_borrow.exit893, %__barray_check_bounds.exit888
+  %183 = icmp ult i64 %"167_0.0989", 9
+  br i1 %183, label %__barray_check_bounds.exit888, label %cond_165_case_0
 
-__hugr__.const_fun_175.284.exit.1:                ; preds = %cond_543_case_1.i.1, %__hugr__.const_fun_175.284.exit
-  %179 = load { i1, i64, i1 }, { i1, i64, i1 }* %128, align 4
-  %.fca.0.extract.i818.2 = extractvalue { i1, i64, i1 } %179, 0
-  br i1 %.fca.0.extract.i818.2, label %cond_543_case_1.i.2, label %__hugr__.const_fun_175.284.exit.2
-
-cond_543_case_1.i.2:                              ; preds = %__hugr__.const_fun_175.284.exit.1
-  %.fca.1.extract.i819.2 = extractvalue { i1, i64, i1 } %179, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.2)
-  br label %__hugr__.const_fun_175.284.exit.2
-
-__hugr__.const_fun_175.284.exit.2:                ; preds = %cond_543_case_1.i.2, %__hugr__.const_fun_175.284.exit.1
-  %180 = load { i1, i64, i1 }, { i1, i64, i1 }* %134, align 4
-  %.fca.0.extract.i818.3 = extractvalue { i1, i64, i1 } %180, 0
-  br i1 %.fca.0.extract.i818.3, label %cond_543_case_1.i.3, label %__hugr__.const_fun_175.284.exit.3
-
-cond_543_case_1.i.3:                              ; preds = %__hugr__.const_fun_175.284.exit.2
-  %.fca.1.extract.i819.3 = extractvalue { i1, i64, i1 } %180, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.3)
-  br label %__hugr__.const_fun_175.284.exit.3
-
-__hugr__.const_fun_175.284.exit.3:                ; preds = %cond_543_case_1.i.3, %__hugr__.const_fun_175.284.exit.2
-  %181 = load { i1, i64, i1 }, { i1, i64, i1 }* %140, align 4
-  %.fca.0.extract.i818.4 = extractvalue { i1, i64, i1 } %181, 0
-  br i1 %.fca.0.extract.i818.4, label %cond_543_case_1.i.4, label %__hugr__.const_fun_175.284.exit.4
-
-cond_543_case_1.i.4:                              ; preds = %__hugr__.const_fun_175.284.exit.3
-  %.fca.1.extract.i819.4 = extractvalue { i1, i64, i1 } %181, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.4)
-  br label %__hugr__.const_fun_175.284.exit.4
-
-__hugr__.const_fun_175.284.exit.4:                ; preds = %cond_543_case_1.i.4, %__hugr__.const_fun_175.284.exit.3
-  %182 = load { i1, i64, i1 }, { i1, i64, i1 }* %146, align 4
-  %.fca.0.extract.i818.5 = extractvalue { i1, i64, i1 } %182, 0
-  br i1 %.fca.0.extract.i818.5, label %cond_543_case_1.i.5, label %__hugr__.const_fun_175.284.exit.5
-
-cond_543_case_1.i.5:                              ; preds = %__hugr__.const_fun_175.284.exit.4
-  %.fca.1.extract.i819.5 = extractvalue { i1, i64, i1 } %182, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.5)
-  br label %__hugr__.const_fun_175.284.exit.5
-
-__hugr__.const_fun_175.284.exit.5:                ; preds = %cond_543_case_1.i.5, %__hugr__.const_fun_175.284.exit.4
-  %183 = load { i1, i64, i1 }, { i1, i64, i1 }* %152, align 4
-  %.fca.0.extract.i818.6 = extractvalue { i1, i64, i1 } %183, 0
-  br i1 %.fca.0.extract.i818.6, label %cond_543_case_1.i.6, label %__hugr__.const_fun_175.284.exit.6
-
-cond_543_case_1.i.6:                              ; preds = %__hugr__.const_fun_175.284.exit.5
-  %.fca.1.extract.i819.6 = extractvalue { i1, i64, i1 } %183, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.6)
-  br label %__hugr__.const_fun_175.284.exit.6
-
-__hugr__.const_fun_175.284.exit.6:                ; preds = %cond_543_case_1.i.6, %__hugr__.const_fun_175.284.exit.5
-  %184 = load { i1, i64, i1 }, { i1, i64, i1 }* %158, align 4
-  %.fca.0.extract.i818.7 = extractvalue { i1, i64, i1 } %184, 0
-  br i1 %.fca.0.extract.i818.7, label %cond_543_case_1.i.7, label %__hugr__.const_fun_175.284.exit.7
-
-cond_543_case_1.i.7:                              ; preds = %__hugr__.const_fun_175.284.exit.6
-  %.fca.1.extract.i819.7 = extractvalue { i1, i64, i1 } %184, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.7)
-  br label %__hugr__.const_fun_175.284.exit.7
-
-__hugr__.const_fun_175.284.exit.7:                ; preds = %cond_543_case_1.i.7, %__hugr__.const_fun_175.284.exit.6
-  %185 = load { i1, i64, i1 }, { i1, i64, i1 }* %164, align 4
-  %.fca.0.extract.i818.8 = extractvalue { i1, i64, i1 } %185, 0
-  br i1 %.fca.0.extract.i818.8, label %cond_543_case_1.i.8, label %__hugr__.const_fun_175.284.exit.8
-
-cond_543_case_1.i.8:                              ; preds = %__hugr__.const_fun_175.284.exit.7
-  %.fca.1.extract.i819.8 = extractvalue { i1, i64, i1 } %185, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.8)
-  br label %__hugr__.const_fun_175.284.exit.8
-
-__hugr__.const_fun_175.284.exit.8:                ; preds = %cond_543_case_1.i.8, %__hugr__.const_fun_175.284.exit.7
-  %186 = load { i1, i64, i1 }, { i1, i64, i1 }* %170, align 4
-  %.fca.0.extract.i818.9 = extractvalue { i1, i64, i1 } %186, 0
-  br i1 %.fca.0.extract.i818.9, label %cond_543_case_1.i.9, label %__hugr__.const_fun_175.284.exit.9
-
-cond_543_case_1.i.9:                              ; preds = %__hugr__.const_fun_175.284.exit.8
-  %.fca.1.extract.i819.9 = extractvalue { i1, i64, i1 } %186, 1
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i819.9)
-  br label %__hugr__.const_fun_175.284.exit.9
-
-__hugr__.const_fun_175.284.exit.9:                ; preds = %cond_543_case_1.i.9, %__hugr__.const_fun_175.284.exit.8
-  tail call void @heap_free(i8* nonnull %111)
+loop_out139:                                      ; preds = %cond_165_case_0
+  tail call void @heap_free(i8* %111)
   tail call void @heap_free(i8* nonnull %113)
-  tail call void @heap_free(i8* %174)
-  %187 = load i64, i64* %87, align 4
-  %188 = and i64 %187, 1023
-  store i64 %188, i64* %87, align 4
-  %189 = icmp eq i64 %188, 0
-  br i1 %189, label %__barray_check_none_borrowed.exit824, label %mask_block_err.i823
+  %184 = load i64, i64* %87, align 4
+  %185 = and i64 %184, 1023
+  store i64 %185, i64* %87, align 4
+  %186 = icmp eq i64 %185, 0
+  br i1 %186, label %__barray_check_none_borrowed.exit898, label %mask_block_err.i897
 
-__barray_check_none_borrowed.exit824:             ; preds = %__hugr__.const_fun_175.284.exit.9
-  %190 = tail call i8* @heap_alloc(i64 10)
-  %191 = tail call i8* @heap_alloc(i64 8)
-  %192 = bitcast i8* %191 to i64*
-  store i64 0, i64* %192, align 1
-  %193 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
-  %.fca.0.extract.i825 = extractvalue { i1, i64, i1 } %193, 0
-  %.fca.1.extract.i826 = extractvalue { i1, i64, i1 } %193, 1
-  br i1 %.fca.0.extract.i825, label %cond_300_case_1.i, label %cond_300_case_0.i
+__barray_check_none_borrowed.exit898:             ; preds = %loop_out139
+  %187 = tail call i8* @heap_alloc(i64 10)
+  %188 = tail call i8* @heap_alloc(i64 8)
+  %189 = bitcast i8* %188 to i64*
+  store i64 0, i64* %189, align 1
+  %190 = load { i1, i64, i1 }, { i1, i64, i1 }* %85, align 4
+  %.fca.0.extract.i899 = extractvalue { i1, i64, i1 } %190, 0
+  %.fca.1.extract.i900 = extractvalue { i1, i64, i1 } %190, 1
+  br i1 %.fca.0.extract.i899, label %cond_300_case_1.i, label %cond_300_case_0.i
 
-mask_block_err.i823:                              ; preds = %__hugr__.const_fun_175.284.exit.9
+mask_block_err.i897:                              ; preds = %loop_out139
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-cond_300_case_0.i:                                ; preds = %__barray_check_none_borrowed.exit824
-  %.fca.2.extract.i = extractvalue { i1, i64, i1 } %193, 2
+cond_501_case_1:                                  ; preds = %__barray_mask_borrow.exit893
+  %.fca.1.extract512 = extractvalue { i1, i64, i1 } %182, 1
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract512)
+  br label %cond_exit_165
+
+cond_300_case_0.i:                                ; preds = %__barray_check_none_borrowed.exit898
+  %.fca.2.extract.i = extractvalue { i1, i64, i1 } %190, 2
   br label %__hugr__.array.__read_bool.3.271.exit
 
-cond_300_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit824
-  %read_bool.i = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826)
+cond_300_case_1.i:                                ; preds = %__barray_check_none_borrowed.exit898
+  %read_bool.i = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900)
   br label %__hugr__.array.__read_bool.3.271.exit
 
 __hugr__.array.__read_bool.3.271.exit:            ; preds = %cond_300_case_0.i, %cond_300_case_1.i
   %"03.0.i" = phi i1 [ %read_bool.i, %cond_300_case_1.i ], [ %.fca.2.extract.i, %cond_300_case_0.i ]
-  %194 = bitcast i8* %190 to i1*
-  store i1 %"03.0.i", i1* %194, align 1
-  %195 = getelementptr inbounds i8, i8* %84, i64 24
-  %196 = bitcast i8* %195 to { i1, i64, i1 }*
-  %197 = load { i1, i64, i1 }, { i1, i64, i1 }* %196, align 4
-  %.fca.0.extract.i825.1 = extractvalue { i1, i64, i1 } %197, 0
-  %.fca.1.extract.i826.1 = extractvalue { i1, i64, i1 } %197, 1
-  br i1 %.fca.0.extract.i825.1, label %cond_300_case_1.i.1, label %cond_300_case_0.i.1
+  %191 = bitcast i8* %187 to i1*
+  store i1 %"03.0.i", i1* %191, align 1
+  %192 = getelementptr inbounds i8, i8* %84, i64 24
+  %193 = bitcast i8* %192 to { i1, i64, i1 }*
+  %194 = load { i1, i64, i1 }, { i1, i64, i1 }* %193, align 4
+  %.fca.0.extract.i899.1 = extractvalue { i1, i64, i1 } %194, 0
+  %.fca.1.extract.i900.1 = extractvalue { i1, i64, i1 } %194, 1
+  br i1 %.fca.0.extract.i899.1, label %cond_300_case_1.i.1, label %cond_300_case_0.i.1
 
 cond_300_case_0.i.1:                              ; preds = %__hugr__.array.__read_bool.3.271.exit
-  %.fca.2.extract.i.1 = extractvalue { i1, i64, i1 } %197, 2
+  %.fca.2.extract.i.1 = extractvalue { i1, i64, i1 } %194, 2
   br label %__hugr__.array.__read_bool.3.271.exit.1
 
 cond_300_case_1.i.1:                              ; preds = %__hugr__.array.__read_bool.3.271.exit
-  %read_bool.i.1 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.1)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.1)
+  %read_bool.i.1 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.1)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.1)
   br label %__hugr__.array.__read_bool.3.271.exit.1
 
 __hugr__.array.__read_bool.3.271.exit.1:          ; preds = %cond_300_case_1.i.1, %cond_300_case_0.i.1
   %"03.0.i.1" = phi i1 [ %read_bool.i.1, %cond_300_case_1.i.1 ], [ %.fca.2.extract.i.1, %cond_300_case_0.i.1 ]
-  %198 = getelementptr inbounds i8, i8* %190, i64 1
-  %199 = bitcast i8* %198 to i1*
-  store i1 %"03.0.i.1", i1* %199, align 1
-  %200 = getelementptr inbounds i8, i8* %84, i64 48
-  %201 = bitcast i8* %200 to { i1, i64, i1 }*
-  %202 = load { i1, i64, i1 }, { i1, i64, i1 }* %201, align 4
-  %.fca.0.extract.i825.2 = extractvalue { i1, i64, i1 } %202, 0
-  %.fca.1.extract.i826.2 = extractvalue { i1, i64, i1 } %202, 1
-  br i1 %.fca.0.extract.i825.2, label %cond_300_case_1.i.2, label %cond_300_case_0.i.2
+  %195 = getelementptr inbounds i8, i8* %187, i64 1
+  %196 = bitcast i8* %195 to i1*
+  store i1 %"03.0.i.1", i1* %196, align 1
+  %197 = getelementptr inbounds i8, i8* %84, i64 48
+  %198 = bitcast i8* %197 to { i1, i64, i1 }*
+  %199 = load { i1, i64, i1 }, { i1, i64, i1 }* %198, align 4
+  %.fca.0.extract.i899.2 = extractvalue { i1, i64, i1 } %199, 0
+  %.fca.1.extract.i900.2 = extractvalue { i1, i64, i1 } %199, 1
+  br i1 %.fca.0.extract.i899.2, label %cond_300_case_1.i.2, label %cond_300_case_0.i.2
 
 cond_300_case_0.i.2:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.1
-  %.fca.2.extract.i.2 = extractvalue { i1, i64, i1 } %202, 2
+  %.fca.2.extract.i.2 = extractvalue { i1, i64, i1 } %199, 2
   br label %__hugr__.array.__read_bool.3.271.exit.2
 
 cond_300_case_1.i.2:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.1
-  %read_bool.i.2 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.2)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.2)
+  %read_bool.i.2 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.2)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.2)
   br label %__hugr__.array.__read_bool.3.271.exit.2
 
 __hugr__.array.__read_bool.3.271.exit.2:          ; preds = %cond_300_case_1.i.2, %cond_300_case_0.i.2
   %"03.0.i.2" = phi i1 [ %read_bool.i.2, %cond_300_case_1.i.2 ], [ %.fca.2.extract.i.2, %cond_300_case_0.i.2 ]
-  %203 = getelementptr inbounds i8, i8* %190, i64 2
-  %204 = bitcast i8* %203 to i1*
-  store i1 %"03.0.i.2", i1* %204, align 1
-  %205 = getelementptr inbounds i8, i8* %84, i64 72
-  %206 = bitcast i8* %205 to { i1, i64, i1 }*
-  %207 = load { i1, i64, i1 }, { i1, i64, i1 }* %206, align 4
-  %.fca.0.extract.i825.3 = extractvalue { i1, i64, i1 } %207, 0
-  %.fca.1.extract.i826.3 = extractvalue { i1, i64, i1 } %207, 1
-  br i1 %.fca.0.extract.i825.3, label %cond_300_case_1.i.3, label %cond_300_case_0.i.3
+  %200 = getelementptr inbounds i8, i8* %187, i64 2
+  %201 = bitcast i8* %200 to i1*
+  store i1 %"03.0.i.2", i1* %201, align 1
+  %202 = getelementptr inbounds i8, i8* %84, i64 72
+  %203 = bitcast i8* %202 to { i1, i64, i1 }*
+  %204 = load { i1, i64, i1 }, { i1, i64, i1 }* %203, align 4
+  %.fca.0.extract.i899.3 = extractvalue { i1, i64, i1 } %204, 0
+  %.fca.1.extract.i900.3 = extractvalue { i1, i64, i1 } %204, 1
+  br i1 %.fca.0.extract.i899.3, label %cond_300_case_1.i.3, label %cond_300_case_0.i.3
 
 cond_300_case_0.i.3:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.2
-  %.fca.2.extract.i.3 = extractvalue { i1, i64, i1 } %207, 2
+  %.fca.2.extract.i.3 = extractvalue { i1, i64, i1 } %204, 2
   br label %__hugr__.array.__read_bool.3.271.exit.3
 
 cond_300_case_1.i.3:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.2
-  %read_bool.i.3 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.3)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.3)
+  %read_bool.i.3 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.3)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.3)
   br label %__hugr__.array.__read_bool.3.271.exit.3
 
 __hugr__.array.__read_bool.3.271.exit.3:          ; preds = %cond_300_case_1.i.3, %cond_300_case_0.i.3
   %"03.0.i.3" = phi i1 [ %read_bool.i.3, %cond_300_case_1.i.3 ], [ %.fca.2.extract.i.3, %cond_300_case_0.i.3 ]
-  %208 = getelementptr inbounds i8, i8* %190, i64 3
-  %209 = bitcast i8* %208 to i1*
-  store i1 %"03.0.i.3", i1* %209, align 1
-  %210 = getelementptr inbounds i8, i8* %84, i64 96
-  %211 = bitcast i8* %210 to { i1, i64, i1 }*
-  %212 = load { i1, i64, i1 }, { i1, i64, i1 }* %211, align 4
-  %.fca.0.extract.i825.4 = extractvalue { i1, i64, i1 } %212, 0
-  %.fca.1.extract.i826.4 = extractvalue { i1, i64, i1 } %212, 1
-  br i1 %.fca.0.extract.i825.4, label %cond_300_case_1.i.4, label %cond_300_case_0.i.4
+  %205 = getelementptr inbounds i8, i8* %187, i64 3
+  %206 = bitcast i8* %205 to i1*
+  store i1 %"03.0.i.3", i1* %206, align 1
+  %207 = getelementptr inbounds i8, i8* %84, i64 96
+  %208 = bitcast i8* %207 to { i1, i64, i1 }*
+  %209 = load { i1, i64, i1 }, { i1, i64, i1 }* %208, align 4
+  %.fca.0.extract.i899.4 = extractvalue { i1, i64, i1 } %209, 0
+  %.fca.1.extract.i900.4 = extractvalue { i1, i64, i1 } %209, 1
+  br i1 %.fca.0.extract.i899.4, label %cond_300_case_1.i.4, label %cond_300_case_0.i.4
 
 cond_300_case_0.i.4:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.3
-  %.fca.2.extract.i.4 = extractvalue { i1, i64, i1 } %212, 2
+  %.fca.2.extract.i.4 = extractvalue { i1, i64, i1 } %209, 2
   br label %__hugr__.array.__read_bool.3.271.exit.4
 
 cond_300_case_1.i.4:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.3
-  %read_bool.i.4 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.4)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.4)
+  %read_bool.i.4 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.4)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.4)
   br label %__hugr__.array.__read_bool.3.271.exit.4
 
 __hugr__.array.__read_bool.3.271.exit.4:          ; preds = %cond_300_case_1.i.4, %cond_300_case_0.i.4
   %"03.0.i.4" = phi i1 [ %read_bool.i.4, %cond_300_case_1.i.4 ], [ %.fca.2.extract.i.4, %cond_300_case_0.i.4 ]
-  %213 = getelementptr inbounds i8, i8* %190, i64 4
-  %214 = bitcast i8* %213 to i1*
-  store i1 %"03.0.i.4", i1* %214, align 1
-  %215 = getelementptr inbounds i8, i8* %84, i64 120
-  %216 = bitcast i8* %215 to { i1, i64, i1 }*
-  %217 = load { i1, i64, i1 }, { i1, i64, i1 }* %216, align 4
-  %.fca.0.extract.i825.5 = extractvalue { i1, i64, i1 } %217, 0
-  %.fca.1.extract.i826.5 = extractvalue { i1, i64, i1 } %217, 1
-  br i1 %.fca.0.extract.i825.5, label %cond_300_case_1.i.5, label %cond_300_case_0.i.5
+  %210 = getelementptr inbounds i8, i8* %187, i64 4
+  %211 = bitcast i8* %210 to i1*
+  store i1 %"03.0.i.4", i1* %211, align 1
+  %212 = getelementptr inbounds i8, i8* %84, i64 120
+  %213 = bitcast i8* %212 to { i1, i64, i1 }*
+  %214 = load { i1, i64, i1 }, { i1, i64, i1 }* %213, align 4
+  %.fca.0.extract.i899.5 = extractvalue { i1, i64, i1 } %214, 0
+  %.fca.1.extract.i900.5 = extractvalue { i1, i64, i1 } %214, 1
+  br i1 %.fca.0.extract.i899.5, label %cond_300_case_1.i.5, label %cond_300_case_0.i.5
 
 cond_300_case_0.i.5:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.4
-  %.fca.2.extract.i.5 = extractvalue { i1, i64, i1 } %217, 2
+  %.fca.2.extract.i.5 = extractvalue { i1, i64, i1 } %214, 2
   br label %__hugr__.array.__read_bool.3.271.exit.5
 
 cond_300_case_1.i.5:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.4
-  %read_bool.i.5 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.5)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.5)
+  %read_bool.i.5 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.5)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.5)
   br label %__hugr__.array.__read_bool.3.271.exit.5
 
 __hugr__.array.__read_bool.3.271.exit.5:          ; preds = %cond_300_case_1.i.5, %cond_300_case_0.i.5
   %"03.0.i.5" = phi i1 [ %read_bool.i.5, %cond_300_case_1.i.5 ], [ %.fca.2.extract.i.5, %cond_300_case_0.i.5 ]
-  %218 = getelementptr inbounds i8, i8* %190, i64 5
-  %219 = bitcast i8* %218 to i1*
-  store i1 %"03.0.i.5", i1* %219, align 1
-  %220 = getelementptr inbounds i8, i8* %84, i64 144
-  %221 = bitcast i8* %220 to { i1, i64, i1 }*
-  %222 = load { i1, i64, i1 }, { i1, i64, i1 }* %221, align 4
-  %.fca.0.extract.i825.6 = extractvalue { i1, i64, i1 } %222, 0
-  %.fca.1.extract.i826.6 = extractvalue { i1, i64, i1 } %222, 1
-  br i1 %.fca.0.extract.i825.6, label %cond_300_case_1.i.6, label %cond_300_case_0.i.6
+  %215 = getelementptr inbounds i8, i8* %187, i64 5
+  %216 = bitcast i8* %215 to i1*
+  store i1 %"03.0.i.5", i1* %216, align 1
+  %217 = getelementptr inbounds i8, i8* %84, i64 144
+  %218 = bitcast i8* %217 to { i1, i64, i1 }*
+  %219 = load { i1, i64, i1 }, { i1, i64, i1 }* %218, align 4
+  %.fca.0.extract.i899.6 = extractvalue { i1, i64, i1 } %219, 0
+  %.fca.1.extract.i900.6 = extractvalue { i1, i64, i1 } %219, 1
+  br i1 %.fca.0.extract.i899.6, label %cond_300_case_1.i.6, label %cond_300_case_0.i.6
 
 cond_300_case_0.i.6:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.5
-  %.fca.2.extract.i.6 = extractvalue { i1, i64, i1 } %222, 2
+  %.fca.2.extract.i.6 = extractvalue { i1, i64, i1 } %219, 2
   br label %__hugr__.array.__read_bool.3.271.exit.6
 
 cond_300_case_1.i.6:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.5
-  %read_bool.i.6 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.6)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.6)
+  %read_bool.i.6 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.6)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.6)
   br label %__hugr__.array.__read_bool.3.271.exit.6
 
 __hugr__.array.__read_bool.3.271.exit.6:          ; preds = %cond_300_case_1.i.6, %cond_300_case_0.i.6
   %"03.0.i.6" = phi i1 [ %read_bool.i.6, %cond_300_case_1.i.6 ], [ %.fca.2.extract.i.6, %cond_300_case_0.i.6 ]
-  %223 = getelementptr inbounds i8, i8* %190, i64 6
-  %224 = bitcast i8* %223 to i1*
-  store i1 %"03.0.i.6", i1* %224, align 1
-  %225 = getelementptr inbounds i8, i8* %84, i64 168
-  %226 = bitcast i8* %225 to { i1, i64, i1 }*
-  %227 = load { i1, i64, i1 }, { i1, i64, i1 }* %226, align 4
-  %.fca.0.extract.i825.7 = extractvalue { i1, i64, i1 } %227, 0
-  %.fca.1.extract.i826.7 = extractvalue { i1, i64, i1 } %227, 1
-  br i1 %.fca.0.extract.i825.7, label %cond_300_case_1.i.7, label %cond_300_case_0.i.7
+  %220 = getelementptr inbounds i8, i8* %187, i64 6
+  %221 = bitcast i8* %220 to i1*
+  store i1 %"03.0.i.6", i1* %221, align 1
+  %222 = getelementptr inbounds i8, i8* %84, i64 168
+  %223 = bitcast i8* %222 to { i1, i64, i1 }*
+  %224 = load { i1, i64, i1 }, { i1, i64, i1 }* %223, align 4
+  %.fca.0.extract.i899.7 = extractvalue { i1, i64, i1 } %224, 0
+  %.fca.1.extract.i900.7 = extractvalue { i1, i64, i1 } %224, 1
+  br i1 %.fca.0.extract.i899.7, label %cond_300_case_1.i.7, label %cond_300_case_0.i.7
 
 cond_300_case_0.i.7:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.6
-  %.fca.2.extract.i.7 = extractvalue { i1, i64, i1 } %227, 2
+  %.fca.2.extract.i.7 = extractvalue { i1, i64, i1 } %224, 2
   br label %__hugr__.array.__read_bool.3.271.exit.7
 
 cond_300_case_1.i.7:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.6
-  %read_bool.i.7 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.7)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.7)
+  %read_bool.i.7 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.7)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.7)
   br label %__hugr__.array.__read_bool.3.271.exit.7
 
 __hugr__.array.__read_bool.3.271.exit.7:          ; preds = %cond_300_case_1.i.7, %cond_300_case_0.i.7
   %"03.0.i.7" = phi i1 [ %read_bool.i.7, %cond_300_case_1.i.7 ], [ %.fca.2.extract.i.7, %cond_300_case_0.i.7 ]
-  %228 = getelementptr inbounds i8, i8* %190, i64 7
-  %229 = bitcast i8* %228 to i1*
-  store i1 %"03.0.i.7", i1* %229, align 1
-  %230 = getelementptr inbounds i8, i8* %84, i64 192
-  %231 = bitcast i8* %230 to { i1, i64, i1 }*
-  %232 = load { i1, i64, i1 }, { i1, i64, i1 }* %231, align 4
-  %.fca.0.extract.i825.8 = extractvalue { i1, i64, i1 } %232, 0
-  %.fca.1.extract.i826.8 = extractvalue { i1, i64, i1 } %232, 1
-  br i1 %.fca.0.extract.i825.8, label %cond_300_case_1.i.8, label %cond_300_case_0.i.8
+  %225 = getelementptr inbounds i8, i8* %187, i64 7
+  %226 = bitcast i8* %225 to i1*
+  store i1 %"03.0.i.7", i1* %226, align 1
+  %227 = getelementptr inbounds i8, i8* %84, i64 192
+  %228 = bitcast i8* %227 to { i1, i64, i1 }*
+  %229 = load { i1, i64, i1 }, { i1, i64, i1 }* %228, align 4
+  %.fca.0.extract.i899.8 = extractvalue { i1, i64, i1 } %229, 0
+  %.fca.1.extract.i900.8 = extractvalue { i1, i64, i1 } %229, 1
+  br i1 %.fca.0.extract.i899.8, label %cond_300_case_1.i.8, label %cond_300_case_0.i.8
 
 cond_300_case_0.i.8:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.7
-  %.fca.2.extract.i.8 = extractvalue { i1, i64, i1 } %232, 2
+  %.fca.2.extract.i.8 = extractvalue { i1, i64, i1 } %229, 2
   br label %__hugr__.array.__read_bool.3.271.exit.8
 
 cond_300_case_1.i.8:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.7
-  %read_bool.i.8 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.8)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.8)
+  %read_bool.i.8 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.8)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.8)
   br label %__hugr__.array.__read_bool.3.271.exit.8
 
 __hugr__.array.__read_bool.3.271.exit.8:          ; preds = %cond_300_case_1.i.8, %cond_300_case_0.i.8
   %"03.0.i.8" = phi i1 [ %read_bool.i.8, %cond_300_case_1.i.8 ], [ %.fca.2.extract.i.8, %cond_300_case_0.i.8 ]
-  %233 = getelementptr inbounds i8, i8* %190, i64 8
-  %234 = bitcast i8* %233 to i1*
-  store i1 %"03.0.i.8", i1* %234, align 1
-  %235 = getelementptr inbounds i8, i8* %84, i64 216
-  %236 = bitcast i8* %235 to { i1, i64, i1 }*
-  %237 = load { i1, i64, i1 }, { i1, i64, i1 }* %236, align 4
-  %.fca.0.extract.i825.9 = extractvalue { i1, i64, i1 } %237, 0
-  %.fca.1.extract.i826.9 = extractvalue { i1, i64, i1 } %237, 1
-  br i1 %.fca.0.extract.i825.9, label %cond_300_case_1.i.9, label %cond_300_case_0.i.9
+  %230 = getelementptr inbounds i8, i8* %187, i64 8
+  %231 = bitcast i8* %230 to i1*
+  store i1 %"03.0.i.8", i1* %231, align 1
+  %232 = getelementptr inbounds i8, i8* %84, i64 216
+  %233 = bitcast i8* %232 to { i1, i64, i1 }*
+  %234 = load { i1, i64, i1 }, { i1, i64, i1 }* %233, align 4
+  %.fca.0.extract.i899.9 = extractvalue { i1, i64, i1 } %234, 0
+  %.fca.1.extract.i900.9 = extractvalue { i1, i64, i1 } %234, 1
+  br i1 %.fca.0.extract.i899.9, label %cond_300_case_1.i.9, label %cond_300_case_0.i.9
 
 cond_300_case_0.i.9:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.8
-  %.fca.2.extract.i.9 = extractvalue { i1, i64, i1 } %237, 2
+  %.fca.2.extract.i.9 = extractvalue { i1, i64, i1 } %234, 2
   br label %__hugr__.array.__read_bool.3.271.exit.9
 
 cond_300_case_1.i.9:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.8
-  %read_bool.i.9 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i826.9)
-  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i826.9)
+  %read_bool.i.9 = tail call i1 @___read_future_bool(i64 %.fca.1.extract.i900.9)
+  tail call void @___dec_future_refcount(i64 %.fca.1.extract.i900.9)
   br label %__hugr__.array.__read_bool.3.271.exit.9
 
 __hugr__.array.__read_bool.3.271.exit.9:          ; preds = %cond_300_case_1.i.9, %cond_300_case_0.i.9
   %"03.0.i.9" = phi i1 [ %read_bool.i.9, %cond_300_case_1.i.9 ], [ %.fca.2.extract.i.9, %cond_300_case_0.i.9 ]
-  %238 = getelementptr inbounds i8, i8* %190, i64 9
-  %239 = bitcast i8* %238 to i1*
-  store i1 %"03.0.i.9", i1* %239, align 1
+  %235 = getelementptr inbounds i8, i8* %187, i64 9
+  %236 = bitcast i8* %235 to i1*
+  store i1 %"03.0.i.9", i1* %236, align 1
   tail call void @heap_free(i8* nonnull %84)
   tail call void @heap_free(i8* nonnull %86)
-  %240 = load i64, i64* %192, align 4
-  %241 = and i64 %240, 1023
-  store i64 %241, i64* %192, align 4
-  %242 = icmp eq i64 %241, 0
-  br i1 %242, label %__barray_check_none_borrowed.exit831, label %mask_block_err.i830
+  %237 = load i64, i64* %189, align 4
+  %238 = and i64 %237, 1023
+  store i64 %238, i64* %189, align 4
+  %239 = icmp eq i64 %238, 0
+  br i1 %239, label %__barray_check_none_borrowed.exit905, label %mask_block_err.i904
 
-__barray_check_none_borrowed.exit831:             ; preds = %__hugr__.array.__read_bool.3.271.exit.9
+__barray_check_none_borrowed.exit905:             ; preds = %__hugr__.array.__read_bool.3.271.exit.9
   %out_arr_alloca = alloca <{ i32, i32, i1*, i1* }>, align 8
   %x_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 0
   %y_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 1
   %arr_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 2
   %mask_ptr = getelementptr inbounds <{ i32, i32, i1*, i1* }>, <{ i32, i32, i1*, i1* }>* %out_arr_alloca, i64 0, i32 3
-  %243 = alloca [10 x i1], align 1
-  %.sub = getelementptr inbounds [10 x i1], [10 x i1]* %243, i64 0, i64 0
-  %244 = bitcast [10 x i1]* %243 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(10) %244, i8 0, i64 10, i1 false)
+  %240 = alloca [10 x i1], align 1
+  %.sub = getelementptr inbounds [10 x i1], [10 x i1]* %240, i64 0, i64 0
+  %241 = bitcast [10 x i1]* %240 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(10) %241, i8 0, i64 10, i1 false)
   store i32 10, i32* %x_ptr, align 8
   store i32 1, i32* %y_ptr, align 4
-  %245 = bitcast i1** %arr_ptr to i8**
-  store i8* %190, i8** %245, align 8
+  %242 = bitcast i1** %arr_ptr to i8**
+  store i8* %187, i8** %242, align 8
   store i1* %.sub, i1** %mask_ptr, align 8
   call void @print_bool_arr(i8* getelementptr inbounds ([16 x i8], [16 x i8]* @res_cs.46C3C4B5.0, i64 0, i64 0), i64 15, <{ i32, i32, i1*, i1* }>* nonnull %out_arr_alloca)
-  br label %__barray_check_bounds.exit839
+  br label %__barray_check_bounds.exit913
 
-mask_block_err.i830:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.9
+mask_block_err.i904:                              ; preds = %__hugr__.array.__read_bool.3.271.exit.9
   tail call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit839:                    ; preds = %cond_exit_95.1, %__barray_check_none_borrowed.exit831
-  %"90_0.sroa.0.0899" = phi i64 [ 0, %__barray_check_none_borrowed.exit831 ], [ %255, %cond_exit_95.1 ]
-  %246 = or i64 %"90_0.sroa.0.0899", 1
-  %247 = lshr i64 %"90_0.sroa.0.0899", 6
-  %248 = getelementptr inbounds i64, i64* %7, i64 %247
-  %249 = load i64, i64* %248, align 4
-  %250 = and i64 %"90_0.sroa.0.0899", 62
-  %251 = shl nuw i64 1, %250
-  %252 = and i64 %249, %251
-  %.not.i840 = icmp eq i64 %252, 0
-  br i1 %.not.i840, label %panic.i841, label %cond_exit_95
+__barray_check_bounds.exit913:                    ; preds = %cond_exit_95.1, %__barray_check_none_borrowed.exit905
+  %"90_0.sroa.0.0972" = phi i64 [ 0, %__barray_check_none_borrowed.exit905 ], [ %252, %cond_exit_95.1 ]
+  %243 = or i64 %"90_0.sroa.0.0972", 1
+  %244 = lshr i64 %"90_0.sroa.0.0972", 6
+  %245 = getelementptr inbounds i64, i64* %7, i64 %244
+  %246 = load i64, i64* %245, align 4
+  %247 = and i64 %"90_0.sroa.0.0972", 62
+  %248 = shl nuw i64 1, %247
+  %249 = and i64 %246, %248
+  %.not.i914 = icmp eq i64 %249, 0
+  br i1 %.not.i914, label %panic.i915, label %cond_exit_95
 
-panic.i841:                                       ; preds = %cond_exit_95, %__barray_check_bounds.exit839
+panic.i915:                                       ; preds = %cond_exit_95, %__barray_check_bounds.exit913
   call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-cond_exit_95:                                     ; preds = %__barray_check_bounds.exit839
-  %253 = xor i64 %249, %251
-  store i64 %253, i64* %248, align 4
-  %254 = getelementptr inbounds i64, i64* %5, i64 %"90_0.sroa.0.0899"
-  store i64 %"90_0.sroa.0.0899", i64* %254, align 4
-  %255 = add nuw nsw i64 %"90_0.sroa.0.0899", 2
-  %256 = lshr i64 %"90_0.sroa.0.0899", 6
-  %257 = getelementptr inbounds i64, i64* %7, i64 %256
-  %258 = load i64, i64* %257, align 4
-  %259 = and i64 %246, 63
-  %260 = shl nuw i64 1, %259
-  %261 = and i64 %258, %260
-  %.not.i840.1 = icmp eq i64 %261, 0
-  br i1 %.not.i840.1, label %panic.i841, label %cond_exit_95.1
+cond_exit_95:                                     ; preds = %__barray_check_bounds.exit913
+  %250 = xor i64 %246, %248
+  store i64 %250, i64* %245, align 4
+  %251 = getelementptr inbounds i64, i64* %5, i64 %"90_0.sroa.0.0972"
+  store i64 %"90_0.sroa.0.0972", i64* %251, align 4
+  %252 = add nuw nsw i64 %"90_0.sroa.0.0972", 2
+  %253 = lshr i64 %"90_0.sroa.0.0972", 6
+  %254 = getelementptr inbounds i64, i64* %7, i64 %253
+  %255 = load i64, i64* %254, align 4
+  %256 = and i64 %243, 63
+  %257 = shl nuw i64 1, %256
+  %258 = and i64 %255, %257
+  %.not.i914.1 = icmp eq i64 %258, 0
+  br i1 %.not.i914.1, label %panic.i915, label %cond_exit_95.1
 
 cond_exit_95.1:                                   ; preds = %cond_exit_95
-  %262 = xor i64 %258, %260
-  store i64 %262, i64* %257, align 4
-  %263 = getelementptr inbounds i64, i64* %5, i64 %246
-  store i64 %246, i64* %263, align 4
-  %exitcond911.not.1 = icmp eq i64 %255, 100
-  br i1 %exitcond911.not.1, label %loop_out164, label %__barray_check_bounds.exit839
+  %259 = xor i64 %255, %257
+  store i64 %259, i64* %254, align 4
+  %260 = getelementptr inbounds i64, i64* %5, i64 %243
+  store i64 %243, i64* %260, align 4
+  %exitcond983.not.1 = icmp eq i64 %252, 100
+  br i1 %exitcond983.not.1, label %loop_out212, label %__barray_check_bounds.exit913
 
-loop_out164:                                      ; preds = %cond_exit_95.1
-  %264 = getelementptr inbounds i8, i8* %6, i64 8
-  %265 = bitcast i8* %264 to i64*
-  %266 = load i64, i64* %265, align 4
-  %267 = and i64 %266, 68719476735
-  store i64 %267, i64* %265, align 4
-  %268 = load i64, i64* %7, align 4
-  %269 = icmp eq i64 %268, 0
-  %270 = icmp eq i64 %267, 0
-  %or.cond = select i1 %269, i1 %270, i1 false
-  br i1 %or.cond, label %__barray_check_none_borrowed.exit847, label %mask_block_err.i846
+loop_out212:                                      ; preds = %cond_exit_95.1
+  %261 = getelementptr inbounds i8, i8* %6, i64 8
+  %262 = bitcast i8* %261 to i64*
+  %263 = load i64, i64* %262, align 4
+  %264 = and i64 %263, 68719476735
+  store i64 %264, i64* %262, align 4
+  %265 = load i64, i64* %7, align 4
+  %266 = icmp eq i64 %265, 0
+  %267 = icmp eq i64 %264, 0
+  %or.cond = select i1 %266, i1 %267, i1 false
+  br i1 %or.cond, label %__barray_check_none_borrowed.exit921, label %mask_block_err.i920
 
-__barray_check_none_borrowed.exit847:             ; preds = %loop_out164
-  %271 = call i8* @heap_alloc(i64 800)
-  %272 = bitcast i8* %271 to i64*
-  %273 = call i8* @heap_alloc(i64 16)
-  %274 = bitcast i8* %273 to i64*
-  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %274, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0i64.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(800) %272, i64* noundef nonnull align 1 dereferenceable(800) %5, i64 800, i1 false)
-  call void @heap_free(i8* %271)
-  %275 = load i64, i64* %265, align 4
-  %276 = and i64 %275, 68719476735
-  store i64 %276, i64* %265, align 4
-  %277 = load i64, i64* %7, align 4
-  %278 = icmp eq i64 %277, 0
-  %279 = icmp eq i64 %276, 0
-  %or.cond913 = select i1 %278, i1 %279, i1 false
-  br i1 %or.cond913, label %__barray_check_none_borrowed.exit852, label %mask_block_err.i851
+__barray_check_none_borrowed.exit921:             ; preds = %loop_out212
+  %268 = call i8* @heap_alloc(i64 800)
+  %269 = bitcast i8* %268 to i64*
+  %270 = call i8* @heap_alloc(i64 16)
+  %271 = bitcast i8* %270 to i64*
+  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %271, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0i64.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(800) %269, i64* noundef nonnull align 1 dereferenceable(800) %5, i64 800, i1 false)
+  call void @heap_free(i8* %268)
+  %272 = load i64, i64* %262, align 4
+  %273 = and i64 %272, 68719476735
+  store i64 %273, i64* %262, align 4
+  %274 = load i64, i64* %7, align 4
+  %275 = icmp eq i64 %274, 0
+  %276 = icmp eq i64 %273, 0
+  %or.cond986 = select i1 %275, i1 %276, i1 false
+  br i1 %or.cond986, label %__barray_check_none_borrowed.exit926, label %mask_block_err.i925
 
-mask_block_err.i846:                              ; preds = %loop_out164
+mask_block_err.i920:                              ; preds = %loop_out212
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit852:             ; preds = %__barray_check_none_borrowed.exit847
-  %out_arr_alloca239 = alloca <{ i32, i32, i64*, i1* }>, align 8
-  %x_ptr240 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 0
-  %y_ptr241 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 1
-  %arr_ptr242 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 2
-  %mask_ptr243 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca239, i64 0, i32 3
-  %280 = alloca [100 x i1], align 1
-  %.sub563 = getelementptr inbounds [100 x i1], [100 x i1]* %280, i64 0, i64 0
-  %281 = bitcast [100 x i1]* %280 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %281, i8 0, i64 100, i1 false)
-  store i32 100, i32* %x_ptr240, align 8
-  store i32 1, i32* %y_ptr241, align 4
-  %282 = bitcast i64** %arr_ptr242 to i8**
-  store i8* %4, i8** %282, align 8
-  store i1* %.sub563, i1** %mask_ptr243, align 8
-  call void @print_int_arr(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @res_is.F21393DB.0, i64 0, i64 0), i64 14, <{ i32, i32, i64*, i1* }>* nonnull %out_arr_alloca239)
-  br label %__barray_check_bounds.exit860
+__barray_check_none_borrowed.exit926:             ; preds = %__barray_check_none_borrowed.exit921
+  %out_arr_alloca287 = alloca <{ i32, i32, i64*, i1* }>, align 8
+  %x_ptr288 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 0
+  %y_ptr289 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 1
+  %arr_ptr290 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 2
+  %mask_ptr291 = getelementptr inbounds <{ i32, i32, i64*, i1* }>, <{ i32, i32, i64*, i1* }>* %out_arr_alloca287, i64 0, i32 3
+  %277 = alloca [100 x i1], align 1
+  %.sub635 = getelementptr inbounds [100 x i1], [100 x i1]* %277, i64 0, i64 0
+  %278 = bitcast [100 x i1]* %277 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %278, i8 0, i64 100, i1 false)
+  store i32 100, i32* %x_ptr288, align 8
+  store i32 1, i32* %y_ptr289, align 4
+  %279 = bitcast i64** %arr_ptr290 to i8**
+  store i8* %4, i8** %279, align 8
+  store i1* %.sub635, i1** %mask_ptr291, align 8
+  call void @print_int_arr(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @res_is.F21393DB.0, i64 0, i64 0), i64 14, <{ i32, i32, i64*, i1* }>* nonnull %out_arr_alloca287)
+  br label %__barray_check_bounds.exit934
 
-mask_block_err.i851:                              ; preds = %__barray_check_none_borrowed.exit847
+mask_block_err.i925:                              ; preds = %__barray_check_none_borrowed.exit921
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_bounds.exit860:                    ; preds = %cond_exit_130, %__barray_check_none_borrowed.exit852
-  %"125_0.sroa.0.0901" = phi i64 [ 0, %__barray_check_none_borrowed.exit852 ], [ %283, %cond_exit_130 ]
-  %283 = add nuw nsw i64 %"125_0.sroa.0.0901", 1
-  %284 = lshr i64 %"125_0.sroa.0.0901", 6
-  %285 = getelementptr inbounds i64, i64* %3, i64 %284
-  %286 = load i64, i64* %285, align 4
-  %287 = and i64 %"125_0.sroa.0.0901", 63
-  %288 = shl nuw i64 1, %287
-  %289 = and i64 %286, %288
-  %.not.i861 = icmp eq i64 %289, 0
-  br i1 %.not.i861, label %panic.i862, label %cond_exit_130
+__barray_check_bounds.exit934:                    ; preds = %cond_exit_130, %__barray_check_none_borrowed.exit926
+  %"125_0.sroa.0.0974" = phi i64 [ 0, %__barray_check_none_borrowed.exit926 ], [ %280, %cond_exit_130 ]
+  %280 = add nuw nsw i64 %"125_0.sroa.0.0974", 1
+  %281 = lshr i64 %"125_0.sroa.0.0974", 6
+  %282 = getelementptr inbounds i64, i64* %3, i64 %281
+  %283 = load i64, i64* %282, align 4
+  %284 = and i64 %"125_0.sroa.0.0974", 63
+  %285 = shl nuw i64 1, %284
+  %286 = and i64 %283, %285
+  %.not.i935 = icmp eq i64 %286, 0
+  br i1 %.not.i935, label %panic.i936, label %cond_exit_130
 
-panic.i862:                                       ; preds = %__barray_check_bounds.exit860
+panic.i936:                                       ; preds = %__barray_check_bounds.exit934
   call void @panic(i32 1002, i8* getelementptr inbounds ([57 x i8], [57 x i8]* @"e_Array alre.5A300C2A.0", i64 0, i64 0))
   unreachable
 
-cond_exit_130:                                    ; preds = %__barray_check_bounds.exit860
-  %290 = sitofp i64 %"125_0.sroa.0.0901" to double
-  %291 = fmul double %290, 6.250000e-02
-  %292 = xor i64 %286, %288
-  store i64 %292, i64* %285, align 4
-  %293 = getelementptr inbounds double, double* %1, i64 %"125_0.sroa.0.0901"
-  store double %291, double* %293, align 8
-  %exitcond912.not = icmp eq i64 %283, 100
-  br i1 %exitcond912.not, label %loop_out251, label %__barray_check_bounds.exit860
+cond_exit_130:                                    ; preds = %__barray_check_bounds.exit934
+  %287 = sitofp i64 %"125_0.sroa.0.0974" to double
+  %288 = fmul double %287, 6.250000e-02
+  %289 = xor i64 %283, %285
+  store i64 %289, i64* %282, align 4
+  %290 = getelementptr inbounds double, double* %1, i64 %"125_0.sroa.0.0974"
+  store double %288, double* %290, align 8
+  %exitcond984.not = icmp eq i64 %280, 100
+  br i1 %exitcond984.not, label %loop_out299, label %__barray_check_bounds.exit934
 
-loop_out251:                                      ; preds = %cond_exit_130
-  %294 = getelementptr inbounds i8, i8* %2, i64 8
-  %295 = bitcast i8* %294 to i64*
-  %296 = load i64, i64* %295, align 4
-  %297 = and i64 %296, 68719476735
-  store i64 %297, i64* %295, align 4
-  %298 = load i64, i64* %3, align 4
-  %299 = icmp eq i64 %298, 0
-  %300 = icmp eq i64 %297, 0
-  %or.cond914 = select i1 %299, i1 %300, i1 false
-  br i1 %or.cond914, label %__barray_check_none_borrowed.exit868, label %mask_block_err.i867
+loop_out299:                                      ; preds = %cond_exit_130
+  %291 = getelementptr inbounds i8, i8* %2, i64 8
+  %292 = bitcast i8* %291 to i64*
+  %293 = load i64, i64* %292, align 4
+  %294 = and i64 %293, 68719476735
+  store i64 %294, i64* %292, align 4
+  %295 = load i64, i64* %3, align 4
+  %296 = icmp eq i64 %295, 0
+  %297 = icmp eq i64 %294, 0
+  %or.cond987 = select i1 %296, i1 %297, i1 false
+  br i1 %or.cond987, label %__barray_check_none_borrowed.exit942, label %mask_block_err.i941
 
-__barray_check_none_borrowed.exit868:             ; preds = %loop_out251
-  %301 = call i8* @heap_alloc(i64 800)
-  %302 = bitcast i8* %301 to double*
-  %303 = call i8* @heap_alloc(i64 16)
-  %304 = bitcast i8* %303 to i64*
-  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %304, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0f64.p0f64.i64(double* noundef nonnull align 1 dereferenceable(800) %302, double* noundef nonnull align 1 dereferenceable(800) %1, i64 800, i1 false)
-  call void @heap_free(i8* %301)
-  %305 = load i64, i64* %295, align 4
-  %306 = and i64 %305, 68719476735
-  store i64 %306, i64* %295, align 4
-  %307 = load i64, i64* %3, align 4
-  %308 = icmp eq i64 %307, 0
-  %309 = icmp eq i64 %306, 0
-  %or.cond915 = select i1 %308, i1 %309, i1 false
-  br i1 %or.cond915, label %__barray_check_none_borrowed.exit873, label %mask_block_err.i872
+__barray_check_none_borrowed.exit942:             ; preds = %loop_out299
+  %298 = call i8* @heap_alloc(i64 800)
+  %299 = bitcast i8* %298 to double*
+  %300 = call i8* @heap_alloc(i64 16)
+  %301 = bitcast i8* %300 to i64*
+  call void @llvm.memset.p0i64.i64(i64* noundef nonnull align 1 dereferenceable(16) %301, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0f64.p0f64.i64(double* noundef nonnull align 1 dereferenceable(800) %299, double* noundef nonnull align 1 dereferenceable(800) %1, i64 800, i1 false)
+  call void @heap_free(i8* %298)
+  %302 = load i64, i64* %292, align 4
+  %303 = and i64 %302, 68719476735
+  store i64 %303, i64* %292, align 4
+  %304 = load i64, i64* %3, align 4
+  %305 = icmp eq i64 %304, 0
+  %306 = icmp eq i64 %303, 0
+  %or.cond988 = select i1 %305, i1 %306, i1 false
+  br i1 %or.cond988, label %__barray_check_none_borrowed.exit947, label %mask_block_err.i946
 
-mask_block_err.i867:                              ; preds = %loop_out251
+mask_block_err.i941:                              ; preds = %loop_out299
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 
-__barray_check_none_borrowed.exit873:             ; preds = %__barray_check_none_borrowed.exit868
-  %out_arr_alloca329 = alloca <{ i32, i32, double*, i1* }>, align 8
-  %x_ptr330 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 0
-  %y_ptr331 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 1
-  %arr_ptr332 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 2
-  %mask_ptr333 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca329, i64 0, i32 3
-  %310 = alloca [100 x i1], align 1
-  %.sub664 = getelementptr inbounds [100 x i1], [100 x i1]* %310, i64 0, i64 0
-  %311 = bitcast [100 x i1]* %310 to i8*
-  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %311, i8 0, i64 100, i1 false)
-  store i32 100, i32* %x_ptr330, align 8
-  store i32 1, i32* %y_ptr331, align 4
-  %312 = bitcast double** %arr_ptr332 to i8**
-  store i8* %0, i8** %312, align 8
-  store i1* %.sub664, i1** %mask_ptr333, align 8
-  call void @print_float_arr(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @res_fs.CBD4AF54.0, i64 0, i64 0), i64 16, <{ i32, i32, double*, i1* }>* nonnull %out_arr_alloca329)
+__barray_check_none_borrowed.exit947:             ; preds = %__barray_check_none_borrowed.exit942
+  %out_arr_alloca377 = alloca <{ i32, i32, double*, i1* }>, align 8
+  %x_ptr378 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 0
+  %y_ptr379 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 1
+  %arr_ptr380 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 2
+  %mask_ptr381 = getelementptr inbounds <{ i32, i32, double*, i1* }>, <{ i32, i32, double*, i1* }>* %out_arr_alloca377, i64 0, i32 3
+  %307 = alloca [100 x i1], align 1
+  %.sub736 = getelementptr inbounds [100 x i1], [100 x i1]* %307, i64 0, i64 0
+  %308 = bitcast [100 x i1]* %307 to i8*
+  call void @llvm.memset.p0i8.i64(i8* noundef nonnull align 1 dereferenceable(100) %308, i8 0, i64 100, i1 false)
+  store i32 100, i32* %x_ptr378, align 8
+  store i32 1, i32* %y_ptr379, align 4
+  %309 = bitcast double** %arr_ptr380 to i8**
+  store i8* %0, i8** %309, align 8
+  store i1* %.sub736, i1** %mask_ptr381, align 8
+  call void @print_float_arr(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @res_fs.CBD4AF54.0, i64 0, i64 0), i64 16, <{ i32, i32, double*, i1* }>* nonnull %out_arr_alloca377)
   ret void
 
-mask_block_err.i872:                              ; preds = %__barray_check_none_borrowed.exit868
+mask_block_err.i946:                              ; preds = %__barray_check_none_borrowed.exit942
   call void @panic(i32 1002, i8* getelementptr inbounds ([48 x i8], [48 x i8]* @"e_Some array.A77EF32E.0", i64 0, i64 0))
   unreachable
 }
@@ -1022,6 +948,8 @@ declare void @panic(i32, i8*) local_unnamed_addr #1
 
 declare void @heap_free(i8*) local_unnamed_addr
 
+declare void @___dec_future_refcount(i64) local_unnamed_addr
+
 declare void @print_bool_arr(i8*, i64, <{ i32, i32, i1*, i1* }>*) local_unnamed_addr
 
 ; Function Attrs: argmemonly mustprogress nofree nounwind willreturn
@@ -1035,8 +963,6 @@ declare void @llvm.memcpy.p0f64.p0f64.i64(double* noalias nocapture writeonly, d
 declare void @print_float_arr(i8*, i64, <{ i32, i32, double*, i1* }>*) local_unnamed_addr
 
 declare i1 @___read_future_bool(i64) local_unnamed_addr
-
-declare void @___dec_future_refcount(i64) local_unnamed_addr
 
 declare i64 @___lazy_measure(i64) local_unnamed_addr
 


### PR DESCRIPTION
Looks like #1230 changed the snapshots, but my local wheel cache didn't update.

This PR includes some fixes:
- Update the pytest snapshots of qis-compiler, with the changes arising from https://github.com/CQCL/hugr/pull/2666 and published in `hugr 0.23.4`.
- Ensures that the required CI checks fail if `tests-qis-compiler` fails. (And makes sure we don't omit new requirements again).
- Adds `update-snapshots-py` to the justfile