### PR TITLE
docs: update example notebook after Guppy optimization fixes

### DIFF
--- a/tket-py/docs/examples/Guppy-opt-example.ipynb
+++ b/tket-py/docs/examples/Guppy-opt-example.ipynb
@@ -39,7 +39,9 @@
    "source": [
     "In this notebook tutorial we will show how to call pytket optimization passes on quantum programs written in [Guppy](https://docs.quantinuum.com/guppy/). Guppy programs compile to  [HUGR](https://github.com/Quantinuum/hugr) which is an intermediate representation for hybrid quantum programs.\n",
     "\n",
-    "As of `tket-py` version 0.12.13 `(tket>=0.12.13)` we can call any serializable pass from [pytket.passes](https://docs.quantinuum.com/tket/api-docs/passes.html) on Guppy programs. The `PytketHugrPass` interface allows the user to define a `Hugr` -> `Hugr` transformation with a pass from the pytket package.\n"
+    "As of `tket-py` version 0.12.13 `(tket>=0.12.13)` we can call any serializable pass from [pytket.passes](https://docs.quantinuum.com/tket/api-docs/passes.html) on Guppy programs. The `PytketHugrPass` interface allows the user to define a `Hugr` -> `Hugr` transformation with a pass from the pytket package.\n",
+    "\n",
+    "The `tket=0.12.14` release contains some key bug fixes for the optimization of Gupp programs.  \n"
    ]
   },
   {
@@ -458,7 +460,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x119de1550>"
+       "<graphviz.graphs.Digraph at 0x130c9c830>"
       ]
      },
      "execution_count": 4,
@@ -488,8 +490,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Node(0) NodeData(op=Module(), parent=None, metadata={'name': '__main__', 'core.used_extensions': [{'name': 'tket.bool', 'version': '0.2.0'}, {'name': 'tket.debug', 'version': '0.2.0'}, {'name': 'tket.futures', 'version': '0.2.0'}, {'name': 'tket.guppy', 'version': '0.2.0'}, {'name': 'tket.qsystem', 'version': '0.5.0'}, {'name': 'tket.qsystem.random', 'version': '0.2.1'}, {'name': 'tket.qsystem.utils', 'version': '0.3.0'}, {'name': 'tket.quantum', 'version': '0.2.1'}, {'name': 'tket.result', 'version': '0.2.0'}, {'name': 'tket.rotation', 'version': '0.2.0'}, {'name': 'tket.wasm', 'version': '0.4.1'}, {'name': 'tket.modifier', 'version': '0.1.0'}, {'name': 'tket.global_phase', 'version': '0.1.0'}, {'name': 'guppylang', 'version': '0.1.0'}, {'name': 'prelude', 'version': '0.2.1'}, {'name': 'collections.array', 'version': '0.1.1'}, {'name': 'arithmetic.float', 'version': '0.1.0'}, {'name': 'arithmetic.float.types', 'version': '0.1.0'}, {'name': 'arithmetic.int', 'version': '0.1.0'}, {'name': 'arithmetic.int.types', 'version': '0.1.0'}, {'name': 'logic', 'version': '0.1.0'}], 'core.generator': {'name': 'guppylang (guppylang-internals-v0.25.0)', 'version': '0.21.6'}})\n",
-      "Node(1) NodeData(op=FuncDefn(f_name='pauli_zz_rotation', inputs=[Qubit, Qubit], params=[], visibility='Private'), parent=Node(0), metadata={})\n",
+      "Node(0) NodeData(op=Module(), parent=None, metadata={'name': '__main__', 'core.used_extensions': [{'name': 'tket.bool', 'version': '0.2.0'}, {'name': 'tket.debug', 'version': '0.2.0'}, {'name': 'tket.futures', 'version': '0.2.0'}, {'name': 'tket.global_phase', 'version': '0.1.0'}, {'name': 'tket.guppy', 'version': '0.2.0'}, {'name': 'tket.modifier', 'version': '0.1.0'}, {'name': 'tket.qsystem', 'version': '0.5.0'}, {'name': 'tket.qsystem.random', 'version': '0.2.1'}, {'name': 'tket.qsystem.utils', 'version': '0.3.0'}, {'name': 'tket.quantum', 'version': '0.2.1'}, {'name': 'tket.result', 'version': '0.2.0'}, {'name': 'tket.rotation', 'version': '0.2.0'}, {'name': 'tket.wasm', 'version': '0.4.1'}, {'name': 'guppylang', 'version': '0.1.0'}, {'name': 'prelude', 'version': '0.2.1'}, {'name': 'collections.array', 'version': '0.1.1'}, {'name': 'arithmetic.float', 'version': '0.1.0'}, {'name': 'arithmetic.float.types', 'version': '0.1.0'}, {'name': 'arithmetic.int', 'version': '0.1.0'}, {'name': 'arithmetic.int.types', 'version': '0.1.0'}, {'name': 'logic', 'version': '0.1.0'}], 'core.generator': {'name': 'guppylang (guppylang-internals-v0.26.0)', 'version': '0.21.7'}})\n",
+      "Node(1) NodeData(op=FuncDefn(f_name='pauli_zz_rotation', inputs=[Qubit, Qubit], params=[], visibility='Private'), parent=Node(0), metadata={'unitary': 0})\n",
       "Node(2) NodeData(op=Input(types=[Qubit, Qubit]), parent=Node(1), metadata={})\n",
       "Node(3) NodeData(op=Output(), parent=Node(1), metadata={})\n",
       "Node(4) NodeData(op=CFG(inputs=[Qubit, Qubit]), parent=Node(1), metadata={})\n",
@@ -743,7 +745,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x119c77ad0>"
+       "<graphviz.graphs.Digraph at 0x130b8a210>"
       ]
      },
      "execution_count": 8,
@@ -993,7 +995,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x119cfae50>"
+       "<graphviz.graphs.Digraph at 0x130bb9b50>"
       ]
      },
      "execution_count": 11,
@@ -1217,7 +1219,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x119dac140>"
+       "<graphviz.graphs.Digraph at 0x130ca4410>"
       ]
      },
      "execution_count": 16,
@@ -1312,9 +1314,7 @@
    "id": "135b6431",
    "metadata": {},
    "source": [
-    "We should see that our optimisation has reduced the number of Rz rotations from 3 to 1.\n",
-    "\n",
-    "Note that this isn't quite working yet. Fix requires https://github.com/Quantinuum/hugr/pull/2739"
+    "We should see that our optimisation has reduced the number of Rz rotations from 3 to 1 by combining the rotation angles."
    ]
   },
   {
@@ -1327,7 +1327,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "#Rz gates in optimized program = 3\n"
+      "#Rz gates in optimized program = 1\n"
      ]
     }
    ],
@@ -1338,7 +1338,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tket2",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
1. Recommends using 0.12.14 in the intro (soon to be relased)
2. I reran this notebook so that the 1q gate squashing example now gives the expected answer. Also updated the text.