### PR TITLE
chore: Update label names in configs

### DIFF
--- a/.github/actions/check-changes/action.yml
+++ b/.github/actions/check-changes/action.yml
@@ -10,7 +10,7 @@ description: Checks if any relevant files have changed in the current pull reque
 # ```
 
 # Set job outputs to values from filter step
-# These outputs are always true when running after a merge to main, or if the PR has a `run-ci-checks` label.
+# These outputs are always true when running after a merge to main, or if the PR has a `X-run-thorough-ci-tests` label.
 outputs:
   extensions:
     description: "The extension definitions have changed"
@@ -37,16 +37,16 @@ runs:
       shell: bash
       id: override
       run: |
-        echo "Label contains run-ci-checks: $OVERRIDE_LABEL"
+        echo "Label contains X-run-thorough-ci-tests: $OVERRIDE_LABEL"
         if [ "$OVERRIDE_LABEL" == "true" ]; then
-          echo "Overriding due to label 'run-ci-checks'"
+          echo "Overriding due to label 'X-run-thorough-ci-tests'"
           echo "out=true" >> $GITHUB_OUTPUT
         elif [ "$DEFAULT_BRANCH" == "true" ]; then
           echo "Overriding due to running on the default branch"
           echo "out=true" >> $GITHUB_OUTPUT
         fi
       env:
-        OVERRIDE_LABEL: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'run-ci-checks') }}
+        OVERRIDE_LABEL: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'X-run-thorough-ci-tests') }}
         DEFAULT_BRANCH: ${{ github.ref_name == github.event.repository.default_branch }}
     - if: steps.override.outputs.out != 'true'
       uses: dorny/paths-filter@v3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     commit-message:
       # Use a conventional commit tag
       prefix: "chore(deps-rs)"
+    labels:
+      - "A-rust"
+      - "X-dependabot"
     groups:
       hugr:
         patterns: ["hugr*"]
@@ -38,6 +41,9 @@ updates:
     commit-message:
       # Use a conventional commit tag
       prefix: "chore(deps-py)"
+    labels:
+      - "A-python"
+      - "X-dependabot"
     groups:
       hugr:
         patterns: ["hugr*"]
@@ -57,3 +63,6 @@ updates:
     commit-message:
       # Use a conventional commit tag
       prefix: "ci(deps)"
+    labels:
+      - "A-ci"
+      - "X-dependabot"

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -68,5 +68,5 @@ jobs:
         The unsoundness check for `quantinuum/tket2` failed.
 
         [Please investigate](https://github.com/quantinuum/tket2/actions/runs/${{ github.run_id }}).
-      unique-label: "unsoundness-checks"
-      other-labels: "bug"
+      unique-label: "X-unsoundness-checks"
+      other-labels: "C-bugfix"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -135,7 +135,7 @@ We welcome contributions to tket! Please open [an issue](https://github.com/quan
 PRs should be made against the `main` branch, and should pass all CI checks before being merged. This includes using the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format for the PR title.
 
 Some tests may be skipped based on the changes made. To run all the tests in
-your PR mark it with a 'run-ci-checks' label and push new commits to it.
+your PR mark it with a 'X-run-thorough-ci-tests' label and push new commits to it.
 
 The general format of a contribution title should be:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "initial-version": "0.0.0",
+    "extra-label": "X-release",
     "separate-pull-requests": true,
     "pull-request-title-pattern": "chore(py): release${component} ${version}",
     "packages": {

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,6 +11,7 @@ release = false
 # (This would normally only be enabled once there are multiple packages in the workspace)
 git_tag_name = "{{ package }}-v{{ version }}"
 git_release_name = "{{ package }}: v{{ version }}"
+pr_labels = ["X-release", "A-rust"]
 
 # Only create releases / push to crates.io after merging a release-please PR.
 # This lets merge new crates to `main` without worrying about accidentally creating


### PR DESCRIPTION
Similar to https://github.com/Quantinuum/hugr/pull/2850

I organized the [project labels](https://github.com/Quantinuum/hugr/labels) for the new project flow.

This PR updates the internal configs that referenced the old labels.