### PR TITLE
ci: Fix release-checks, ensure minimum conan version

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -58,10 +58,10 @@ jobs:
           uv python pin ${{ matrix.target.python }}
       - name: Setup `tket-py` with only pypi deps
         env:
-          UV_RESOLUTION: ${{ matrix.target.resolution }}
+          RES: ${{ matrix.target.resolution }}
         run: |
-          uv lock --no-sources -U
-          uv sync --no-sources --no-install-workspace
+          UV_RESOLUTION="$RES" uv lock --no-sources -U
+          UV_RESOLUTION="$RES" uv sync --no-sources --no-install-workspace
           uv pip install --no-sources tket-exts
           uv pip install --no-sources tket-eccs
           uv run --no-sync maturin develop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dev = [
     "hypothesis >=6.111.1,<7",
     "graphviz ~=0.21.0",
     "pre-commit ~=4.3",
-    "conan >= 2.0.0,<3",
+    "conan >= 2.23.0,<3",
     # Required to run `maturin develop`
     "pip >=25",
     # Pyyaml 0.6.0 makes setuptools fail. This ensures we're using a newer version.

--- a/qis-compiler/pyproject.toml
+++ b/qis-compiler/pyproject.toml
@@ -7,7 +7,7 @@ dev = [
     "pytest>=8.4.2",
     "pytest-snapshot~=0.9.0",
     "cibuildwheel>=2.23.2",
-    "hugr>=0.14.0",
+    "hugr>=0.14.4",
 ]
 
 [project]

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ members = [
 
 [manifest.dependency-groups]
 dev = [
-    { name = "conan", specifier = ">=2.0.0,<3" },
+    { name = "conan", specifier = ">=2.23.0,<3" },
     { name = "graphviz", specifier = "~=0.21.0" },
     { name = "hypothesis", specifier = ">=6.111.1,<7" },
     { name = "maturin", specifier = ">=1.9.2,<2" },
@@ -615,7 +615,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2609,7 +2609,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "cibuildwheel", specifier = ">=2.23.2" },
-    { name = "hugr", specifier = ">=0.14.0" },
+    { name = "hugr", specifier = ">=0.14.4" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-snapshot", specifier = "~=0.9.0" },
 ]


### PR DESCRIPTION
Installing `tket-eccs` on the fourth step was downgrading `hugr` to `0.13`, since we were using `UV_RESOLUTION=lowest-direct` and the step is separated from the project's sync (which requires `hugr 0.14`)

test run: https://github.com/Quantinuum/tket2/actions/runs/20106380296/job/57691368563