### PR TITLE
docs: fix tket-exts pyproject description

### DIFF
--- a/tket-exts/pyproject.toml
+++ b/tket-exts/pyproject.toml
@@ -2,7 +2,7 @@
 name = "tket-exts"
 version = "0.12.2"
 requires-python = ">=3.10"
-description = "Precompiled rewrite sets for the tket compiler"
+description = "Python interface for hugr extensions offered by tket"
 license = { file = "LICENCE" }
 readme = "README.md"
 authors = [


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
docs: fix tket-exts pyproject description (#1436)

Release-As: 0.13.0
END_COMMIT_OVERRIDE