### PR TITLE
ci: Fix miri unsoundness check

### DIFF
--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -21,18 +21,38 @@ env:
   MIRIFLAGS: "-Zmiri-permissive-provenance -Zmiri-env-forward=PROPTEST_DISABLE_FAILURE_PERSISTENCE"
   PROPTEST_DISABLE_FAILURE_PERSISTENCE: true
 
+  # different strings for install action and feature name
+  # adapted from https://github.com/TheDan64/inkwell/blob/master/.github/workflows/test.yml
+  LLVM_VERSION: "14.0"
+  LLVM_FEATURE_NAME: "14-0"
+
+  # Path to the cached tket-c-api library
+  # When this envvar is set, the `./.github/actions/tket-c-api` action **must** be run to fetch the artifacts
+  # This config is not required, but speeds up the build by caching the tket-c-api library
+  # The alternative is to install conan and remove the env var
+  TKET_C_API_PATH: "${{ github.workspace }}/tket-c-api"
+  LD_LIBRARY_PATH: ${{ github.workspace }}/tket-c-api/lib
+
 jobs:
   miri:
     name: "Miri"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri
           rustup override set nightly
           cargo miri setup
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: ${{ env.LLVM_VERSION }}
+      - name: Install tket-c-api library
+        uses: ./.github/actions/tket-c-api
+        with:
+          install-path: ${{ env.TKET_C_API_PATH }}
       - name: Test with Miri
         run: cargo miri test
 


### PR DESCRIPTION
Build `tket-c-api` before running the miri tests.
The test was failing before with a `conan not found` error while building.

[Test run](https://github.com/Quantinuum/tket2/actions/runs/20929102142/job/60135002024)