### PR TITLE
fix!: Replace non-deterministic iterations on hash maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
           cargo llvm-cov --no-report --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --no-default-features --doctests
           cargo llvm-cov --no-report --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --all-features --doctests
       - name: Generate coverage report
-        run: cargo llvm-cov --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --all-features report --codecov --output-path coverage.json
+        run: cargo llvm-cov report --codecov --output-path coverage.json
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v6
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,7 @@ missing_docs = "warn"
 
 [workspace.lints.clippy]
 allow_attributes = "warn"
-
-# TODO: Fix warnings of this lint and set to "warn"
-iter_over_hash_type = "allow"
+iter_over_hash_type = "warn"
 
 # TODO: Reduce the size of error types.
 result_large_err = "allow"

--- a/tket-qsystem/src/pytket/tests.rs
+++ b/tket-qsystem/src/pytket/tests.rs
@@ -38,6 +38,10 @@ const NATIVE_GATES_JSON: &str = r#"{
     }"#;
 
 /// Check some properties of the serial circuit.
+#[expect(
+    clippy::iter_over_hash_type,
+    reason = "test validation checks every permutation entry independently, so iteration order cannot affect the result"
+)]
 fn validate_serial_circ(circ: &SerialCircuit) {
     // Check that all commands have valid arguments.
     for command in &circ.commands {
@@ -76,6 +80,10 @@ fn validate_serial_circ(circ: &SerialCircuit) {
     );
 }
 
+#[expect(
+    clippy::iter_over_hash_type,
+    reason = "test comparison checks command multiplicities; iteration order only affects which mismatch is reported first"
+)]
 fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
     assert_eq!(a.name, b.name);
     assert_eq!(a.phase, b.phase);

