### PR TITLE
feat: Add qsystem.rz pytket decoder

### DIFF
--- a/tket-qsystem/src/pytket/qsystem.rs
+++ b/tket-qsystem/src/pytket/qsystem.rs
@@ -116,7 +116,11 @@ impl QSystemEmitter {
 
 impl PytketDecoder for QSystemEmitter {
     fn op_types(&self) -> Vec<PytketOptype> {
-        // Process native optypes that are not supported by the `TketOp` emitter.
+        // Process native optypes with direct qsystem counterparts.
+        //
+        // Some of these overlap with what the `TketOp` emitter can decode. The
+        // decoder used for those cases will be the first one registered in the
+        // [`PytketDecoderConfig`].
         vec![
             PytketOptype::Rz,
             PytketOptype::PhasedX,


### PR DESCRIPTION
Adds a translation from pytket's `Rz` optype to `tket.qsystem.rz`.

When using the default pytket decoder config we translate `PytketOptype::Rz` into `TketOp::Rz`. Since the `tket.quantum` decoder comes first in the default config, this PR's change won't affect the default behaviour.

This will only affect cases where we manually create a decoder config with the `qsystem` decoder but no `tket.quantum`.