### PR TITLE
feat: upgrade to hugr v0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c016d3b51aa136190cd5ff125a96ec32a94e0f2a736a3a668bfe084ec9d9a9e"
+checksum = "e91648ee98355c1d502a0d466eec0b67ca2612f81ef5d261e62fca8aa567ab52"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6f210455279ec319e42263cb1d9890295cd5a53fdc2f1f34cf4f6901453377"
+checksum = "b1c7b88b23e22f987c6f65cbfb1b23fd6573ccb2be50824b39baf8b421a7958c"
 dependencies = [
  "anyhow",
  "clap",
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827c0827ea0e1f6c606a17ba9926d3867b008d975688a6d4357d5847eb5826e5"
+checksum = "dbea3356943ad488326fcea465519c25d03ab792198331610d1292c324d209b8"
 dependencies = [
  "base64",
  "cgmath",
@@ -1198,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-llvm"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aac6e08f12883f1d69c1f145c70251e755dde89821719741193c1f51259a59e"
+checksum = "de92b58fa5e8e0c2d03aab5a6a9cd50b4021ad5e3c0ca68d6ffeb604833337ca"
 dependencies = [
  "anyhow",
  "cc",
@@ -1218,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-model"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7878f4cb16c1f8d69ea9e832ff77694d9647aa5b963cb242b10969550b2d6e08"
+checksum = "9699c56c272a729b110e989d799e63beb6f077b5bcc118cd76c088453693615e"
 dependencies = [
  "base64",
  "bumpalo",
@@ -1319,22 +1319,22 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1def4112dfb2ce2993db7027f7acdb43c1f4ee1c70a082a2eef306ed5d0df365"
+checksum = "7decbc9dfa45a4a827a6ff7b822c113b1285678a937e84213417d4ca8a095782"
 dependencies = [
+ "bitflags",
  "inkwell_internals",
  "libc",
  "llvm-sys",
- "once_cell",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63736175c9a30ea123f7018de9f26163e0b39cd6978990ae486b510c4f3bad69"
+checksum = "6cfe97ee860815a90ed17e09639513269e39420a7440f3f4c996f238c514cf8d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "base64",
  "cgmath",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "anyhow",
  "cc",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "base64",
  "bumpalo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "base64",
  "cgmath",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "anyhow",
  "cc",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
+source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
 dependencies = [
  "base64",
  "bumpalo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,7 +1159,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
 dependencies = [
  "base64",
  "cgmath",
@@ -1196,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
 dependencies = [
  "anyhow",
  "cc",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "git+https://github.com/quantinuum/hugr?rev=cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5#cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5"
 dependencies = [
  "base64",
  "bumpalo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,8 +1129,7 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91648ee98355c1d502a0d466eec0b67ca2612f81ef5d261e62fca8aa567ab52"
+source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1140,8 +1139,7 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c7b88b23e22f987c6f65cbfb1b23fd6573ccb2be50824b39baf8b421a7958c"
+source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
 dependencies = [
  "anyhow",
  "clap",
@@ -1161,8 +1159,7 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbea3356943ad488326fcea465519c25d03ab792198331610d1292c324d209b8"
+source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
 dependencies = [
  "base64",
  "cgmath",
@@ -1199,8 +1196,7 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de92b58fa5e8e0c2d03aab5a6a9cd50b4021ad5e3c0ca68d6ffeb604833337ca"
+source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
 dependencies = [
  "anyhow",
  "cc",
@@ -1219,8 +1215,7 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9699c56c272a729b110e989d799e63beb6f077b5bcc118cd76c088453693615e"
+source = "git+https://github.com/quantinuum/hugr?rev=f7d18dee930e54887839e2de2259b77087e50912#f7d18dee930e54887839e2de2259b77087e50912"
 dependencies = [
  "base64",
  "bumpalo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,7 +1129,8 @@ dependencies = [
 [[package]]
 name = "hugr"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91648ee98355c1d502a0d466eec0b67ca2612f81ef5d261e62fca8aa567ab52"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -1139,7 +1140,8 @@ dependencies = [
 [[package]]
 name = "hugr-cli"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c7b88b23e22f987c6f65cbfb1b23fd6573ccb2be50824b39baf8b421a7958c"
 dependencies = [
  "anyhow",
  "clap",
@@ -1159,7 +1161,8 @@ dependencies = [
 [[package]]
 name = "hugr-core"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbea3356943ad488326fcea465519c25d03ab792198331610d1292c324d209b8"
 dependencies = [
  "base64",
  "cgmath",
@@ -1196,7 +1199,8 @@ dependencies = [
 [[package]]
 name = "hugr-llvm"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de92b58fa5e8e0c2d03aab5a6a9cd50b4021ad5e3c0ca68d6ffeb604833337ca"
 dependencies = [
  "anyhow",
  "cc",
@@ -1215,7 +1219,8 @@ dependencies = [
 [[package]]
 name = "hugr-model"
 version = "0.27.1"
-source = "git+https://github.com/quantinuum/hugr?rev=316fe8d8686b30e3ee64a404d98fd34f66089c42#316fe8d8686b30e3ee64a404d98fd34f66089c42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699c56c272a729b110e989d799e63beb6f077b5bcc118cd76c088453693615e"
 dependencies = [
  "base64",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
-hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
-hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
-hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5" }
+hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5" }
+hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5" }
+hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5" }
 # portgraph = { git = "https://github.com/quantinuum/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,9 +52,9 @@ large_enum_variant = "allow"
 
 [workspace.dependencies]
 # Make sure to run `just recompile-eccs` if the hugr serialisation format changes.
-hugr = "0.27.0"
-hugr-core = "0.27.0"
-hugr-cli = "0.27.0"
+hugr = "0.27.1"
+hugr-core = "0.27.1"
+hugr-cli = "0.27.1"
 portgraph = "0.16.1"
 # There can only be one `pyo3` version in the whole workspace, so we use a
 # loose version constraint to prevent breaking changes in dependent crates where possible.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "f7d18dee930e54887839e2de2259b77087e50912" }
-hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "f7d18dee930e54887839e2de2259b77087e50912" }
-hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "f7d18dee930e54887839e2de2259b77087e50912" }
-hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "f7d18dee930e54887839e2de2259b77087e50912" }
+hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
 # portgraph = { git = "https://github.com/quantinuum/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
-hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
-hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
-hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+#hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+#hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+#hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+#hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
 # portgraph = { git = "https://github.com/quantinuum/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5" }
-hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5" }
-hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5" }
-hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "cf374ccb7a8d8cc6a61c8910fa53dc67f8232eb5" }
+hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
+hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "316fe8d8686b30e3ee64a404d98fd34f66089c42" }
 # portgraph = { git = "https://github.com/quantinuum/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ large_enum_variant = "allow"
 [patch.crates-io]
 
 # Uncomment to use unreleased versions of hugr
-# hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "de7b9f7581ae02cd80dff7b12794b55635903304" }
-# hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "de7b9f7581ae02cd80dff7b12794b55635903304" }
-# hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "de7b9f7581ae02cd80dff7b12794b55635903304" }
-# hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "de7b9f7581ae02cd80dff7b12794b55635903304" }
+hugr = { git = "https://github.com/quantinuum/hugr", "rev" = "f7d18dee930e54887839e2de2259b77087e50912" }
+hugr-core = { git = "https://github.com/quantinuum/hugr", "rev" = "f7d18dee930e54887839e2de2259b77087e50912" }
+hugr-cli = { git = "https://github.com/quantinuum/hugr", "rev" = "f7d18dee930e54887839e2de2259b77087e50912" }
+hugr-llvm = { git = "https://github.com/quantinuum/hugr", "rev" = "f7d18dee930e54887839e2de2259b77087e50912" }
 # portgraph = { git = "https://github.com/quantinuum/portgraph", rev = "68b96ac737e0c285d8c543b2d74a7aa80a18202c" }
 
 [workspace.dependencies]

--- a/qis-compiler/Cargo.toml
+++ b/qis-compiler/Cargo.toml
@@ -43,7 +43,7 @@ typetag.workspace = true
 
 # Defined here so it can be overridden by the codspeed CI job
 # using `cargo add`.
-insta = "1.47.0"
+insta = "1.47.2"
 
 [package.metadata.cargo-machete]
 ignored = ["cbindgen", "pyo3-build-config"]

--- a/tket-qsystem/src/lib.rs
+++ b/tket-qsystem/src/lib.rs
@@ -313,7 +313,6 @@ mod test {
         types::Signature,
     };
 
-    use hugr_core::hugr::internal::{HugrInternals, PortgraphNodeMap};
     use petgraph::visit::{Topo, Walker as _};
     use rstest::rstest;
     use tket::extension::{
@@ -388,13 +387,13 @@ mod test {
         }
         QSystemPass::default().run(&mut hugr).unwrap();
 
-        let (pg, node_map) = hugr.region_portgraph(main_node);
-        let topo_sorted = Topo::new(&pg).iter(&pg).collect_vec();
+        let sg = hugr.scheduling_graph(main_node);
+        let topo_sorted = Topo::new(sg.petgraph()).iter(&sg.petgraph()).collect_vec();
 
         let get_pos = |x| {
             topo_sorted
                 .iter()
-                .position(|&y| y == node_map.to_portgraph(x))
+                .position(|&y| y == sg.node_to_pg(x))
                 .unwrap()
         };
         assert!(get_pos(h_node) < get_pos(f_node));
@@ -403,7 +402,7 @@ mod test {
 
         for n in topo_sorted
             .iter()
-            .map(|&pg_n| node_map.from_portgraph(pg_n))
+            .map(|&pg_n| sg.pg_to_node(pg_n))
             .filter(|&n| FutureOpDef::try_from(hugr.get_optype(n)) == Ok(FutureOpDef::Read))
         {
             assert!(get_pos(call_node) < get_pos(n));

--- a/tket/Cargo.toml
+++ b/tket/Cargo.toml
@@ -92,7 +92,7 @@ proptest-recurse = { workspace = true }
 # Defined here so it can be overridden by the codspeed CI job
 # using `cargo add`.
 criterion = { version = "0.8.2", features = ["html_reports"] }
-insta = "1.47.0"
+insta = "1.47.2"
 
 [[bench]]
 name = "bench_main"

--- a/tket/src/circuit.rs
+++ b/tket/src/circuit.rs
@@ -14,7 +14,7 @@ pub use command::{Command, CommandIterator};
 use hugr::extension::prelude::{NoopDef, TupleOpDef};
 use hugr::extension::simple_op::MakeOpDef;
 use hugr::hugr::views::sibling_subgraph::InvalidSubgraph;
-use hugr::hugr::views::{ExtractionResult, RootChecked, SiblingSubgraph};
+use hugr::hugr::views::{ExtractionResult, RootChecked, SchedulingGraph, SiblingSubgraph};
 use hugr::ops::handle::DataflowParentID;
 use itertools::Either::{Left, Right};
 
@@ -108,6 +108,10 @@ impl<T: HugrView> Circuit<T> {
     /// Returns the node containing the circuit definition.
     pub fn parent(&self) -> T::Node {
         self.hugr.entrypoint()
+    }
+
+    pub(crate) fn sched_graph(&self) -> SchedulingGraph<'_, T> {
+        self.hugr.scheduling_graph(self.parent())
     }
 
     /// Get a reference to the HUGR containing the circuit.

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -292,7 +292,7 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
         //          returning a new struct (borrowing the Circuit) that contains the SchedulingGraph,
         //          where the new struct defines a method returning an Iterator<Item=Node/Command>
         //          (actually returning a struct holding the Topo).
-        // (2) reimplement here caching a Vec of nodes topsorted from the scheduling_graph
+        // (2) reimplement here precomputing the Vec of nodes topsorted from the scheduling_graph
         //     - this will give poor perf/high memory usage - and deprecate CommandIterator at that time.
         let (region, region_node_map) = circ.hugr().region_portgraph(circ.parent());
         let node_count = region.node_count();

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -6,14 +6,14 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::iter::FusedIterator;
 
-use hugr::hugr::views::{SchedulingGraph, SynEdgeWrapper};
+use hugr::hugr::views::SchedulingGraph;
 use hugr::metadata::Metadata;
 use hugr::ops::{OpTag, OpTrait};
 use hugr::{HugrView, IncomingPort, OutgoingPort};
-use hugr_core::hugr::internal::HugrInternals;
 use itertools::Either::{self, Left, Right};
 use itertools::{EitherOrBoth, Itertools};
-use petgraph::visit::{self as pv, NodeCount};
+use petgraph::visit::{self as pv, IntoNeighborsDirected, NodeCount, Topo, Visitable};
+use portgraph::NodeIndex as PGIdx;
 
 use super::Circuit;
 use super::units::{DefaultUnitLabeller, LinearUnit, UnitLabeller, Units, filter};
@@ -231,25 +231,43 @@ impl<T: HugrView> std::hash::Hash for Command<'_, T> {
     }
 }
 
-/// A non-borrowing topological walker over the nodes of a circuit.
-type NodeWalker<'circ, T> = pv::Topo<
-    portgraph::NodeIndex,
-    <SynEdgeWrapper<
-        portgraph::view::FlatRegion<'circ, <T as HugrInternals>::RegionPortgraph<'circ>>,
-    > as petgraph::visit::Visitable>::Map,
->;
+trait CloneableIterator<'a>: Iterator {
+    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a>;
+}
+
+struct NodeWalker<'a, H: HugrView, PTG, VM> {
+    graph: SchedulingGraph<'a, H>,
+    petgraph: PTG,
+    topo: pv::Topo<PGIdx, VM>,
+}
+
+impl <'a, H: HugrView, NM: Visitable<NodeId = PGIdx> + IntoNeighborsDirected> Iterator for NodeWalker<'a, H, NM, NM::Map> {
+    type Item = H::Node;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.topo.next(&self.petgraph).map(|pg| self.graph.pg_to_node(pg))
+    }
+}
+
+
+//impl <'a, NM:PortgraphNodeMap<Node> + 'a, G: pv::Visitable<NodeId=PGIdx, Map: Clone> + IntoNeighborsDirected + 'a> CloneableIterator<'a> for NodeWalker<NM, G> {
+impl <'a, H: HugrView, NM: Visitable<NodeId = PGIdx, Map: Clone> + IntoNeighborsDirected + 'a + Clone> CloneableIterator<'a> for NodeWalker<'a, H, NM, NM::Map> {
+    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a> {
+        Box::new(Self {
+            petgraph: self.petgraph.clone(),
+            graph: self.graph.clone(),
+            topo: self.topo.clone(),
+        })
+    }
+}
 
 /// An iterator over the commands of a circuit.
 // TODO: this can only be made generic over node type once `SiblingGraph` is
 // generic over node type. See https://github.com/quantinuum/hugr/issues/1926
-#[derive(Clone)]
 pub struct CommandIterator<'circ, T: HugrView> {
     /// The circuit.
     circ: &'circ Circuit<T>,
-    /// A view of the top-level region of the circuit.
-    sched_graph: SchedulingGraph<'circ, T>,
     /// Toposorted nodes.
-    nodes: NodeWalker<'circ, T>,
+    nodes: Box<dyn CloneableIterator<'circ, Item = T::Node> + 'circ>,
     /// Last wire for each [`LinearUnit`] in the circuit.
     wire_unit: HashMap<Wire, usize>,
     /// Maximum number of remaining commands, not counting I/O nodes nor root nodes.
@@ -274,6 +292,20 @@ pub struct CommandIterator<'circ, T: HugrView> {
     delayed_node: Option<Node>,
 }
 
+impl<'circ, T: HugrView> Clone for CommandIterator<'_, T> {
+    fn clone(&self) -> Self {
+        Self {
+            circ: self.circ.clone(),
+            nodes: self.nodes.clone_box(),
+            wire_unit: self.wire_unit.clone(),
+            max_remaining: self.max_remaining.clone(),
+            delayed_consts: self.delayed_consts.clone(),
+            delayed_consumers: self.delayed_consumers.clone(),
+            delayed_node: self.delayed_node.clone(),
+        }
+    }
+}
+
 impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// Create a new iterator over the commands of a circuit.
     pub(super) fn new(circ: &'circ Circuit<T>) -> Self {
@@ -286,12 +318,17 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
             .map(|(linear_unit, port, _)| (Wire::new(circ.input_node(), port), linear_unit.index()))
             .collect();
 
-        let sched_graph = circ.hugr().scheduling_graph(circ.parent());
-        let node_count = sched_graph.petgraph().node_count();
-        let nodes = pv::Topo::new(sched_graph.petgraph());
+        let region_graph = circ.hugr().scheduling_graph(circ.parent());
+        let topo = Topo::new(region_graph.petgraph());
+        let nodes = Box::new(NodeWalker {
+            graph: region_graph.clone(),
+            petgraph: region_graph.petgraph(),
+            topo,
+        });
+
+        let node_count = region_graph.petgraph().node_count();
         Self {
             circ,
-            sched_graph,
             nodes,
             wire_unit,
             // Ignore the input and output nodes, and the root.
@@ -307,10 +344,7 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// If the next node in the topological order is a constant or load const node,
     /// delay it until its consumers are processed.
     fn next_node(&mut self) -> Option<Node> {
-        let node = self.delayed_node.take().or_else(|| {
-            let pg_node = self.nodes.next(&self.sched_graph.petgraph())?;
-            Some(self.sched_graph.pg_to_node(pg_node))
-        })?;
+        let node = self.delayed_node.take().or_else(|| self.nodes.next())?;
         if node == self.circ.parent() {
             // Ignore the root of the circuit.
             // This will only happen once.

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -6,16 +6,14 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::iter::FusedIterator;
 
-use hugr::hugr::views::SchedulingGraph;
 use hugr::metadata::Metadata;
 use hugr::ops::{OpTag, OpTrait};
 use hugr::{HugrView, IncomingPort, OutgoingPort};
+use hugr_core::hugr::internal::{HugrInternals, PortgraphNodeMap};
 use itertools::Either::{self, Left, Right};
 use itertools::{EitherOrBoth, Itertools};
-use petgraph::visit::{
-    self as pv, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, Visitable,
-};
-use portgraph::NodeIndex as PGIdx;
+use petgraph::visit as pv;
+use portgraph::PortView;
 
 use super::Circuit;
 use super::units::{DefaultUnitLabeller, LinearUnit, UnitLabeller, Units, filter};
@@ -233,69 +231,25 @@ impl<T: HugrView> std::hash::Hash for Command<'_, T> {
     }
 }
 
-trait CloneableIterator<'a>: Iterator {
-    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a>;
-}
-
-struct NodeWalker<'a, H: HugrView, PGF, VM> {
-    graph: SchedulingGraph<'a, H>,
-    petgraph_func: PGF,
-    topo: Option<pv::Topo<PGIdx, VM>>,
-}
-
-impl<'a, H: HugrView, G: Visitable, PGF: Fn(&SchedulingGraph<'a, H>) -> G>
-    NodeWalker<'a, H, PGF, G::Map>
-{
-    fn new(graph: SchedulingGraph<'a, H>, petgraph_func: PGF) -> Self {
-        Self {
-            graph,
-            petgraph_func,
-            topo: None,
-        }
-    }
-}
-
-impl<
-    'a,
-    H: HugrView,
-    G: Visitable<NodeId = PGIdx> + IntoNeighborsDirected + IntoNodeIdentifiers,
-    PGF: Fn(&SchedulingGraph<'a, H>) -> G,
-> Iterator for NodeWalker<'a, H, PGF, G::Map>
-{
-    type Item = H::Node;
-    fn next(&mut self) -> Option<Self::Item> {
-        let g: G = (self.petgraph_func)(&self.graph);
-        self.topo
-            .get_or_insert_with(|| pv::Topo::new(g))
-            .next(g)
-            .map(|pg| self.graph.pg_to_node(pg))
-    }
-}
-
-impl<
-    'a,
-    H: HugrView,
-    G: Visitable<NodeId = PGIdx, Map: Clone + 'a> + IntoNodeIdentifiers + IntoNeighborsDirected,
-    PGF: 'a + Clone + Fn(&SchedulingGraph<'a, H>) -> G,
-> CloneableIterator<'a> for NodeWalker<'a, H, PGF, G::Map>
-{
-    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a> {
-        Box::new(Self {
-            petgraph_func: self.petgraph_func.clone(),
-            graph: self.graph.clone(),
-            topo: self.topo.clone(),
-        })
-    }
-}
+/// A non-borrowing topological walker over the nodes of a circuit.
+type NodeWalker<'circ, T> = pv::Topo<
+    portgraph::NodeIndex,
+    <portgraph::view::FlatRegion<'circ, <T as HugrInternals>::RegionPortgraph<'circ>> as petgraph::visit::Visitable>::Map,
+>;
 
 /// An iterator over the commands of a circuit.
 // TODO: this can only be made generic over node type once `SiblingGraph` is
 // generic over node type. See https://github.com/quantinuum/hugr/issues/1926
+#[derive(Clone)]
 pub struct CommandIterator<'circ, T: HugrView> {
     /// The circuit.
     circ: &'circ Circuit<T>,
+    /// A view of the top-level region of the circuit.
+    region: portgraph::view::FlatRegion<'circ, T::RegionPortgraph<'circ>>,
+    /// A map between portgraph nodes in [`CommandIterator::region`] and circuit nodes.
+    region_node_map: T::RegionPortgraphNodes,
     /// Toposorted nodes.
-    nodes: Box<dyn CloneableIterator<'circ, Item = T::Node> + 'circ>,
+    nodes: NodeWalker<'circ, T>,
     /// Last wire for each [`LinearUnit`] in the circuit.
     wire_unit: HashMap<Wire, usize>,
     /// Maximum number of remaining commands, not counting I/O nodes nor root nodes.
@@ -320,20 +274,6 @@ pub struct CommandIterator<'circ, T: HugrView> {
     delayed_node: Option<Node>,
 }
 
-impl<'circ, T: HugrView> Clone for CommandIterator<'_, T> {
-    fn clone(&self) -> Self {
-        Self {
-            circ: self.circ.clone(),
-            nodes: self.nodes.clone_box(),
-            wire_unit: self.wire_unit.clone(),
-            max_remaining: self.max_remaining.clone(),
-            delayed_consts: self.delayed_consts.clone(),
-            delayed_consumers: self.delayed_consumers.clone(),
-            delayed_node: self.delayed_node.clone(),
-        }
-    }
-}
-
 impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// Create a new iterator over the commands of a circuit.
     pub(super) fn new(circ: &'circ Circuit<T>) -> Self {
@@ -346,13 +286,19 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
             .map(|(linear_unit, port, _)| (Wire::new(circ.input_node(), port), linear_unit.index()))
             .collect();
 
-        let region_graph = circ.hugr().scheduling_graph(circ.parent());
-        let node_count = region_graph.petgraph().node_count();
-        let nodes = NodeWalker::new(region_graph, SchedulingGraph::petgraph);
-
+        #[expect(deprecated)] // When region_portgraph is removed from Hugr, either:
+        // (1) if we've already deprecated CommandIterator + Circuit by then, remove them
+        // (2) reimplement using scheduling_graph - this will require caching the topsorted nodes
+        //     which will give poor performance/high memory usage - and deprecate CommandIterator
+        //     at that time.
+        let (region, region_node_map) = circ.hugr().region_portgraph(circ.parent());
+        let node_count = region.node_count();
+        let nodes = pv::Topo::new(&region);
         Self {
             circ,
-            nodes: Box::new(nodes),
+            region,
+            region_node_map,
+            nodes,
             wire_unit,
             // Ignore the input and output nodes, and the root.
             max_remaining: node_count - 2,
@@ -367,7 +313,10 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// If the next node in the topological order is a constant or load const node,
     /// delay it until its consumers are processed.
     fn next_node(&mut self) -> Option<Node> {
-        let node = self.delayed_node.take().or_else(|| self.nodes.next())?;
+        let node = self.delayed_node.take().or_else(|| {
+            let pg_node = self.nodes.next(&self.region)?;
+            Some(self.region_node_map.from_portgraph(pg_node))
+        })?;
         if node == self.circ.parent() {
             // Ignore the root of the circuit.
             // This will only happen once.

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -288,9 +288,12 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
 
         #[expect(deprecated)] // When region_portgraph is removed from Hugr, either:
         // (1) if we've already deprecated CommandIterator + Circuit by then, remove them
-        // (2) reimplement using scheduling_graph - this will require caching the topsorted nodes
-        //     which will give poor performance/high memory usage - and deprecate CommandIterator
-        //     at that time.
+        //     (1a) We could remove CommandIterator but keep Circuit, with a method on Circuit
+        //          returning a new struct (borrowing the Circuit) that contains the SchedulingGraph,
+        //          where the new struct defines a method returning an Iterator<Item=Node/Command>
+        //          (actually returning a struct holding the Topo).
+        // (2) reimplement here caching a Vec of nodes topsorted from the scheduling_graph
+        //     - this will give poor perf/high memory usage - and deprecate CommandIterator at that time.
         let (region, region_node_map) = circ.hugr().region_portgraph(circ.parent());
         let node_count = region.node_count();
         let nodes = pv::Topo::new(&region);

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -12,7 +12,9 @@ use hugr::ops::{OpTag, OpTrait};
 use hugr::{HugrView, IncomingPort, OutgoingPort};
 use itertools::Either::{self, Left, Right};
 use itertools::{EitherOrBoth, Itertools};
-use petgraph::visit::{self as pv, IntoNeighborsDirected, NodeCount, Topo, Visitable};
+use petgraph::visit::{
+    self as pv, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCount, Visitable,
+};
 use portgraph::NodeIndex as PGIdx;
 
 use super::Circuit;
@@ -235,25 +237,51 @@ trait CloneableIterator<'a>: Iterator {
     fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a>;
 }
 
-struct NodeWalker<'a, H: HugrView, PTG, VM> {
+struct NodeWalker<'a, H: HugrView, PGF, VM> {
     graph: SchedulingGraph<'a, H>,
-    petgraph: PTG,
-    topo: pv::Topo<PGIdx, VM>,
+    petgraph_func: PGF,
+    topo: Option<pv::Topo<PGIdx, VM>>,
 }
 
-impl <'a, H: HugrView, NM: Visitable<NodeId = PGIdx> + IntoNeighborsDirected> Iterator for NodeWalker<'a, H, NM, NM::Map> {
-    type Item = H::Node;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.topo.next(&self.petgraph).map(|pg| self.graph.pg_to_node(pg))
+impl<'a, H: HugrView, G: Visitable, PGF: Fn(&SchedulingGraph<'a, H>) -> G>
+    NodeWalker<'a, H, PGF, G::Map>
+{
+    fn new(graph: SchedulingGraph<'a, H>, petgraph_func: PGF) -> Self {
+        Self {
+            graph,
+            petgraph_func,
+            topo: None,
+        }
     }
 }
 
+impl<
+    'a,
+    H: HugrView,
+    G: Visitable<NodeId = PGIdx> + IntoNeighborsDirected + IntoNodeIdentifiers,
+    PGF: Fn(&SchedulingGraph<'a, H>) -> G,
+> Iterator for NodeWalker<'a, H, PGF, G::Map>
+{
+    type Item = H::Node;
+    fn next(&mut self) -> Option<Self::Item> {
+        let g: G = (self.petgraph_func)(&self.graph);
+        self.topo
+            .get_or_insert_with(|| pv::Topo::new(g))
+            .next(g)
+            .map(|pg| self.graph.pg_to_node(pg))
+    }
+}
 
-//impl <'a, NM:PortgraphNodeMap<Node> + 'a, G: pv::Visitable<NodeId=PGIdx, Map: Clone> + IntoNeighborsDirected + 'a> CloneableIterator<'a> for NodeWalker<NM, G> {
-impl <'a, H: HugrView, NM: Visitable<NodeId = PGIdx, Map: Clone> + IntoNeighborsDirected + 'a + Clone> CloneableIterator<'a> for NodeWalker<'a, H, NM, NM::Map> {
+impl<
+    'a,
+    H: HugrView,
+    G: Visitable<NodeId = PGIdx, Map: Clone + 'a> + IntoNodeIdentifiers + IntoNeighborsDirected,
+    PGF: 'a + Clone + Fn(&SchedulingGraph<'a, H>) -> G,
+> CloneableIterator<'a> for NodeWalker<'a, H, PGF, G::Map>
+{
     fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a> {
         Box::new(Self {
-            petgraph: self.petgraph.clone(),
+            petgraph_func: self.petgraph_func.clone(),
             graph: self.graph.clone(),
             topo: self.topo.clone(),
         })
@@ -319,17 +347,12 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
             .collect();
 
         let region_graph = circ.hugr().scheduling_graph(circ.parent());
-        let topo = Topo::new(region_graph.petgraph());
-        let nodes = Box::new(NodeWalker {
-            graph: region_graph.clone(),
-            petgraph: region_graph.petgraph(),
-            topo,
-        });
-
         let node_count = region_graph.petgraph().node_count();
+        let nodes = NodeWalker::new(region_graph, SchedulingGraph::petgraph);
+
         Self {
             circ,
-            nodes,
+            nodes: Box::new(nodes),
             wire_unit,
             // Ignore the input and output nodes, and the root.
             max_remaining: node_count - 2,

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -6,13 +6,14 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::iter::FusedIterator;
 
+use hugr::hugr::views::SchedulingGraph;
 use hugr::metadata::Metadata;
 use hugr::ops::{OpTag, OpTrait};
 use hugr::{HugrView, IncomingPort, OutgoingPort};
 use hugr_core::hugr::internal::{HugrInternals, PortgraphNodeMap};
 use itertools::Either::{self, Left, Right};
 use itertools::{EitherOrBoth, Itertools};
-use petgraph::visit as pv;
+use petgraph::visit::{self as pv, IntoNeighborsDirected, NodeCount, Topo, VisitMap, Visitable, Walker};
 use portgraph::PortView;
 
 use super::Circuit;
@@ -231,25 +232,48 @@ impl<T: HugrView> std::hash::Hash for Command<'_, T> {
     }
 }
 
-/// A non-borrowing topological walker over the nodes of a circuit.
-type NodeWalker<'circ, T> = pv::Topo<
-    portgraph::NodeIndex,
-    <portgraph::view::FlatRegion<'circ, <T as HugrInternals>::RegionPortgraph<'circ>> as petgraph::visit::Visitable>::Map,
->;
+trait CloneableIterator<'a>: Iterator {
+    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a>;
+}
+
+impl<'a, T: Iterator + Clone + 'a> CloneableIterator<'a> for T {
+    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a> {
+        Box::new(self.clone())
+    }
+}
+
+struct NodeWalker<NM, G: Visitable> {
+    node_map: NM,
+    graph: G,
+    topo: pv::Topo<portgraph::NodeIndex, <G as Visitable>::Map>
+}
+
+impl <NM: PortgraphNodeMap<Node>, G: pv::Visitable<NodeId=portgraph::NodeIndex> + IntoNeighborsDirected> Iterator for NodeWalker<NM, G> {
+    type Item = Node;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.topo.next(&self.graph).map(|pg| self.node_map.from_portgraph(pg))
+    }
+}
+
+
+impl <'a, NM:PortgraphNodeMap<Node> + 'a, G: pv::Visitable<NodeId=portgraph::NodeIndex, Map: Clone> + IntoNeighborsDirected + 'a> CloneableIterator<'a> for NodeWalker<NM, G> {
+    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a> {
+        Box::new(Self {
+            node_map: self.node_map.clone(),
+            graph: self.graph.clone(),
+            topo: self.topo.clone(),
+        })
+    }
+}
 
 /// An iterator over the commands of a circuit.
 // TODO: this can only be made generic over node type once `SiblingGraph` is
 // generic over node type. See https://github.com/quantinuum/hugr/issues/1926
-#[derive(Clone)]
 pub struct CommandIterator<'circ, T: HugrView> {
     /// The circuit.
     circ: &'circ Circuit<T>,
-    /// A view of the top-level region of the circuit.
-    region: portgraph::view::FlatRegion<'circ, T::RegionPortgraph<'circ>>,
-    /// A map between portgraph nodes in [`CommandIterator::region`] and circuit nodes.
-    region_node_map: T::RegionPortgraphNodes,
     /// Toposorted nodes.
-    nodes: NodeWalker<'circ, T>,
+    nodes: Box<dyn CloneableIterator<'circ, Item = T::Node> + 'circ>,
     /// Last wire for each [`LinearUnit`] in the circuit.
     wire_unit: HashMap<Wire, usize>,
     /// Maximum number of remaining commands, not counting I/O nodes nor root nodes.
@@ -274,6 +298,20 @@ pub struct CommandIterator<'circ, T: HugrView> {
     delayed_node: Option<Node>,
 }
 
+impl<'circ, T: HugrView> Clone for CommandIterator<'_, T> {
+    fn clone(&self) -> Self {
+        Self {
+            circ: self.circ.clone(),
+            nodes: self.nodes.clone_box(),
+            wire_unit: self.wire_unit.clone(),
+            max_remaining: self.max_remaining.clone(),
+            delayed_consts: self.delayed_consts.clone(),
+            delayed_consumers: self.delayed_consumers.clone(),
+            delayed_node: self.delayed_node.clone(),
+        }
+    }
+}
+
 impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// Create a new iterator over the commands of a circuit.
     pub(super) fn new(circ: &'circ Circuit<T>) -> Self {
@@ -286,13 +324,17 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
             .map(|(linear_unit, port, _)| (Wire::new(circ.input_node(), port), linear_unit.index()))
             .collect();
 
-        let (region, region_node_map) = circ.hugr().region_portgraph(circ.parent());
-        let node_count = region.node_count();
-        let nodes = pv::Topo::new(&region);
+        let region_graph = circ.hugr().scheduling_graph(circ.parent());
+        let topo = Topo::new(region_graph.petgraph());
+        let nodes = Box::new(NodeWalker {
+            node_map: region_graph,
+            graph: region_graph.petgraph(),
+            topo,
+        });
+
+        let node_count = region_graph.petgraph().node_count();
         Self {
             circ,
-            region,
-            region_node_map,
             nodes,
             wire_unit,
             // Ignore the input and output nodes, and the root.
@@ -308,10 +350,7 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// If the next node in the topological order is a constant or load const node,
     /// delay it until its consumers are processed.
     fn next_node(&mut self) -> Option<Node> {
-        let node = self.delayed_node.take().or_else(|| {
-            let pg_node = self.nodes.next(&self.region)?;
-            Some(self.region_node_map.from_portgraph(pg_node))
-        })?;
+        let node = self.delayed_node.take().or_else(|| self.nodes.next())?;
         if node == self.circ.parent() {
             // Ignore the root of the circuit.
             // This will only happen once.

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -6,14 +6,14 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::iter::FusedIterator;
 
-use hugr::hugr::views::SchedulingGraph;
+use hugr::hugr::views::{SchedulingGraph, SynEdgeWrapper};
 use hugr::metadata::Metadata;
 use hugr::ops::{OpTag, OpTrait};
 use hugr::{HugrView, IncomingPort, OutgoingPort};
+use hugr_core::hugr::internal::HugrInternals;
 use itertools::Either::{self, Left, Right};
 use itertools::{EitherOrBoth, Itertools};
-use petgraph::visit::{self as pv, IntoNeighborsDirected, NodeCount, Topo, Visitable};
-use portgraph::NodeIndex as PGIdx;
+use petgraph::visit::{self as pv, NodeCount};
 
 use super::Circuit;
 use super::units::{DefaultUnitLabeller, LinearUnit, UnitLabeller, Units, filter};
@@ -231,43 +231,25 @@ impl<T: HugrView> std::hash::Hash for Command<'_, T> {
     }
 }
 
-trait CloneableIterator<'a>: Iterator {
-    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a>;
-}
-
-struct NodeWalker<'a, H: HugrView, PTG, VM> {
-    graph: SchedulingGraph<'a, H>,
-    petgraph: PTG,
-    topo: pv::Topo<PGIdx, VM>,
-}
-
-impl <'a, H: HugrView, NM: Visitable<NodeId = PGIdx> + IntoNeighborsDirected> Iterator for NodeWalker<'a, H, NM, NM::Map> {
-    type Item = H::Node;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.topo.next(&self.petgraph).map(|pg| self.graph.pg_to_node(pg))
-    }
-}
-
-
-//impl <'a, NM:PortgraphNodeMap<Node> + 'a, G: pv::Visitable<NodeId=PGIdx, Map: Clone> + IntoNeighborsDirected + 'a> CloneableIterator<'a> for NodeWalker<NM, G> {
-impl <'a, H: HugrView, NM: Visitable<NodeId = PGIdx, Map: Clone> + IntoNeighborsDirected + 'a + Clone> CloneableIterator<'a> for NodeWalker<'a, H, NM, NM::Map> {
-    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a> {
-        Box::new(Self {
-            petgraph: self.petgraph.clone(),
-            graph: self.graph.clone(),
-            topo: self.topo.clone(),
-        })
-    }
-}
+/// A non-borrowing topological walker over the nodes of a circuit.
+type NodeWalker<'circ, T> = pv::Topo<
+    portgraph::NodeIndex,
+    <SynEdgeWrapper<
+        portgraph::view::FlatRegion<'circ, <T as HugrInternals>::RegionPortgraph<'circ>>,
+    > as petgraph::visit::Visitable>::Map,
+>;
 
 /// An iterator over the commands of a circuit.
 // TODO: this can only be made generic over node type once `SiblingGraph` is
 // generic over node type. See https://github.com/quantinuum/hugr/issues/1926
+#[derive(Clone)]
 pub struct CommandIterator<'circ, T: HugrView> {
     /// The circuit.
     circ: &'circ Circuit<T>,
+    /// A view of the top-level region of the circuit.
+    sched_graph: SchedulingGraph<'circ, T>,
     /// Toposorted nodes.
-    nodes: Box<dyn CloneableIterator<'circ, Item = T::Node> + 'circ>,
+    nodes: NodeWalker<'circ, T>,
     /// Last wire for each [`LinearUnit`] in the circuit.
     wire_unit: HashMap<Wire, usize>,
     /// Maximum number of remaining commands, not counting I/O nodes nor root nodes.
@@ -292,20 +274,6 @@ pub struct CommandIterator<'circ, T: HugrView> {
     delayed_node: Option<Node>,
 }
 
-impl<'circ, T: HugrView> Clone for CommandIterator<'_, T> {
-    fn clone(&self) -> Self {
-        Self {
-            circ: self.circ.clone(),
-            nodes: self.nodes.clone_box(),
-            wire_unit: self.wire_unit.clone(),
-            max_remaining: self.max_remaining.clone(),
-            delayed_consts: self.delayed_consts.clone(),
-            delayed_consumers: self.delayed_consumers.clone(),
-            delayed_node: self.delayed_node.clone(),
-        }
-    }
-}
-
 impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// Create a new iterator over the commands of a circuit.
     pub(super) fn new(circ: &'circ Circuit<T>) -> Self {
@@ -318,17 +286,12 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
             .map(|(linear_unit, port, _)| (Wire::new(circ.input_node(), port), linear_unit.index()))
             .collect();
 
-        let region_graph = circ.hugr().scheduling_graph(circ.parent());
-        let topo = Topo::new(region_graph.petgraph());
-        let nodes = Box::new(NodeWalker {
-            graph: region_graph.clone(),
-            petgraph: region_graph.petgraph(),
-            topo,
-        });
-
-        let node_count = region_graph.petgraph().node_count();
+        let sched_graph = circ.hugr().scheduling_graph(circ.parent());
+        let node_count = sched_graph.petgraph().node_count();
+        let nodes = pv::Topo::new(sched_graph.petgraph());
         Self {
             circ,
+            sched_graph,
             nodes,
             wire_unit,
             // Ignore the input and output nodes, and the root.
@@ -344,7 +307,10 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// If the next node in the topological order is a constant or load const node,
     /// delay it until its consumers are processed.
     fn next_node(&mut self) -> Option<Node> {
-        let node = self.delayed_node.take().or_else(|| self.nodes.next())?;
+        let node = self.delayed_node.take().or_else(|| {
+            let pg_node = self.nodes.next(&self.sched_graph.petgraph())?;
+            Some(self.sched_graph.pg_to_node(pg_node))
+        })?;
         if node == self.circ.parent() {
             // Ignore the root of the circuit.
             // This will only happen once.

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -10,11 +10,10 @@ use hugr::hugr::views::SchedulingGraph;
 use hugr::metadata::Metadata;
 use hugr::ops::{OpTag, OpTrait};
 use hugr::{HugrView, IncomingPort, OutgoingPort};
-use hugr_core::hugr::internal::{HugrInternals, PortgraphNodeMap};
 use itertools::Either::{self, Left, Right};
 use itertools::{EitherOrBoth, Itertools};
-use petgraph::visit::{self as pv, IntoNeighborsDirected, NodeCount, Topo, VisitMap, Visitable, Walker};
-use portgraph::PortView;
+use petgraph::visit::{self as pv, IntoNeighborsDirected, NodeCount, Topo, Visitable};
+use portgraph::NodeIndex as PGIdx;
 
 use super::Circuit;
 use super::units::{DefaultUnitLabeller, LinearUnit, UnitLabeller, Units, filter};
@@ -236,30 +235,25 @@ trait CloneableIterator<'a>: Iterator {
     fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a>;
 }
 
-impl<'a, T: Iterator + Clone + 'a> CloneableIterator<'a> for T {
-    fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a> {
-        Box::new(self.clone())
-    }
+struct NodeWalker<'a, H: HugrView, PTG, VM> {
+    graph: SchedulingGraph<'a, H>,
+    petgraph: PTG,
+    topo: pv::Topo<PGIdx, VM>,
 }
 
-struct NodeWalker<NM, G: Visitable> {
-    node_map: NM,
-    graph: G,
-    topo: pv::Topo<portgraph::NodeIndex, <G as Visitable>::Map>
-}
-
-impl <NM: PortgraphNodeMap<Node>, G: pv::Visitable<NodeId=portgraph::NodeIndex> + IntoNeighborsDirected> Iterator for NodeWalker<NM, G> {
-    type Item = Node;
+impl <'a, H: HugrView, NM: Visitable<NodeId = PGIdx> + IntoNeighborsDirected> Iterator for NodeWalker<'a, H, NM, NM::Map> {
+    type Item = H::Node;
     fn next(&mut self) -> Option<Self::Item> {
-        self.topo.next(&self.graph).map(|pg| self.node_map.from_portgraph(pg))
+        self.topo.next(&self.petgraph).map(|pg| self.graph.pg_to_node(pg))
     }
 }
 
 
-impl <'a, NM:PortgraphNodeMap<Node> + 'a, G: pv::Visitable<NodeId=portgraph::NodeIndex, Map: Clone> + IntoNeighborsDirected + 'a> CloneableIterator<'a> for NodeWalker<NM, G> {
+//impl <'a, NM:PortgraphNodeMap<Node> + 'a, G: pv::Visitable<NodeId=PGIdx, Map: Clone> + IntoNeighborsDirected + 'a> CloneableIterator<'a> for NodeWalker<NM, G> {
+impl <'a, H: HugrView, NM: Visitable<NodeId = PGIdx, Map: Clone> + IntoNeighborsDirected + 'a + Clone> CloneableIterator<'a> for NodeWalker<'a, H, NM, NM::Map> {
     fn clone_box(&self) -> Box<dyn CloneableIterator<'a, Item = Self::Item> + 'a> {
         Box::new(Self {
-            node_map: self.node_map.clone(),
+            petgraph: self.petgraph.clone(),
             graph: self.graph.clone(),
             topo: self.topo.clone(),
         })
@@ -327,8 +321,8 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
         let region_graph = circ.hugr().scheduling_graph(circ.parent());
         let topo = Topo::new(region_graph.petgraph());
         let nodes = Box::new(NodeWalker {
-            node_map: region_graph,
-            graph: region_graph.petgraph(),
+            graph: region_graph.clone(),
+            petgraph: region_graph.petgraph(),
             topo,
         });
 

--- a/tket/src/modifier/modifier_resolver/dfg_modify.rs
+++ b/tket/src/modifier/modifier_resolver/dfg_modify.rs
@@ -17,7 +17,6 @@ use hugr::{
     std_extensions::collections::array::ArrayOpBuilder,
     types::{FuncTypeBase, Signature, TypeArg, TypeRow},
 };
-use hugr_core::hugr::internal::PortgraphNodeMap;
 use petgraph::visit::{Topo, Walker};
 
 use super::{DirWire, ModifierFlags, ModifierResolver, ModifierResolverErrors, PortExt};
@@ -58,14 +57,14 @@ impl<N: HugrNode> ModifierResolver<N> {
         let mut worklist = VecDeque::new();
         // This block is needed to appease the borrow checker.
         {
-            let (region_graph, node_map) = h.region_portgraph(n);
-            let mut topo: Vec<_> = Topo::new(&region_graph).iter(&region_graph).collect();
+            let sg = h.scheduling_graph(n);
+            let mut topo: Vec<_> = Topo::new(sg.petgraph()).iter(sg.petgraph()).collect();
             // Reverse the topological order if dagger is applied.
             if self.modifiers.dagger {
                 topo.reverse();
             }
             for old_n_id in topo {
-                worklist.push_back(node_map.from_portgraph(old_n_id));
+                worklist.push_back(sg.pg_to_node(old_n_id));
             }
         }
         self.with_worklist(worklist, |this| {

--- a/tket/src/passes/force_order.rs
+++ b/tket/src/passes/force_order.rs
@@ -1,7 +1,6 @@
 //! Provides [`force_order`], a tool for fixing the order of nodes in a Hugr.
 use std::{cmp::Reverse, collections::BinaryHeap, iter};
 
-use hugr_core::hugr::internal::PortgraphNodeMap;
 use hugr_core::{
     HugrView as _, Node,
     hugr::{HugrError, hugrmut::HugrMut},
@@ -56,15 +55,15 @@ pub fn force_order_by_key<H: HugrMut<Node = Node>, K: Ord>(
         // we filter out the input and output nodes from the topological sort
         let [i, o] = hugr.get_io(dp).unwrap();
         let ordered_nodes = {
-            let (region, node_map) = hugr.region_portgraph(dp);
-            let rank = |n| rank(hugr, node_map.from_portgraph(n));
-            let i_pg = node_map.to_portgraph(i);
-            let o_pg = node_map.to_portgraph(o);
-            let petgraph = NodeFiltered::from_fn(&region, |x| x != i_pg && x != o_pg);
+            let sg = hugr.scheduling_graph(dp);
+            let rank = |n| rank(hugr, sg.pg_to_node(n));
+            let i_pg = sg.node_to_pg(i);
+            let o_pg = sg.node_to_pg(o);
+            let petgraph = NodeFiltered::from_fn(sg.petgraph(), |x| x != i_pg && x != o_pg);
             ForceOrder::<_, portgraph::NodeIndex, _, _>::new(&petgraph, &rank)
                 .iter(&petgraph)
                 .filter_map(|x| {
-                    let x = node_map.from_portgraph(x);
+                    let x = sg.pg_to_node(x);
                     let expected_edge = Some(EdgeKind::StateOrder);
                     let optype = hugr.get_optype(x);
                     if optype.other_input() == expected_edge
@@ -208,7 +207,6 @@ mod test {
 
     use super::*;
     use hugr_core::builder::{BuildHandle, Dataflow, DataflowHugr, endo_sig};
-    use hugr_core::hugr::internal::HugrInternals;
     use hugr_core::ops::handle::{DataflowOpID, NodeHandle};
 
     use hugr_core::ops::{self, Value};
@@ -278,11 +276,11 @@ mod test {
         })
         .unwrap();
 
-        let (graph, node_map) = hugr.region_portgraph(hugr.entrypoint());
+        let sg = hugr.scheduling_graph(hugr.entrypoint());
 
-        let topo_sorted = Topo::new(&graph)
-            .iter(&graph)
-            .map(|n| node_map.from_portgraph(n))
+        let topo_sorted = Topo::new(sg.petgraph())
+            .iter(sg.petgraph())
+            .map(|n| sg.pg_to_node(n))
             .filter(|n| rank_map.contains_key(n))
             .collect_vec();
         hugr.validate().unwrap();

--- a/tket/src/passes/redundant_order_edges.rs
+++ b/tket/src/passes/redundant_order_edges.rs
@@ -3,7 +3,6 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use hugr_core::core::HugrNode;
-use hugr_core::hugr::internal::PortgraphNodeMap;
 use hugr_core::hugr::{HugrError, hugrmut::HugrMut};
 use hugr_core::ops::{OpTag, OpTrait};
 use hugr_core::{HugrView, IncomingPort, Node, OutgoingPort};
@@ -67,10 +66,10 @@ impl RedundantOrderEdgesPass {
         let mut to_remove = Vec::new();
 
         // Traverse the region in topological order.
-        let (region, node_map) = hugr.region_portgraph(parent);
-        let postorder = petgraph::visit::Topo::new(&region);
-        for pg_child in postorder.iter(&region) {
-            let child = node_map.from_portgraph(pg_child);
+        let sg = hugr.scheduling_graph(parent);
+        let postorder = petgraph::visit::Topo::new(sg.petgraph());
+        for pg_child in postorder.iter(sg.petgraph()) {
+            let child = sg.pg_to_node(pg_child);
             let op = hugr.get_optype(child);
 
             // If the child itself is a region (parent) and we are running recursively, add the child to the region candidates.
@@ -142,7 +141,7 @@ impl RedundantOrderEdgesPass {
             to_remove.extend(removable_edges);
         }
         // Release the hugr borrow so we can mutate it.
-        drop(region);
+        drop(sg);
         let edges_removed = to_remove.len();
 
         for edge in to_remove {

--- a/tket/src/passes/untuple.rs
+++ b/tket/src/passes/untuple.rs
@@ -2,12 +2,12 @@
 
 use std::collections::VecDeque;
 
+use hugr::hugr::views::sibling_subgraph::SchedGraphChecker;
 use hugr_core::builder::{DFGBuilder, Dataflow, DataflowHugr};
 use hugr_core::extension::prelude::{MakeTuple, UnpackTuple};
 use hugr_core::hugr::SimpleReplacementError;
 use hugr_core::hugr::hugrmut::HugrMut;
 use hugr_core::hugr::views::SiblingSubgraph;
-use hugr_core::hugr::views::sibling_subgraph::TopoConvexChecker;
 use hugr_core::ops::{OpTrait, OpType};
 use hugr_core::types::Type;
 use hugr_core::{HugrView, Node, PortIndex, SimpleReplacement};
@@ -80,8 +80,9 @@ fn find_rewrites<H: HugrView>(
 
     while let Some(parent) = children_queue.pop_front() {
         // Required to create SimpleReplacements.
-        // Reset for each parent as `TopoConvexChecker` is tied to a specific parent node.
-        let mut convex_checker: Option<TopoConvexChecker<H>> = None;
+        // Reset for each parent as `SchedGraphChecker` and all `HugrConvexChecker`s
+        // are tied to a specific parent node.
+        let mut convex_checker: Option<SchedGraphChecker<H>> = None;
 
         for node in hugr.children(parent) {
             let op = hugr.get_optype(node);
@@ -138,7 +139,7 @@ fn is_unpack_tuple(optype: &OpType) -> bool {
 /// Otherwise, return None.
 fn make_rewrite<'h, T: HugrView>(
     hugr: &'h T,
-    convex_checker: &mut Option<TopoConvexChecker<'h, T>>,
+    convex_checker: &mut Option<SchedGraphChecker<'h, T>>,
     node: T::Node,
     op: &OpType,
 ) -> Option<SimpleReplacement<T::Node>> {
@@ -203,14 +204,15 @@ fn make_rewrite<'h, T: HugrView>(
 /// and `other_tuple_links` other operations.
 fn remove_pack_unpack<'h, T: HugrView>(
     hugr: &'h T,
-    convex_checker: &mut Option<TopoConvexChecker<'h, T>>,
+    convex_checker: &mut Option<SchedGraphChecker<'h, T>>,
     tuple_types: &[Type],
     pack_node: T::Node,
     unpack_nodes: Vec<T::Node>,
     num_other_outputs: usize,
 ) -> SimpleReplacement<T::Node> {
     let parent = hugr.get_parent(pack_node).expect("pack_node has no parent");
-    let checker = convex_checker.get_or_insert_with(|| TopoConvexChecker::new(hugr, parent));
+    let checker =
+        convex_checker.get_or_insert_with(|| SchedGraphChecker::new(hugr.scheduling_graph(parent)));
 
     let mut nodes = unpack_nodes.clone();
     nodes.push(pack_node);

--- a/tket/src/passes/utils/chunks.rs
+++ b/tket/src/passes/utils/chunks.rs
@@ -9,13 +9,13 @@ use std::ops::{Index, IndexMut};
 use derive_more::From;
 use hugr::builder::{Container, FunctionBuilder};
 use hugr::hugr::hugrmut::HugrMut;
-use hugr::hugr::views::sibling_subgraph::TopoConvexChecker;
+use hugr::hugr::views::sibling_subgraph::{HugrConvexChecker, SchedGraphChecker};
 use hugr::hugr::views::{RootChecked, SiblingSubgraph};
 use hugr::hugr::{HugrError, NodeMetadataMap};
 use hugr::ops::OpType;
 use hugr::ops::handle::DataflowParentID;
 use hugr::types::Signature;
-use hugr::{Hugr, HugrView, IncomingPort, Node, OutgoingPort, PortIndex, Wire};
+use hugr::{HugrView, IncomingPort, Node, OutgoingPort, PortIndex, Wire};
 use hugr_core::hugr::internal::{HugrInternals, HugrMutInternals as _};
 use itertools::Itertools;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
@@ -52,7 +52,7 @@ impl Chunk {
     pub(self) fn extract(
         circ: &Circuit,
         nodes: impl IntoIterator<Item = Node>,
-        checker: &TopoConvexChecker<'_, Hugr>,
+        checker: &impl HugrConvexChecker<Node>,
     ) -> Self {
         let subgraph = SiblingSubgraph::try_from_nodes_with_checker(
             nodes.into_iter().collect_vec(),
@@ -283,7 +283,7 @@ impl CircuitChunks {
             .collect();
 
         let mut chunks = Vec::new();
-        let convex_checker = TopoConvexChecker::new(circ.hugr(), circ.parent());
+        let convex_checker = SchedGraphChecker::new(circ.sched_graph());
         let mut running_cost = C::default();
         let mut current_group = 0;
         for (_, commands) in &circ.commands().map(|cmd| cmd.node()).chunk_by(|&node| {

--- a/tket/src/passes/utils/hash.rs
+++ b/tket/src/passes/utils/hash.rs
@@ -3,7 +3,6 @@
 use derive_more::{Display, Error};
 use fxhash::{FxHashMap, FxHasher64};
 use hugr_core::HugrView;
-use hugr_core::hugr::internal::PortgraphNodeMap;
 use hugr_core::ops::OpType;
 use hugr_core::ops::{OpTag, OpTrait};
 use petgraph::visit::{self as pg, Walker};
@@ -56,9 +55,9 @@ fn dfg_hash<H: HugrView>(dfg_hugr: &H, node: H::Node) -> Result<u64, HashError> 
 
     let [_, output_node] = dfg_hugr.get_io(node).expect("DFG region missing I/O nodes");
 
-    let (region, node_map) = dfg_hugr.region_portgraph(node);
-    for pg_node in pg::Topo::new(&region).iter(&region) {
-        let child = node_map.from_portgraph(pg_node);
+    let sg = dfg_hugr.scheduling_graph(node);
+    for pg_node in pg::Topo::new(sg.petgraph()).iter(sg.petgraph()) {
+        let child = sg.pg_to_node(pg_node);
         let hash = dfg_hash_node(dfg_hugr, child, &mut node_hashes)?;
         if node_hashes.set_hash(child, hash).is_some() {
             panic!("Hash already set for node {node}");

--- a/tket/src/portmatching/matcher.rs
+++ b/tket/src/portmatching/matcher.rs
@@ -9,9 +9,12 @@ use std::{
 
 use super::{CircuitPattern, NodeID, PEdge, PNode};
 use derive_more::{Display, Error, From};
-use hugr::hugr::views::SiblingSubgraph;
 use hugr::hugr::views::sibling_subgraph::{
-    InvalidReplacement, InvalidSubgraph, InvalidSubgraphBoundary, TopoConvexChecker,
+    InvalidReplacement, InvalidSubgraph, InvalidSubgraphBoundary,
+};
+use hugr::hugr::views::{
+    SiblingSubgraph,
+    sibling_subgraph::{HugrConvexChecker, SchedGraphChecker},
 };
 use hugr::ops::OpType;
 use hugr::{HugrView, IncomingPort, Node, OutgoingPort, Port, PortIndex};
@@ -122,7 +125,7 @@ impl PatternMatch {
         circ: &Circuit,
         matcher: &PatternMatcher,
     ) -> Result<Self, InvalidPatternMatch> {
-        let checker = TopoConvexChecker::new(circ.hugr(), circ.parent());
+        let checker = SchedGraphChecker::new(circ.sched_graph());
         Self::try_from_root_match_with_checker(root, pattern, circ, matcher, &checker)
     }
 
@@ -137,7 +140,7 @@ impl PatternMatch {
         pattern: PatternID,
         circ: &Circuit<H>,
         matcher: &PatternMatcher,
-        checker: &TopoConvexChecker<'_, H>,
+        checker: &impl HugrConvexChecker<Node>,
     ) -> Result<Self, InvalidPatternMatch> {
         let pattern_ref = matcher
             .get_pattern(pattern)
@@ -180,7 +183,7 @@ impl PatternMatch {
         inputs: Vec<Vec<(Node, IncomingPort)>>,
         outputs: Vec<(Node, OutgoingPort)>,
     ) -> Result<Self, InvalidPatternMatch> {
-        let checker = TopoConvexChecker::new(circ.hugr(), circ.parent());
+        let checker = SchedGraphChecker::new(circ.sched_graph());
         Self::try_from_io_with_checker(root, pattern, circ, inputs, outputs, &checker)
     }
 
@@ -198,7 +201,7 @@ impl PatternMatch {
         circ: &Circuit<H>,
         inputs: Vec<Vec<(Node, IncomingPort)>>,
         outputs: Vec<(Node, OutgoingPort)>,
-        checker: &TopoConvexChecker<'_, H>,
+        checker: &impl HugrConvexChecker<Node>,
     ) -> Result<Self, InvalidPatternMatch> {
         let subgraph =
             SiblingSubgraph::try_new_with_checker(inputs, outputs, circ.hugr(), checker)?;
@@ -272,7 +275,7 @@ impl PatternMatcher {
         &'a self,
         circuit: &'c Circuit<impl HugrView<Node = Node>>,
     ) -> impl Iterator<Item = PatternMatch> + 'a {
-        let checker = TopoConvexChecker::new(circuit.hugr(), circuit.parent());
+        let checker = SchedGraphChecker::new(circuit.sched_graph());
         circuit
             .commands()
             .flat_map(move |cmd| self.find_rooted_matches(circuit, cmd.node(), &checker))
@@ -288,7 +291,7 @@ impl PatternMatcher {
         &self,
         circ: &Circuit<H>,
         root: Node,
-        checker: &TopoConvexChecker<'_, H>,
+        checker: &impl HugrConvexChecker<Node>,
     ) -> Vec<PatternMatch> {
         self.automaton
             .run(

--- a/tket/src/resource/scope.rs
+++ b/tket/src/resource/scope.rs
@@ -17,12 +17,10 @@ use hugr::hugr::views::sibling_subgraph::InvalidSubgraph;
 use hugr::ops::OpTrait;
 use hugr::types::Signature;
 use hugr::{Direction, HugrView, IncomingPort, OutgoingPort, Port, PortIndex, Wire};
-use hugr_core::hugr::internal::PortgraphNodeMap;
 use indexmap::IndexMap;
 use indexmap::map::Entry;
 use itertools::Itertools;
-use portgraph::algorithms::{TopoSort, toposort};
-use portgraph::view::{FilteredGraph, NodeFilter, NodeFiltered};
+use petgraph::visit::{NodeFiltered, Topo, Walker};
 
 use super::{Position, ResourceAllocator, ResourceId};
 
@@ -592,26 +590,12 @@ fn toposort_subgraph<'h, H: HugrView>(
     subgraph: &'h SiblingSubgraph<H::Node>,
     sources: impl IntoIterator<Item = H::Node>,
 ) -> Vec<H::Node> {
-    fn contains_node(node: portgraph::NodeIndex, nodes: &&BTreeSet<portgraph::NodeIndex>) -> bool {
-        nodes.contains(&node)
-    }
+    let sg = hugr.scheduling_graph(subgraph.get_parent(hugr));
+    let subgraph_nodes: BTreeSet<_> = subgraph.nodes().iter().map(|&n| sg.node_to_pg(n)).collect();
 
-    let (pg, pg_map) = hugr.region_portgraph(subgraph.get_parent(hugr));
-    let subgraph_nodes: BTreeSet<_> = subgraph
-        .nodes()
-        .iter()
-        .map(|&n| pg_map.to_portgraph(n))
-        .collect();
-
-    let pg: NodeFiltered<_, NodeFilter<_, _>, _> =
-        FilteredGraph::new(&pg, contains_node, |_, _| true, &subgraph_nodes);
-    let topo: TopoSort<_> = toposort(
-        pg,
-        sources.into_iter().map(|n| pg_map.to_portgraph(n)),
-        Direction::Outgoing,
-    );
-
-    topo.map(|n| pg_map.from_portgraph(n)).collect()
+    let pg = NodeFiltered::from_fn(sg.petgraph(), |node| subgraph_nodes.contains(&node));
+    let t = Topo::with_initials(&pg, sources.into_iter().map(|n| sg.node_to_pg(n)));
+    t.iter(&pg).map(|n| sg.pg_to_node(n)).collect()
 }
 
 #[cfg(test)]

--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -5,7 +5,6 @@ mod unsupported_tracker;
 mod value_tracker;
 
 use hugr::core::HugrNode;
-use hugr_core::hugr::internal::PortgraphNodeMap;
 use tket_json_rs::clexpr::InputClRegister;
 use tket_json_rs::opbox::BoxID;
 pub use value_tracker::{
@@ -207,13 +206,13 @@ impl<H: HugrView> PytketEncoderContext<H> {
             cache.insert(region, CachedEncodedFunction::InEncodingStack);
         }
 
-        let (region, node_map) = hugr.region_portgraph(region);
+        let sg = hugr.scheduling_graph(region);
         // TODO: Use weighted topological sort to try and explore unsupported
         // ops first (that is, ops with no available emitter in `self.config`),
         // to ensure we group them as much as possible.
-        let mut topo = petgraph::visit::Topo::new(&region);
-        while let Some(pg_node) = topo.next(&region) {
-            let node = node_map.from_portgraph(pg_node);
+        let mut topo = petgraph::visit::Topo::new(sg.petgraph());
+        while let Some(pg_node) = topo.next(sg.petgraph()) {
+            let node = sg.pg_to_node(pg_node);
             self.try_encode_node(node, hugr)?;
         }
         Ok(())


### PR DESCRIPTION
Mostly this was straightforward, with only `scope.rs` requiring a switch from portgraph algorithms to petgraph.

That is, until `command.rs` and `CommandIterator`, which raise many problems with SchedulingGraph. I tried a few other approaches simulating API changes to Hugr but these only worked if Hugr were to expose many more details of the internals of SchedulingGraph than desired. However, Circuit and CommandIterator are planned for removal anyway, so instead I've left CommandIterator using the deprecated `region_portgraph` with a comment about the various things we can do when region_portgraph is removed (if CommandIterator hasn't been removed first).