--- a/tket/src/passes/const_fold.rs
+++ b/tket/src/passes/const_fold.rs
@@ -2,7 +2,7 @@
 //! An (example) use of the [dataflow analysis framework](crate::passes::dataflow).
 
 pub mod value_handle;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 use thiserror::Error;
 
 use hugr_core::{
@@ -28,7 +28,7 @@ pub struct ConstantFoldPass {
     /// Each outer key Node must be either:
     ///   - a `FuncDefn` child of the root, if the root is a module; or
     ///   - the entrypoint, if the entrypoint is not a Module
-    inputs: HashMap<Node, HashMap<IncomingPort, Value>>,
+    inputs: BTreeMap<Node, BTreeMap<IncomingPort, Value>>,
 }
 
 #[derive(Clone, Debug, Error, PartialEq)]

--- a/tket/src/passes/dataflow/partial_value.rs
+++ b/tket/src/passes/dataflow/partial_value.rs
@@ -4,8 +4,8 @@ use hugr_core::Node;
 use hugr_core::types::{SumType, Type, TypeArg, TypeEnum, TypeRow};
 use itertools::{Itertools, zip_eq};
 use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
+use std::collections::BTreeMap;
+use std::hash::Hash;
 use thiserror::Error;
 
 use super::row_contains_bottom;
@@ -63,14 +63,14 @@ pub struct LoadedFunction<N> {
 
 /// A representation of a value of [`SumType`], that may have one or more possible tags,
 /// with a [`PartialValue`] representation of each element-value of each possible tag.
-#[derive(PartialEq, Clone, Eq)]
-pub struct PartialSum<V, N = Node>(pub HashMap<usize, Vec<PartialValue<V, N>>>);
+#[derive(PartialEq, Clone, Eq, Hash)]
+pub struct PartialSum<V, N = Node>(pub BTreeMap<usize, Vec<PartialValue<V, N>>>);
 
 impl<V, N> PartialSum<V, N> {
     /// New instance for a single known tag.
     /// (Multi-tag instances can be created via [`Self::try_join_mut`].)
     pub fn new_variant(tag: usize, values: impl IntoIterator<Item = PartialValue<V, N>>) -> Self {
-        Self(HashMap::from([(tag, Vec::from_iter(values))]))
+        Self(BTreeMap::from([(tag, Vec::from_iter(values))]))
     }
 
     /// The number of possible variants we know about. (NOT the number
@@ -107,10 +107,6 @@ impl<V: AbstractValue, N: PartialEq + PartialOrd> PartialSum<V, N> {
     /// whether `self` has changed.
     ///
     /// Fails (without mutation) with the conflicting tag if any common rows have different lengths.
-    #[expect(
-        clippy::iter_over_hash_type,
-        reason = "join is pointwise over independent variant tags, so iteration order cannot affect the lattice result"
-    )]
     pub fn try_join_mut(&mut self, other: Self) -> Result<bool, usize> {
         for (k, v) in &other.0 {
             if self.0.get(k).is_some_and(|row| row.len() != v.len()) {
@@ -139,10 +135,6 @@ impl<V: AbstractValue, N: PartialEq + PartialOrd> PartialSum<V, N> {
     /// Fails without mutation, either:
     /// * `Some(tag)` if the two [`PartialSum`]s both had rows with that `tag` but of different lengths
     /// * `None` if the two instances had no rows in common (i.e., the result is "Bottom")
-    #[expect(
-        clippy::iter_over_hash_type,
-        reason = "meet is pointwise over independent variant tags, so iteration order cannot affect the lattice result"
-    )]
     pub fn try_meet_mut(&mut self, other: Self) -> Result<bool, Option<usize>> {
         let mut changed = false;
         let mut keys_to_remove = vec![];
@@ -273,63 +265,31 @@ impl<V: Clone, N: Clone> PartialSum<V, N> {
 }
 
 impl<V: PartialEq, N: PartialEq + PartialOrd> PartialOrd for PartialSum<V, N> {
-    #[expect(
-        clippy::iter_over_hash_type,
-        reason = "key iteration only fills presence bitmaps; value comparison below uses numeric tag order"
-    )]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        let max_key = self.0.keys().chain(other.0.keys()).copied().max().unwrap();
-        let (mut keys1, mut keys2) = (vec![0; max_key + 1], vec![0; max_key + 1]);
-        for k in self.0.keys() {
-            keys1[*k] = 1;
-        }
-
-        for k in other.0.keys() {
-            keys2[*k] = 1;
-        }
-
-        Some(match keys1.cmp(&keys2) {
-            ord @ (Ordering::Greater | Ordering::Less) => ord,
-            Ordering::Equal => {
-                for k in 0..=max_key {
-                    let Some(lhs) = self.0.get(&k) else {
-                        continue;
-                    };
-                    let Some(rhs) = other.0.get(&k) else {
-                        unreachable!()
-                    };
-                    let key_cmp = lhs.partial_cmp(rhs);
-                    if key_cmp != Some(Ordering::Equal) {
-                        return key_cmp;
+        for e in self
+            .0
+            .iter()
+            .merge_join_by(other.0.iter(), |(k1, _), (k2, _)| k1.cmp(k2))
+        {
+            match e {
+                itertools::EitherOrBoth::Left(_) => return Some(Ordering::Greater),
+                itertools::EitherOrBoth::Right(_) => return Some(Ordering::Less),
+                itertools::EitherOrBoth::Both((_, v1), (_, v2)) => {
+                    let cmp = v1.partial_cmp(v2);
+                    if cmp != Some(Ordering::Equal) {
+                        return cmp;
                     }
                 }
-                Ordering::Equal
             }
-        })
+        }
+
+        Some(Ordering::Equal)
     }
 }
 
 impl<V: std::fmt::Debug, N: std::fmt::Debug> std::fmt::Debug for PartialSum<V, N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-impl<V: Hash, N: Hash> Hash for PartialSum<V, N> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // Highest tag present in the sum.
-        //
-        // Hashing must be independent of `HashMap` iteration order so that equal
-        // `PartialSum`s always feed the same sequence into the caller's hasher.
-        let max_variant_key = self.0.keys().copied().max().unwrap_or(0);
-
-        for k in 0..=max_variant_key {
-            let Some(v) = self.0.get(&k) else {
-                continue;
-            };
-            k.hash(state);
-            v.hash(state);
-        }
     }
 }
 
@@ -591,10 +551,6 @@ mod test {
     }
 
     impl TestSumType {
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "test validation checks every possible tag independently, so iteration order cannot affect the result"
-        )]
         fn check_value(&self, pv: &PartialValue<TestValue>) -> bool {
             match (self, pv) {
                 (_, PartialValue::Bottom | PartialValue::Top) => true,

--- a/tket/src/passes/dataflow/partial_value.rs
+++ b/tket/src/passes/dataflow/partial_value.rs
@@ -107,6 +107,10 @@ impl<V: AbstractValue, N: PartialEq + PartialOrd> PartialSum<V, N> {
     /// whether `self` has changed.
     ///
     /// Fails (without mutation) with the conflicting tag if any common rows have different lengths.
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "join is pointwise over independent variant tags, so iteration order cannot affect the lattice result"
+    )]
     pub fn try_join_mut(&mut self, other: Self) -> Result<bool, usize> {
         for (k, v) in &other.0 {
             if self.0.get(k).is_some_and(|row| row.len() != v.len()) {
@@ -135,6 +139,10 @@ impl<V: AbstractValue, N: PartialEq + PartialOrd> PartialSum<V, N> {
     /// Fails without mutation, either:
     /// * `Some(tag)` if the two [`PartialSum`]s both had rows with that `tag` but of different lengths
     /// * `None` if the two instances had no rows in common (i.e., the result is "Bottom")
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "meet is pointwise over independent variant tags, so iteration order cannot affect the lattice result"
+    )]
     pub fn try_meet_mut(&mut self, other: Self) -> Result<bool, Option<usize>> {
         let mut changed = false;
         let mut keys_to_remove = vec![];
@@ -265,6 +273,10 @@ impl<V: Clone, N: Clone> PartialSum<V, N> {
 }
 
 impl<V: PartialEq, N: PartialEq + PartialOrd> PartialOrd for PartialSum<V, N> {
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "key iteration only fills presence bitmaps; value comparison below uses numeric tag order"
+    )]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         let max_key = self.0.keys().chain(other.0.keys()).copied().max().unwrap();
         let (mut keys1, mut keys2) = (vec![0; max_key + 1], vec![0; max_key + 1]);
@@ -279,8 +291,11 @@ impl<V: PartialEq, N: PartialEq + PartialOrd> PartialOrd for PartialSum<V, N> {
         Some(match keys1.cmp(&keys2) {
             ord @ (Ordering::Greater | Ordering::Less) => ord,
             Ordering::Equal => {
-                for (k, lhs) in &self.0 {
-                    let Some(rhs) = other.0.get(k) else {
+                for k in 0..=max_key {
+                    let Some(lhs) = self.0.get(&k) else {
+                        continue;
+                    };
+                    let Some(rhs) = other.0.get(&k) else {
                         unreachable!()
                     };
                     let key_cmp = lhs.partial_cmp(rhs);
@@ -302,7 +317,16 @@ impl<V: std::fmt::Debug, N: std::fmt::Debug> std::fmt::Debug for PartialSum<V, N
 
 impl<V: Hash, N: Hash> Hash for PartialSum<V, N> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        for (k, v) in &self.0 {
+        // Highest tag present in the sum.
+        //
+        // Hashing must be independent of `HashMap` iteration order so that equal
+        // `PartialSum`s always feed the same sequence into the caller's hasher.
+        let max_variant_key = self.0.keys().copied().max().unwrap_or(0);
+
+        for k in 0..=max_variant_key {
+            let Some(v) = self.0.get(&k) else {
+                continue;
+            };
             k.hash(state);
             v.hash(state);
         }
@@ -567,6 +591,10 @@ mod test {
     }
 
     impl TestSumType {
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "test validation checks every possible tag independently, so iteration order cannot affect the result"
+        )]
         fn check_value(&self, pv: &PartialValue<TestValue>) -> bool {
             match (self, pv) {
                 (_, PartialValue::Bottom | PartialValue::Top) => true,

--- a/tket/src/passes/monomorphize.rs
+++ b/tket/src/passes/monomorphize.rs
@@ -15,6 +15,7 @@ use hugr_core::{
 };
 
 use hugr_core::hugr::{HugrView, OpType, hugrmut::HugrMut};
+use indexmap::IndexMap;
 use itertools::Itertools as _;
 
 use crate::passes::composable::WithScope;
@@ -31,7 +32,7 @@ fn is_polymorphic_funcdefn(t: &OpType) -> bool {
 struct Instantiating<'a> {
     subst: &'a Substitution<'a>,
     target_container: Node,
-    node_map: &'a mut HashMap<Node, Node>,
+    node_map: &'a mut IndexMap<Node, Node>,
 }
 
 type Instantiations = HashMap<Node, HashMap<Vec<TypeArg>, Node>>;
@@ -130,7 +131,7 @@ fn instantiate(
     // Insert BEFORE we scan (in case of recursion), hence we cannot use Entry::or_insert
     ve.insert(mono_tgt);
     // Now make the instantiation
-    let mut node_map = HashMap::new();
+    let mut node_map = IndexMap::new();
     let mut inst = Instantiating {
         subst: &Substitution::new(&type_args),
         target_container: mono_tgt,

--- a/tket/src/passes/nest_cfgs.rs
+++ b/tket/src/passes/nest_cfgs.rs
@@ -89,6 +89,11 @@ pub fn transform_cfg_to_nested<T: Copy + Eq + Hash + std::fmt::Debug>(
 ) {
     let edge_classes = EdgeClassifier::get_edge_classes(view);
     let mut rem_edges: HashMap<usize, HashSet<(T, T)>> = HashMap::new();
+
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "edge-class iteration only groups edges by class; traversal later chooses edges from deterministic CFG successor order"
+    )]
     for (e, cls) in &edge_classes {
         rem_edges.entry(*cls).or_default().insert(*e);
     }
@@ -583,6 +588,10 @@ pub(crate) mod test {
     use hugr_core::types::{EdgeKind, Signature};
     use hugr_core::utils::depth;
 
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "test helper groups all entries and sorts each group before comparison"
+    )]
     pub fn group_by<E: Eq + Hash + Ord, V: Eq + Hash>(h: HashMap<E, V>) -> HashSet<Vec<E>> {
         let mut res = HashMap::new();
         for (k, v) in h {

--- a/tket/src/passes/utils/chunks.rs
+++ b/tket/src/passes/utils/chunks.rs
@@ -17,6 +17,7 @@ use hugr::ops::handle::DataflowParentID;
 use hugr::types::Signature;
 use hugr::{HugrView, IncomingPort, Node, OutgoingPort, PortIndex, Wire};
 use hugr_core::hugr::internal::{HugrInternals, HugrMutInternals as _};
+use indexmap::IndexMap;
 use itertools::Itertools;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use rayon::slice::ParallelSliceMut;
@@ -115,8 +116,8 @@ impl Chunk {
                 .unwrap_or_else(|e| panic!("The chunk circuit is no longer a dataflow graph: {e}"));
         let node_map = circ.insert_subgraph(root, &chunk, &subgraph);
 
-        let mut input_map = HashMap::with_capacity(self.inputs.len());
-        let mut output_map = HashMap::with_capacity(self.outputs.len());
+        let mut input_map = IndexMap::with_capacity(self.inputs.len());
+        let mut output_map = IndexMap::with_capacity(self.outputs.len());
 
         // Translate each connection from the chunk input into a [`ConnectionTarget`].
         //
@@ -168,8 +169,8 @@ impl Chunk {
     fn empty_chunk_insert_result(&self) -> ChunkInsertResult {
         let hugr = self.circ.hugr();
         let [chunk_inp, chunk_out] = self.circ.io_nodes();
-        let mut input_map = HashMap::with_capacity(self.inputs.len());
-        let mut output_map = HashMap::with_capacity(self.outputs.len());
+        let mut input_map = IndexMap::with_capacity(self.inputs.len());
+        let mut output_map = IndexMap::with_capacity(self.outputs.len());
 
         for (&connection, chunk_inp_port) in self.inputs.iter().zip(hugr.node_outputs(chunk_inp)) {
             let connection_targets: Vec<ConnectionTarget> = hugr
@@ -207,12 +208,12 @@ impl Chunk {
 /// A map from the original input/output [`ChunkConnection`]s to an inserted chunk's inputs and outputs.
 #[derive(Debug, Clone)]
 struct ChunkInsertResult {
-    /// A map from incoming connections to a chunk, to the new node and incoming port targets.
+    /// Incoming connections to a chunk, in chunk input order, to the new node and incoming port targets.
     ///
     /// A chunk may specify multiple targets to be connected to a single incoming `ChunkConnection`.
-    pub incoming_connections: HashMap<ChunkConnection, Vec<ConnectionTarget>>,
-    /// A map from outgoing connections from a chunk, to the new node and outgoing port target.
-    pub outgoing_connections: HashMap<ChunkConnection, ConnectionTarget>,
+    pub incoming_connections: IndexMap<ChunkConnection, Vec<ConnectionTarget>>,
+    /// Outgoing connections from a chunk, in chunk output order, to the new node and outgoing port target.
+    pub outgoing_connections: IndexMap<ChunkConnection, ConnectionTarget>,
 }
 
 /// The target of a chunk connection in a reassembled circuit.
@@ -326,7 +327,7 @@ impl CircuitChunks {
         // The chunks input and outputs are each identified with a
         // [`ChunkConnection`]. We collect both sides first, and rewire them
         // after the chunks have been inserted.
-        let mut sources: HashMap<ChunkConnection, (Node, OutgoingPort)> = HashMap::new();
+        let mut sources: IndexMap<ChunkConnection, (Node, OutgoingPort)> = IndexMap::new();
         let mut targets: HashMap<ChunkConnection, Vec<(Node, IncomingPort)>> = HashMap::new();
 
         // A map for `ChunkConnection`s that have been merged into another (due

--- a/tket/src/serialize/pytket/encoder/unsupported_tracker.rs
+++ b/tket/src/serialize/pytket/encoder/unsupported_tracker.rs
@@ -91,6 +91,11 @@ impl<N: HugrNode> UnsupportedTracker<N> {
         // and use it here. For now we just traverse all unextracted nodes.
         let mut nodes = BTreeSet::new();
         nodes.insert(node);
+
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "iteration only filters membership; nodes are collected into a BTreeSet before any output-affecting use"
+        )]
         for (&n, data) in &self.nodes {
             if self.components.find_mut(data.component) == representative {
                 nodes.insert(n);

--- a/tket/src/serialize/pytket/encoder/unsupported_tracker.rs
+++ b/tket/src/serialize/pytket/encoder/unsupported_tracker.rs
@@ -92,18 +92,11 @@ impl<N: HugrNode> UnsupportedTracker<N> {
         let mut nodes = BTreeSet::new();
         nodes.insert(node);
 
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "iteration only filters membership; nodes are collected into a BTreeSet before any output-affecting use"
-        )]
-        for (&n, data) in &self.nodes {
-            if self.components.find_mut(data.component) == representative {
-                nodes.insert(n);
-            }
-        }
-        for n in &nodes {
-            self.nodes.remove(n);
-        }
+        nodes.extend(
+            self.nodes
+                .extract_if(|_, data| self.components.find_mut(data.component) == representative)
+                .map(|(n, _)| n),
+        );
 
         OpaqueSubgraph::try_from_nodes(nodes, hugr)
     }

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -152,6 +152,10 @@ const IMPLICIT_PERMUTATION: &str = r#"{
     }"#;
 
 /// Check some properties of the serial circuit.
+#[expect(
+    clippy::iter_over_hash_type,
+    reason = "test validation checks every permutation entry independently, so iteration order cannot affect the result"
+)]
 fn validate_serial_circ(circ: &SerialCircuit) {
     // Check that all commands have valid arguments.
     for command in &circ.commands {
@@ -192,6 +196,10 @@ fn validate_serial_circ(circ: &SerialCircuit) {
     );
 }
 
+#[expect(
+    clippy::iter_over_hash_type,
+    reason = "test comparison checks command multiplicities; iteration order only affects which mismatch is reported first"
+)]
 fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
     assert_eq!(a.name, b.name);
     assert_eq!(a.phase, b.phase);


### PR DESCRIPTION
Enables the `iter_over_hash_type` clippy lint, and fixes all cases of iteration over hashmaps and hashsets that could cause non-deterministic outputs.

BREAKING CHANGE: Changed public field `PartialSum::0` from a `HashMap` to a `BTreeMap`.