### PR TITLE
test(guppy_opt.rs): `run_pytket` applies to entire hugr instead of just the entrypoint

### DIFF
--- a/tket-qsystem/tests/guppy_opt.rs
+++ b/tket-qsystem/tests/guppy_opt.rs
@@ -94,7 +94,7 @@ fn count_gates(h: &impl HugrView) -> HashMap<SmolStr, usize> {
 
 #[rstest]
 #[case::nested_array("nested_array", None)]
-#[should_panic = "xfail"]
+#[should_panic = "PytketDecodeError { inner: DuplicatedParameter"]
 #[case::angles("angles", Some(vec![
     ("tket.quantum.Rz", 2), ("tket.quantum.Measure", 1), ("tket.quantum.H", 2), ("tket.quantum.QAlloc", 1), ("tket.quantum.QFree", 1)
 ]))]

--- a/tket-qsystem/tests/guppy_opt.rs
+++ b/tket-qsystem/tests/guppy_opt.rs
@@ -50,13 +50,12 @@ fn load_guppy_example(path: &str) -> std::io::Result<Hugr> {
 
 /// Run a json-encoded pytket pass on the given HUGR.
 fn run_pytket(h: &mut Hugr, pass_json: &str) {
-    let ep = h.entrypoint();
-    h.set_entrypoint(h.module_root());
     let encode_options = EncodeOptions::new()
         .with_subcircuits(true)
         .with_config(qsystem_encoder_config(QSystemPlatform::Helios));
 
-    let mut encoded = EncodedCircuit::new(h, encode_options).unwrap();
+    let mut encoded =
+        EncodedCircuit::new_with_entrypoint(h, h.module_root(), encode_options).unwrap();
 
     encoded
         .par_iter_mut()
@@ -72,7 +71,6 @@ fn run_pytket(h: &mut Hugr, pass_json: &str) {
             Some(qsystem_decoder_config(QSystemPlatform::Helios).into()),
         )
         .unwrap();
-    h.set_entrypoint(ep);
 }
 
 fn count_gates(h: &impl HugrView) -> HashMap<SmolStr, usize> {

--- a/tket-qsystem/tests/guppy_opt.rs
+++ b/tket-qsystem/tests/guppy_opt.rs
@@ -1,6 +1,5 @@
 //! Tests optimizing Guppy-generated programs.
 
-use hugr::hugr::hugrmut::HugrMut;
 use rayon::iter::ParallelIterator;
 use smol_str::SmolStr;
 use std::collections::HashMap;

--- a/tket-qsystem/tests/guppy_opt.rs
+++ b/tket-qsystem/tests/guppy_opt.rs
@@ -94,6 +94,7 @@ fn count_gates(h: &impl HugrView) -> HashMap<SmolStr, usize> {
 
 #[rstest]
 #[case::nested_array("nested_array", None)]
+// Following is https://github.com/Quantinuum/tket2/issues/1747:
 #[should_panic = "PytketDecodeError { inner: DuplicatedParameter"]
 #[case::angles("angles", Some(vec![
     ("tket.quantum.Rz", 2), ("tket.quantum.Measure", 1), ("tket.quantum.H", 2), ("tket.quantum.QAlloc", 1), ("tket.quantum.QFree", 1)

--- a/tket-qsystem/tests/guppy_opt.rs
+++ b/tket-qsystem/tests/guppy_opt.rs
@@ -1,5 +1,6 @@
 //! Tests optimizing Guppy-generated programs.
 
+use hugr::hugr::hugrmut::HugrMut;
 use rayon::iter::ParallelIterator;
 use smol_str::SmolStr;
 use std::collections::HashMap;
@@ -49,6 +50,8 @@ fn load_guppy_example(path: &str) -> std::io::Result<Hugr> {
 
 /// Run a json-encoded pytket pass on the given HUGR.
 fn run_pytket(h: &mut Hugr, pass_json: &str) {
+    let ep = h.entrypoint();
+    h.set_entrypoint(h.module_root());
     let encode_options = EncodeOptions::new()
         .with_subcircuits(true)
         .with_config(qsystem_encoder_config(QSystemPlatform::Helios));
@@ -69,6 +72,7 @@ fn run_pytket(h: &mut Hugr, pass_json: &str) {
             Some(qsystem_decoder_config(QSystemPlatform::Helios).into()),
         )
         .unwrap();
+    h.set_entrypoint(ep);
 }
 
 fn count_gates(h: &impl HugrView) -> HashMap<SmolStr, usize> {
@@ -98,14 +102,8 @@ fn count_gates(h: &impl HugrView) -> HashMap<SmolStr, usize> {
 #[case::simple_cx("simple_cx", Some(vec![
     ("tket.quantum.QAlloc", 2), ("tket.quantum.MeasureFree", 2),
 ]))]
-#[should_panic = "xfail"]
-#[case::nested("nested", Some(vec![
-    ("tket.quantum.CZ", 6), ("tket.quantum.QAlloc", 3), ("tket.quantum.MeasureFree", 3), ("tket.quantum.H", 6)
-]))]
-#[should_panic = "xfail"]
-#[case::ranges("ranges", Some(vec![
-    ("tket.quantum.H", 8), ("tket.quantum.MeasureFree", 4), ("tket.quantum.QAlloc", 4), ("tket.quantum.CX", 6)
-]))]
+#[case::nested("nested", None)]
+#[case::ranges("ranges", None)]
 #[should_panic = "xfail"]
 #[case::false_branch("false_branch", Some(vec![
  ("tket.quantum.Measure", 1), ("tket.quantum.QAlloc", 1), ("tket.quantum.QFree", 1)

