### PR TITLE
fix: Update examples link in README.md

### DIFF
--- a/tket-py/README.md
+++ b/tket-py/README.md
@@ -30,7 +30,7 @@ pip install tket
 See the [Getting Started][getting-started] guide and the other [examples].
 
   [getting-started]: https://github.com/quantinuum/tket2/blob/main/tket-py/examples/1-Getting-Started.ipynb
-  [examples]: https://github.com/quantinuum/tket2/tree/main/tket-py/examples
+  [examples]: https://github.com/quantinuum/tket2/tree/main/tket-py/docs/examples
 
 The API documentation for `tket-py` can be found at https://quantinuum.github.io/tket2/.
 


### PR DESCRIPTION
fix the link to the example folder in the pytket readme