### PR TITLE
fix: boost 1.90 dependecy conflict

### DIFF
--- a/tket1-passes/conanfile.txt
+++ b/tket1-passes/conanfile.txt
@@ -1,2 +1,2 @@
 [requires]
-tket-c-api/2.1.64@tket/stable
+tket-c-api/2.1.67@tket/stable


### PR DESCRIPTION
Bumped tket-c-api dependency to avoid boost 1.90 dependency mismatch