### PR TITLE
ci: Don't use a _target trigger for semver-checks

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -1,6 +1,6 @@
 name: Rust Semver Checks
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 


### PR DESCRIPTION
This should fix the spurious semver checks fail.

Github's documentation states that `github.event.pull_request.merge_commit_sha` contains the ref for the commit merging a PR's HEAD with the target branch.
In practice, that field seems to be always empty.
As a fallback, the `rs-semver-checks` action uses the default `GITHUB_SHA`.

On `pull_request` triggers, that value is exactly what we want (the commit after the merge), but for `pull_request_target` triggers it gets assigned to the target branch commit.

There doesn't seem to be another way to retrieve the `merge_commit_sha`, so we cannot fix the action in `hugrverse-actions` directly.
The solution instead is to change the trigger for the workflows that call it.