### PR TITLE
ci: Use latest version of sccache

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -113,10 +113,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: mozilla-actions/sccache-action@v0.0.9
-        # The sccache 0.13.0 release is missing intel mac builds
-        # see <https://github.com/mozilla/sccache/issues/2554>
-        with:
-          version: "v0.12.0"
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
See https://github.com/mozilla/sccache/releases/tag/v0.14.0 .