### PR TITLE
fix(pytket decoder): Panic on repeated bit registers in pytket decoded output

### DIFF
--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -311,16 +311,9 @@ impl<'h> PytketDecoderContext<'h> {
         mut self,
         encoded_info: Option<&EncodedCircuitInfo>,
     ) -> Result<Node, PytketDecodeError> {
-        // Order the final wires according to the serial circuit register order.
-        let mut known_qubits: IndexSet<TrackedQubit> =
-            self.wire_tracker.known_pytket_qubits().cloned().collect();
-        let mut known_bits: IndexSet<TrackedBit> =
-            self.wire_tracker.known_pytket_bits().cloned().collect();
-
         // Qubits and bits appearing at the output.
         let mut qubits: Vec<TrackedQubit> = Vec::new();
         let mut bits: Vec<TrackedBit> = Vec::new();
-
         if let Some(encoded_info) = encoded_info {
             for qubit in encoded_info.output_qubits.iter() {
                 let id = self.wire_tracker.tracked_qubit_for_register(qubit)?;
@@ -332,7 +325,13 @@ impl<'h> PytketDecoderContext<'h> {
             }
         }
 
-        // Add any additional qubits or bits we have seen but haven't added to the list.
+        // Add any other qubit and bit names used throughout the circuit, in the
+        // order they were registered.
+        let mut known_qubits: IndexSet<TrackedQubit> =
+            self.wire_tracker.known_pytket_qubits().cloned().collect();
+        let mut known_bits: IndexSet<TrackedBit> =
+            self.wire_tracker.known_pytket_bits().cloned().collect();
+        // Ignore qubits and bits that were already added to the list.
         for q in &qubits {
             known_qubits.shift_remove(q);
         }

--- a/tket/src/serialize/pytket/decoder/subgraph.rs
+++ b/tket/src/serialize/pytket/decoder/subgraph.rs
@@ -65,9 +65,6 @@ impl<'h> PytketDecoderContext<'h> {
         qubits.iter().for_each(|q| {
             self.wire_tracker.mark_qubit_outdated(q.clone());
         });
-        bits.iter().for_each(|b| {
-            self.wire_tracker.mark_bit_outdated(b.clone());
-        });
 
         Ok(status)
     }

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -542,15 +542,6 @@ impl WireTracker {
         qubit
     }
 
-    /// Mark a bit as outdated, without adding a new wire containing the fresh value.
-    ///
-    /// This is used when a hugr operation consumes pytket registers as its inputs, but doesn't use them in the outputs.
-    pub fn mark_bit_outdated(&mut self, mut bit: TrackedBit) -> TrackedBit {
-        self.bits[bit.id().0].mark_outdated();
-        bit.mark_outdated();
-        bit
-    }
-
     /// Returns the latest tracked qubit for a pytket register.
     ///
     /// Returns an error if the register is not known.
@@ -686,16 +677,16 @@ impl WireTracker {
         };
 
         // List candidate wires that contain the qubits and bits we need.
-        let qubit_candidates = if reg_count.qubits > 0 && !qubit_args.is_empty() {
-            itertools::Either::Left(self.qubit_wires(&qubit_args[0]))
-        } else {
-            itertools::Either::Right(std::iter::empty())
-        };
-        let bit_candidates = if reg_count.bits > 0 && !bit_args.is_empty() {
-            itertools::Either::Left(self.bit_wires(&bit_args[0]))
-        } else {
-            itertools::Either::Right(std::iter::empty())
-        };
+        let qubit_candidates = qubit_args
+            .first()
+            .into_iter()
+            .filter(|_| reg_count.qubits > 0 && !qubit_args.is_empty())
+            .flat_map(|qb| self.qubit_wires(qb));
+        let bit_candidates = bit_args
+            .first()
+            .into_iter()
+            .filter(|_| reg_count.bits > 0 && !bit_args.is_empty())
+            .flat_map(|bit| self.bit_wires(bit));
         let candidates = qubit_candidates.chain(bit_candidates).collect_vec();
 
         // The bits and qubits we expect the wire to contain.
@@ -767,9 +758,8 @@ impl WireTracker {
         *bit_args = &bit_args[reg_count.bits..];
 
         // Convert the wire type, if needed.
-        let wire_data = &self.wires[&wire];
-        let found_wire_type = wire_data.ty();
-        let new_wire = config.transform_typed_value(wire, found_wire_type, ty, builder)?;
+        let found_wire_data = &self.wires[&wire];
+        let new_wire = config.transform_typed_value(wire, found_wire_data.ty(), ty, builder)?;
 
         if wire == new_wire {
             Ok(FoundWire::Register(self.wires[&wire].clone()))

--- a/tket/src/serialize/pytket/extension/bool.rs
+++ b/tket/src/serialize/pytket/extension/bool.rs
@@ -67,13 +67,10 @@ impl<H: HugrView> PytketEmitter<H> for BoolEmitter {
             .collect_vec();
 
         let op = make_tk1_classical_expression(bit_count, &output_bits, &[], expression);
-        encoder.emit_node_command(
-            node,
-            hugr,
-            // Output bits use new registers, so don't reuse any input bits.
-            EmitCommandOptions::new().reuse_bits(|_| vec![]),
-            move |_| op,
-        )?;
+        // Output bits should use new registers, so don't reuse any input bits.
+        let dont_reuse_inputs = EmitCommandOptions::new().reuse_bits(|_| vec![]);
+        encoder.emit_node_command(node, hugr, dont_reuse_inputs, move |_| op)?;
+
         Ok(EncodeStatus::Success)
     }
 
@@ -192,4 +189,52 @@ pub(crate) fn set_bits_op(values: &[bool]) -> tket_json_rs::circuit_json::Operat
             values: values.to_vec(),
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extension::bool::bool_type;
+    use crate::serialize::pytket::{EncodeOptions, TKETDecode};
+    use hugr::builder::{Dataflow, DataflowHugr, FunctionBuilder};
+    use hugr::types::Signature;
+    use rstest::rstest;
+    use tket_json_rs::circuit_json::SerialCircuit;
+
+    /// ClExprs .
+    #[rstest]
+    #[case::not(BoolOp::not, 1)]
+    #[case::and(BoolOp::and, 2)]
+    #[case::or(BoolOp::or, 2)]
+    #[case::xor(BoolOp::xor, 2)]
+    #[case::eq(BoolOp::eq, 2)]
+    fn bool_op_output_uses_fresh_bits(#[case] op: BoolOp, #[case] num_inputs: usize) {
+        let input_t: Vec<_> = (0..num_inputs).map(|_| bool_type()).collect();
+        let output_t = vec![bool_type()];
+        let mut h = FunctionBuilder::new("bool_op", Signature::new(input_t, output_t)).unwrap();
+        let inputs: Vec<_> = h.input_wires().collect();
+        let [out] = h.add_dataflow_op(op, inputs).unwrap().outputs_arr();
+        let hugr = h.finish_hugr_with_outputs([out]).unwrap();
+
+        let ser = SerialCircuit::encode(&hugr, EncodeOptions::new()).unwrap();
+
+        let clexpr_cmd = ser
+            .commands
+            .iter()
+            .find(|cmd| cmd.op.op_type == tket_json_rs::OpType::ClExpr)
+            .expect("Expected a ClExpr command in the encoded circuit");
+
+        // Args layout for a BoolOp: [input_bits..., output_bit]
+        // The output bit must use a fresh register, not one of the input bits.
+        assert_eq!(clexpr_cmd.args.len(), num_inputs + 1);
+        let input_args = &clexpr_cmd.args[..num_inputs];
+        let output_args = &clexpr_cmd.args[num_inputs..];
+        for output_arg in output_args {
+            assert!(
+                !input_args.contains(output_arg),
+                "Output bit {output_arg} reuses an input bit register. Input args: {}",
+                input_args.iter().join(", ")
+            );
+        }
+    }
 }

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -288,7 +288,7 @@ fn circ_preset_qubits() -> Hugr {
 }
 
 /// A simple circuit with some preset input and output bit registers,
-/// including multiple outputs for the same register.
+/// including multiple outputs of the same register.
 #[fixture]
 fn circ_preset_bits() -> Hugr {
     let input_t = vec![bool_type()];


### PR DESCRIPTION
Fix an edge case where we extracted a hugr from a pytket circuit, and declared multiple output ports to have the same bit register.

Also cleans up a bit of the logic that handled consumed bit wires, to avoid marking them as outdated if they can still be used by other operations.