### PR TITLE
feat: Print full traceback for rust-originated errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,6 +2743,7 @@ dependencies = [
 name = "tket-py"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "cool_asserts",
  "derive_more 2.1.1",
  "hugr",

--- a/tket-py/Cargo.toml
+++ b/tket-py/Cargo.toml
@@ -32,7 +32,8 @@ hugr = { workspace = true }
 itertools = { workspace = true }
 num_cpus = { workspace = true }
 portmatching = { workspace = true }
-pyo3 = { workspace = true, features = ["py-clone", "abi3-py310"] }
+pyo3 = { workspace = true, features = ["py-clone", "abi3-py310", "anyhow"] }
+anyhow = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/tket-py/src/circuit/tk2circuit.rs
+++ b/tket-py/src/circuit/tk2circuit.rs
@@ -7,6 +7,7 @@ use std::mem;
 use std::num::{NonZero, NonZeroU8};
 use std::sync::LazyLock;
 
+use anyhow::Context;
 use hugr::algorithms::ComposablePass;
 use hugr::builder::{CircuitBuilder, DFGBuilder, Dataflow, DataflowHugr};
 use hugr::envelope::{EnvelopeConfig, EnvelopeFormat, ZstdConfig};
@@ -75,22 +76,23 @@ impl Tk2Circuit {
     /// Converts the input circuit to a `Hugr` if required via its serialisation
     /// interface.
     #[new]
-    pub fn new(circ: &Bound<PyAny>) -> PyResult<Self> {
+    pub fn new(circ: &Bound<PyAny>) -> anyhow::Result<Self> {
         Ok(Self {
             circ: with_circ(circ, |hugr, _| hugr)?,
         })
     }
 
     /// Convert the [`Tk2Circuit`] to a tket1 circuit.
-    pub fn to_tket1<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    pub fn to_tket1<'py>(&self, py: Python<'py>) -> anyhow::Result<Bound<'py, PyAny>> {
         let mut hugr = self.circ.hugr().clone();
-        NormalizeGuppy::default().run(&mut hugr).convert_pyerrs()?;
-        SerialCircuit::encode(
+        NormalizeGuppy::default().run(&mut hugr)?;
+        let serial = SerialCircuit::encode(
             &hugr,
             EncodeOptions::new().with_config(tket_qsystem::pytket::qsystem_encoder_config()),
-        )
-        .convert_pyerrs()?
-        .to_tket1(py)
+        )?;
+        serial
+            .to_tket1(py)
+            .context("Could not convert tk2circuit to tket1")
     }
 
     /// Apply a rewrite on the circuit.
@@ -102,16 +104,15 @@ impl Tk2Circuit {
     ///
     /// If no config is given, it defaults to the default binary envelope.
     #[pyo3(signature = (config = None))]
-    pub fn to_bytes(&self, config: Option<Bound<'_, PyAny>>) -> PyResult<Vec<u8>> {
-        fn err(e: impl Display) -> PyErr {
-            PyErr::new::<PyAttributeError, _>(format!("Could not encode circuit: {e}"))
-        };
+    pub fn to_bytes(&self, config: Option<Bound<'_, PyAny>>) -> anyhow::Result<Vec<u8>> {
         let config = match config {
             Some(cfg) => envelope_config_from_py(cfg)?,
             None => EnvelopeConfig::binary(),
         };
         let mut buf = Vec::new();
-        self.circ.store(&mut buf, config).map_err(err)?;
+        self.circ
+            .store(&mut buf, config)
+            .context("Could not encode tk2circuit to bytes")?;
         Ok(buf)
     }
 
@@ -119,15 +120,14 @@ impl Tk2Circuit {
     ///
     /// If no config is given, it defaults to the default text envelope.
     #[pyo3(signature = (config = None))]
-    pub fn to_str(&self, config: Option<Bound<'_, PyAny>>) -> PyResult<String> {
-        fn err(e: impl Display) -> PyErr {
-            PyErr::new::<PyAttributeError, _>(format!("Could not encode circuit: {e}"))
-        };
+    pub fn to_str(&self, config: Option<Bound<'_, PyAny>>) -> anyhow::Result<String> {
         let config = match config {
             Some(cfg) => envelope_config_from_py(cfg)?,
             None => EnvelopeConfig::text(),
         };
-        self.circ.store_str(config).map_err(err)
+        self.circ
+            .store_str(config)
+            .context("Could not encode tk2circuit to string")
     }
 
     /// Loads a circuit from a HUGR envelope.
@@ -137,15 +137,13 @@ impl Tk2Circuit {
     // TODO(deprecated): Drop the `function_name` parameter in a breaking change.
     #[staticmethod]
     #[pyo3(signature = (bytes, function_name = None))]
-    pub fn from_bytes(bytes: &[u8], function_name: Option<String>) -> PyResult<Self> {
-        fn err(e: impl Display) -> PyErr {
-            PyErr::new::<PyAttributeError, _>(format!("Could not read envelope: {e}"))
-        };
+    pub fn from_bytes(bytes: &[u8], function_name: Option<String>) -> anyhow::Result<Self> {
         let circ = match function_name {
             // NOTE: `load_function` uses the default REGISTRY which does not contain tket-qsystem extensions.
-            Some(name) => Circuit::load_function(bytes, name).map_err(err)?,
-            None => Circuit::load(bytes, Some(&REGISTRY)).map_err(err)?,
-        };
+            Some(name) => Circuit::load_function(bytes, name),
+            None => Circuit::load(bytes, Some(&REGISTRY)),
+        }
+        .context("Could not read tk2circuit from bytes")?;
         Ok(Tk2Circuit { circ })
     }
 
@@ -156,71 +154,59 @@ impl Tk2Circuit {
     // TODO(deprecated): Drop the `function_name` parameter in a breaking change.
     #[staticmethod]
     #[pyo3(signature = (envelope, function_name = None))]
-    pub fn from_str(envelope: &str, function_name: Option<String>) -> PyResult<Self> {
-        fn err(e: impl Display) -> PyErr {
-            PyErr::new::<PyAttributeError, _>(format!("Could not read envelope: {e}"))
-        };
+    pub fn from_str(envelope: &str, function_name: Option<String>) -> anyhow::Result<Self> {
         let circ = match function_name {
             // NOTE: `load_function_str` uses the default REGISTRY which does not contain tket-qsystem extensions.
-            Some(name) => Circuit::load_function_str(envelope, name).map_err(err)?,
-            None => Circuit::load_str(envelope, Some(&REGISTRY)).map_err(err)?,
-        };
+            Some(name) => Circuit::load_function_str(envelope, name),
+            None => Circuit::load_str(envelope, Some(&REGISTRY)),
+        }
+        .context("Could not read tk2circuit from string")?;
         Ok(Tk2Circuit { circ })
     }
 
     /// Encode the circuit as a tket1 json string.
-    pub fn to_tket1_json(&self) -> PyResult<String> {
+    pub fn to_tket1_json(&self) -> anyhow::Result<String> {
         // Try to simplify tuple pack-unpack pairs, and other operations not supported by pytket.
         let mut hugr = self.circ.hugr().clone();
-        NormalizeGuppy::default().run(&mut hugr).convert_pyerrs()?;
+        NormalizeGuppy::default().run(&mut hugr)?;
         let serial = SerialCircuit::encode(
             &hugr,
             EncodeOptions::new().with_config(tket_qsystem::pytket::qsystem_encoder_config()),
-        )
-        .convert_pyerrs()?;
-        serde_json::to_string(&serial).map_err(|e| {
-            PyErr::new::<PyValueError, _>(format!("Could not encode pytket circuit to str: {e}"))
-        })
+        )?;
+        serde_json::to_string(&serial).context("Could not encode pytket circuit to str")
     }
 
     /// Decode a tket1 json string to a circuit.
     #[staticmethod]
-    pub fn from_tket1_json(json: &str) -> PyResult<Self> {
+    pub fn from_tket1_json(json: &str) -> anyhow::Result<Self> {
         let hugr = tket::serialize::load_tk1_json_str(
             json,
             DecodeOptions::new().with_config(tket_qsystem::pytket::qsystem_decoder_config()),
         )
-        .map_err(|e| {
-            PyErr::new::<PyAttributeError, _>(format!("Could not load pytket circuit: {e}"))
-        })?;
+        .context("Could not load pytket circuit")?;
         Ok(Tk2Circuit { circ: hugr.into() })
     }
 
     /// Encode the circuit as a tket1 json utf8 bytes.
-    pub fn to_tket1_json_bytes(&self) -> PyResult<Vec<u8>> {
+    pub fn to_tket1_json_bytes(&self) -> anyhow::Result<Vec<u8>> {
         // Try to simplify tuple pack-unpack pairs, and other operations not supported by pytket.
         let mut hugr = self.circ.hugr().clone();
-        NormalizeGuppy::default().run(&mut hugr).convert_pyerrs()?;
+        NormalizeGuppy::default().run(&mut hugr)?;
         let serial = SerialCircuit::encode(
             &hugr,
             EncodeOptions::new().with_config(tket_qsystem::pytket::qsystem_encoder_config()),
-        )
-        .convert_pyerrs()?;
-        serde_json::to_vec(&serial).map_err(|e| {
-            PyErr::new::<PyValueError, _>(format!("Could not encode pytket circuit to bytes: {e}"))
-        })
+        )?;
+        serde_json::to_vec(&serial).context("Could not encode pytket circuit to bytes")
     }
 
     /// Decode a tket1 json utf8 bytes to a circuit.
     #[staticmethod]
-    pub fn from_tket1_json_bytes(json: &[u8]) -> PyResult<Self> {
+    pub fn from_tket1_json_bytes(json: &[u8]) -> anyhow::Result<Self> {
         let hugr = tket::serialize::load_tk1_json_reader(
             json,
             DecodeOptions::new().with_config(tket_qsystem::pytket::qsystem_decoder_config()),
         )
-        .map_err(|e| {
-            PyErr::new::<PyAttributeError, _>(format!("Could not load pytket circuit: {e}"))
-        })?;
+        .context("Could not load pytket circuit")?;
         Ok(Tk2Circuit { circ: hugr.into() })
     }
 
@@ -231,15 +217,16 @@ impl Tk2Circuit {
     ///     `__eq__`, `__int__`, and integer `__div__`.
     ///
     /// :returns: The sum of all operation costs.
-    pub fn circuit_cost<'py>(&self, cost_fn: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    pub fn circuit_cost<'py>(
+        &self,
+        cost_fn: &Bound<'py, PyAny>,
+    ) -> anyhow::Result<Bound<'py, PyAny>> {
         let py = cost_fn.py();
-        let cost_fn = |op: &OpType| -> PyResult<PyCircuitCost> {
+        let cost_fn = |op: &OpType| -> anyhow::Result<PyCircuitCost> {
             // TODO: We should ignore non-tket operations instead.
             let Some(tk2_op) = op.cast::<TketOp>() else {
                 let op_name = op.to_string();
-                return Err(PyErr::new::<PyValueError, _>(format!(
-                    "Could not convert circuit operation to a `TketOp`: {op_name}"
-                )));
+                anyhow::bail!("Could not convert circuit operation to a `TketOp`: {op_name}");
             };
             let tk2_py_op = PyTketOp::from(tk2_op);
             let cost = cost_fn.call1((tk2_py_op,))?;
@@ -269,27 +256,20 @@ impl Tk2Circuit {
     }
 
     /// Copy the circuit.
-    pub fn __copy__(&self) -> PyResult<Self> {
+    pub fn __copy__(&self) -> anyhow::Result<Self> {
         Ok(self.clone())
     }
 
     /// Copy the circuit.
-    pub fn __deepcopy__(&self, _memo: Bound<PyAny>) -> PyResult<Self> {
+    pub fn __deepcopy__(&self, _memo: Bound<PyAny>) -> anyhow::Result<Self> {
         Ok(self.clone())
     }
 
-    fn node_op(&self, node: PyNode) -> PyResult<Cow<'_, [u8]>> {
-        let custom: ExtensionOp = self
-            .circ
-            .hugr()
-            .get_optype(node.node)
-            .clone()
-            .try_into()
-            .map_err(|e| {
-                PyErr::new::<PyValueError, _>(format!(
-                    "Could not convert circuit operation to an `ExtensionOp`: {e}"
-                ))
-            })?;
+    fn node_op(&self, node: PyNode) -> anyhow::Result<Cow<'_, [u8]>> {
+        let optype: OpType = self.circ.hugr().get_optype(node.node).clone();
+        let custom: ExtensionOp = optype.try_into().map_err(|_| {
+            anyhow::anyhow!("Could not convert circuit operation to an `ExtensionOp`")
+        })?;
 
         Ok(serde_json::to_vec(&custom).unwrap().into())
     }
@@ -332,14 +312,13 @@ impl Tk2Circuit {
 }
 
 /// Converts a python `hugr.envelope.EnvelopeConfig` into a rust-based [`EnvelopeConfig`].
-pub fn envelope_config_from_py(config: Bound<'_, PyAny>) -> PyResult<EnvelopeConfig> {
+pub fn envelope_config_from_py(config: Bound<'_, PyAny>) -> anyhow::Result<EnvelopeConfig> {
     let mut res = EnvelopeConfig::default();
 
     let format = config.getattr("format")?;
     let format_ident: usize = format.getattr("value")?.extract()?;
-    res.format = EnvelopeFormat::from_repr(format_ident).ok_or_else(|| {
-        PyErr::new::<PyValueError, _>(format!("Invalid envelope format: {format_ident}"))
-    })?;
+    res.format = EnvelopeFormat::from_repr(format_ident)
+        .ok_or_else(|| anyhow::anyhow!("Invalid envelope format: {format_ident}"))?;
 
     let zstd: Option<usize> = config.getattr("zstd")?.extract()?;
     res.zstd = zstd.map(|level| {

--- a/tket-py/test/test_errors.py
+++ b/tket-py/test/test_errors.py
@@ -1,0 +1,30 @@
+import pytest
+from hugr import ops, tys
+from hugr.build.dfg import Function
+from tket.circuit import Tk2Circuit
+
+
+def test_unresolved_op() -> None:
+    """Define a function with an unresolved op, and try to convert it to a Tk2Circuit."""
+    fn = Function("unresolved_op", [tys.Qubit])
+    [q] = fn.inputs()
+    [q] = fn.add_op(
+        ops.Custom(
+            "unresolved",
+            signature=tys.FunctionType([tys.Qubit], [tys.Qubit]),
+            extension="unknown",
+        )
+    ).outputs()
+    fn.set_outputs(q)
+    hugr = fn.hugr
+
+    # Loading the tk2circuit errors out since it cannot find the extension.
+    with pytest.raises(RuntimeError) as excinfo:
+        Tk2Circuit.from_bytes(hugr.to_bytes())
+
+    # The error contains the full traceback, rather than just the top-level error message.
+    err = str(excinfo.value)
+    assert "Could not read tk2circuit from bytes" in err
+    assert "Error reading package payload in envelope." in err
+    assert "OpaqueOp:unknown.unresolved" in err
+    assert "requires extension unknown" in err


### PR DESCRIPTION
Uses `anyhow` to properly format rust errors with their sources when raising them as python exceptions.

Previously we only showed the top-level line.
E.g. in the included test case we printed
```bash
RuntimeError: Could not read tk2circuit from bytes
```
after this change, it reads
```bash
E       RuntimeError: Could not read tk2circuit from bytes
E       
E       Caused by:
E           0: Error reading package payload in envelope.
E           1: Error reading package payload in envelope.
E           2: OpaqueOp:unknown.unresolved in Node(4) requires extension unknown, but it could not be found in the extension list used during resolution. The available extensions are: arithmetic.conversions, arithmetic.float, arithmetic.float.types, arithmetic.int, arithmetic.int.types, collections.array, collections.borrow_arr, collections.list, collections.static_array, logic, prelude, ptr, tket.bool, tket.debug, tket.futures, tket.global_phase, tket.gpu, tket.guppy, tket.modifier, tket.qsystem, tket.qsystem.random, tket.qsystem.utils, tket.quantum, tket.result, tket.rotation, tket.wasm
```