### PR TITLE
ci: Use older sccache in wheels build workflow

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -113,6 +113,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: mozilla-actions/sccache-action@v0.0.9
+        # The sccache 0.13.0 release is missing intel mac builds
+        # see <https://github.com/mozilla/sccache/issues/2554>
+        with:
+          version: "v0.12.0"
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
`sccache 0.13.0` did not ship pre-built binaries for `macos-intel`, so `sccache-action` produces a 404 error when running on those runners.

This PR just forces an older sccache version until https://github.com/mozilla/sccache/issues/2554 gets solved.