### PR TITLE
docs: Fix tket README introductory example

### DIFF
--- a/tket/README.md
+++ b/tket/README.md
@@ -30,7 +30,7 @@ use tket::serialize::{TKETDecode, pytket::DecodeOptions};
 use tket_json_rs::circuit_json::SerialCircuit;
 
 // Load a tket1 circuit.
-let reader = BufReader::new(std::fs::File::open("test_files/pytket/barenco_tof_5.json").unwrap());
+let reader = BufReader::new(std::fs::File::open("../test_files/pytket/barenco_tof_5.json").unwrap());
 let ser: SerialCircuit = serde_json::from_reader(reader).unwrap();
 let mut circ: Circuit = ser.decode(DecodeOptions::new()).unwrap().into();
 

--- a/tket/src/lib.rs
+++ b/tket/src/lib.rs
@@ -69,3 +69,7 @@ pub use circuit::{Circuit, CircuitError, CircuitMutError};
 pub use hugr;
 pub use hugr::Hugr;
 pub use ops::{Pauli, TketOp, op_matches, symbolic_constant_op};
+
+#[doc = include_str!("../README.md")]
+#[cfg(doctest)]
+pub struct ReadmeDoctests;


### PR DESCRIPTION
There were a couple of more issues than just the `json` module missing. This variant has been tried and tested locally. Perhaps we should add some tests for this? I don't know whether we can.

Closes #1362