### PR TITLE
fix: Incorrect manylinux version in linux wheels

### DIFF
--- a/.github/actions/tket-c-api/action.yml
+++ b/.github/actions/tket-c-api/action.yml
@@ -1,5 +1,5 @@
 name: "Install tket-c-api C++ library"
-description: "Retrieve cached tket-c-api C++ library or build if needed"
+description: "Retrieve cached tket-c-api C++ library or build if needed."
 
 inputs:
   install-path:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -85,16 +85,16 @@ jobs:
           #  target: aarch64-unknown-linux-musl
           #  manylinux: "musllinux_1_2"
           - runner: ubuntu-24.04
-            # NOTE: We use the sightly older Ubuntu 22.04 runner to force a
-            # lower GLIBC version in the tket-c-api build.
-            #
-            # This should no longer be necessary once we fix the tket-c-api build.
-            # <https://github.com/Quantinuum/tket2/issues/1272>
             target: x86_64-unknown-linux-gnu
-            manylinux: "manylinux_2_39"
+            # Note: The runner image uses GLIBC 2.39, but we verified that the
+            # tket-c-api build works with GLIBC 2.34.
+            #
+            # This is a temporary workaround until we use a pre-built c-api library.
+            # <https://github.com/Quantinuum/tket2/issues/1272>
+            # <https://github.com/Quantinuum/tket2/pull/1271>
+            manylinux: "manylinux_2_34"
             test-wheels: true
           - runner: ubuntu-24.04
-            # NOTE: See comment above about Ubuntu 22.04 runner
             target: x86_64-unknown-linux-musl
             manylinux: "musllinux_1_2"
           # ---------------- Mac


### PR DESCRIPTION
The linux-gnu wheel builds were incorrectly stating we support `manylinux2014` (`glibc 2.17`).
The wheels include the `tket-c-api` library, which is built directly on the container and hence uses the system's glibc version.

For the supported `ubuntu 24.04` runner, that is `glibc 2.39`.
After some investigation, it seems that if we change the conan profile used to build `tket-c-api` from `-gcc14` to `-gcc13` the resulting `.so` only requires `glibc 2.34`.

This is just a patch to ensure the wheels we built correctly announce their properties.
The issue for actually fixing the root problem is here: https://github.com/Quantinuum/tket2/issues/1272

[Test build](https://github.com/Quantinuum/tket2/actions/runs/20335124960/job/58419711500#step:13:314)