### PR TITLE
feat(const-fold): combine Consts for each out-port; write prepopulated inputs

### DIFF
--- a/tket/src/passes/const_fold.rs
+++ b/tket/src/passes/const_fold.rs
@@ -139,7 +139,7 @@ impl<H: HugrMut<Node = Node> + 'static> ComposablePass<H> for ConstantFoldPass {
 
         let results = m.run_subtree(ConstFoldContext, root);
         let mut root_descs = hugr.descendants(root);
-        assert_eq!(root_descs.next(), Some(root)); // Skip root
+        assert_eq!(root_descs.next(), Some(root), "Could not skip root");
         let wires_to_break = root_descs
             .filter(|n| !hugr.get_optype(*n).is_load_constant()) // no point in adding another Const!
             .flat_map(|n| hugr.out_value_types(n).map(move |(outp, _ty)| (n, outp)))


### PR DESCRIPTION
Previously we made a list of *input ports* whose incoming edges to break with a Const+LoadConstant, thus duplicating the Const for any outport with multiple edges. Instead, place one Const+LoadConstant per outport (that has >=1 edge), and reroute all the old edges to come from the same LoadConstant. (These could be nonlocal, iff the original edges were.)

Also remove the `mb_root_inp` mechanism that had been used to prevent values passed to `prepopulate_wire` / `prepopulate_inputs` being written into the graph - writing these in is consistent with what we do to other ops. (There are some tests using `assert_fully_folded` that this would have broken without the first/Const-combining change; and bugs fixed in #1470 and #1474  that `mb_root_inp` was hiding; but now these are solved, removal is straightforward.)
