### PR TITLE
chore(py-deps): Bump min pytket and hugr deps

### DIFF
--- a/tket-py/pyproject.toml
+++ b/tket-py/pyproject.toml
@@ -29,10 +29,10 @@ classifiers = [
 
 
 dependencies = [
-    'hugr >= 0.14.4',
-    "pytket>=1.34,<3",
+    'hugr ~= 0.15.0',
+    "pytket>=2.1.0,<3",
     'tket_eccs ~= 0.5.1',
-    'tket_exts >= 0.10.1, <0.13',
+    'tket_exts >= 0.12.1, <0.13',
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -2943,8 +2943,8 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hugr", specifier = ">=0.14.4" },
-    { name = "pytket", specifier = ">=1.34,<3" },
+    { name = "hugr", specifier = "~=0.15.0" },
+    { name = "pytket", specifier = ">=2.1.0,<3" },
     { name = "tket-eccs", editable = "tket-eccs" },
     { name = "tket-exts", editable = "tket-exts" },
 ]


### PR DESCRIPTION
- Bumps the hugr version from `>=0.14` to `~=0.15`
- Bumps the required `tket_exts` version to one that matches the current rust-side definitions.

- Bumps the minimum pytket version from `1.34` to `2.1.0`.
  That version included a breaking change to the serialization of `CliffordSimp` (https://github.com/Quantinuum/tket/pull/1801), that caused incompatibilities with the internal pytket pass interface.
  
This should fix the release-checks error on `min-dependencies` from https://github.com/Quantinuum/tket2/pull/1324.