### PR TITLE
feat: Use constant folding by default on NormalizeGuppy

### DIFF
--- a/tket-py/src/passes.rs
+++ b/tket-py/src/passes.rs
@@ -64,7 +64,7 @@ create_py_exception!(
 /// - remove_dead_funcs: Whether to remove dead functions.
 /// - inline_dfgs: Whether to inline DFG operations.
 #[pyfunction]
-#[pyo3(signature = (circ, *, simplify_cfgs = true, remove_tuple_untuple = true, constant_folding = false, remove_dead_funcs = true, inline_dfgs = true))]
+#[pyo3(signature = (circ, *, simplify_cfgs = true, remove_tuple_untuple = true, constant_folding = true, remove_dead_funcs = true, inline_dfgs = true))]
 fn normalize_guppy<'py>(
     circ: &Bound<'py, PyAny>,
     simplify_cfgs: bool,

--- a/tket-py/tket/_tket/passes.pyi
+++ b/tket-py/tket/_tket/passes.pyi
@@ -25,7 +25,7 @@ def normalize_guppy(
     *,
     simplify_cfgs: bool = True,
     remove_tuple_untuple: bool = True,
-    constant_folding: bool = False,
+    constant_folding: bool = True,
     remove_dead_funcs: bool = True,
     inline_dfgs: bool = True,
 ) -> CircuitClass:


### PR DESCRIPTION
We had this enabled by default on the rust side, but not for python due to some bugs that have now been fixed.