--- a/tket-qsystem/tests/guppy_opt.rs
+++ b/tket-qsystem/tests/guppy_opt.rs
@@ -135,26 +135,12 @@ fn optimize_flattened_guppy(#[case] name: &str, #[case] xfail: Option<Vec<(&str,
 #[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 fn optimize_guppy_ranges_array() {
     // Demonstrates we can fully optimize the array operations in ranges
-    // (after control flow is flattened) if we play around with the entrypoint.
-    use hugr::hugr::hugrmut::HugrMut;
-    use tket::passes::BorrowSquashPass;
-    use tket::passes::const_fold::ConstantFoldPass;
+    // (i.e. after control flow is flattened, but the array ops are not)
     let mut hugr = load_guppy_example("ranges/ranges.flat.array.hugr").unwrap();
 
-    ConstantFoldPass::default().run(&mut hugr).unwrap();
-    BorrowSquashPass::default().run(&mut hugr).unwrap();
-
-    let f = hugr
-        .children(hugr.module_root())
-        .find(|n| {
-            hugr.get_optype(*n)
-                .as_func_defn()
-                .is_some_and(|fd| fd.func_name() == "__main__.f")
-        })
-        .unwrap();
-    hugr.set_entrypoint(f);
-
+    NormalizeGuppy::default().run(&mut hugr).unwrap();
     run_pytket(&mut hugr, CLIFFORD_SIMP_STR);
+
     let expected_counts =
         count_gates(&load_guppy_circuit("ranges", HugrFileType::Optimized).unwrap());
     assert_eq!(count_gates(&hugr), expected_counts);


### PR DESCRIPTION
closes #1639

`guppy_opt.rs` uses its own `run_pytket` function that builds an EncodedCircuit. EncodedCircuit looks only within the entrypoint, so....instead run it everywhere.

This fixes two of the tests, so remove xfails :-)

(So, this is a bit of a test artifact. Does this mean we should update any other tests anywhere? IIUC for python stuff the answer is no.)

Also simplify the ranges.flat.array test (standard treatment now fine).

A couple of the others improve, to the point they have no "true quantum" gates only qalloc/measure/qfree. This is just that the tket1 pass in CLIFFORD_SIMP_STR does not optimize out these totally-predictable measurements....

And there's another change to behaviour on `angles.rs`, for which I've raised #1747 