### PR TITLE
ci: Fix CI build error for qis-compiler tests

### DIFF
--- a/.github/change-filters.yml
+++ b/.github/change-filters.yml
@@ -14,7 +14,6 @@ rust:
   - "compile-rewriter/**"
   - "tket1-passes/**"
   - "tket-qec/**"
-  - "qis-compiler/**"
 
 python:
   - *rust-core

--- a/.github/change-filters.yml
+++ b/.github/change-filters.yml
@@ -14,6 +14,7 @@ rust:
   - "compile-rewriter/**"
   - "tket1-passes/**"
   - "tket-qec/**"
+  - "qis-compiler/**"
 
 python:
   - *rust-core

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -15,7 +15,7 @@ permissions:
   id-token: write
 
 env:
-  UV_VERSION: "0.9.7"
+  UV_VERSION: "0.11.15"
   UV_FROZEN: 1
 
 jobs:
@@ -45,7 +45,6 @@ jobs:
       - uses: extractions/setup-just@v4
         with:
           just-version: "1.40.0"
-
 
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   # Pinned version for the uv package manager
-  UV_VERSION: "0.9.7"
+  UV_VERSION: "0.11.15"
   UV_FROZEN: 1
   # The highest and lowest supported Python versions, used for testing
   PYTHON_HIGHEST: "3.14"
@@ -167,13 +167,15 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-      - name: Install Python ${{ env.PYTHON_HIGHEST }}
-        # Required to compile tests in crates that use pyo3.
-        run: uv python install ${{ env.PYTHON_HIGHEST }}
+      - name: Install Python
+        # Required to link tests in crates that use pyo3.
+        run: |
+          uv python install ${{ env.PYTHON_HIGHEST }}
+          echo "UV_PYTHON=${{ env.PYTHON_HIGHEST }}" >> "$GITHUB_ENV"
       - name: Build with all features
-        run: cargo nextest r --verbose --workspace --all-features --no-run
+        run: uv run --no-project cargo nextest r --verbose --workspace --all-features --no-run
       - name: Tests with all features
-        run: cargo nextest r --verbose --workspace --all-features
+        run: uv run --no-project cargo nextest r --verbose --workspace --all-features
 
   # Run tests on other toolchains
   tests-rs-other:
@@ -204,17 +206,19 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-      - name: Install Python ${{ env.PYTHON_HIGHEST }}
-        # Required to compile tests in crates that use pyo3.
-        run: uv python install ${{ env.PYTHON_HIGHEST }}
+      - name: Install Python
+        # Required to link tests in crates that use pyo3.
+        run: |
+          uv python install ${{ env.PYTHON_HIGHEST }}
+          echo "UV_PYTHON=${{ env.PYTHON_HIGHEST }}" >> "$GITHUB_ENV"
       - name: Build with no features
-        run: cargo nextest r --verbose --workspace --no-default-features --no-run
+        run: uv run --no-project cargo nextest r --verbose --workspace --no-default-features --no-run
       - name: Tests with no features
-        run: cargo nextest r --verbose --workspace --no-default-features
+        run: uv run --no-project cargo nextest r --verbose --workspace --no-default-features
       - name: Build with all features
-        run: cargo nextest r --verbose --workspace --all-features --no-run
+        run: uv run --no-project cargo nextest r --verbose --workspace --all-features --no-run
       - name: Tests with all features
-        run: cargo nextest r --verbose --workspace --all-features
+        run: uv run --no-project cargo nextest r --verbose --workspace --all-features
 
   tests-nightly-coverage:
     needs: [changes]
@@ -238,14 +242,16 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-      - name: Install Python ${{ env.PYTHON_HIGHEST }}
-        # Required to compile tests in crates that use pyo3.
-        run: uv python install ${{ env.PYTHON_HIGHEST }}
+      - name: Install Python
+        # Required to link tests in crates that use pyo3.
+        run: |
+          uv python install ${{ env.PYTHON_HIGHEST }}
+          echo "UV_PYTHON=${{ env.PYTHON_HIGHEST }}" >> "$GITHUB_ENV"
       - name: Run tests with coverage instrumentation
         run: |
-          cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report --workspace --no-default-features --doctests
-          cargo llvm-cov --no-report --workspace --all-features --doctests
+          uv run --no-project cargo llvm-cov clean --workspace
+          uv run --no-project cargo llvm-cov --no-report --workspace --no-default-features --doctests
+          uv run --no-project cargo llvm-cov --no-report --workspace --all-features --doctests
       - name: Generate coverage report
         run: cargo llvm-cov --all-features report --codecov --output-path coverage.json
       - name: Upload coverage to codecov.io
@@ -289,9 +295,11 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
-      - name: Install Python ${{ env.PYTHON_LOWEST }}
-        # Required to compile tests in crates that use pyo3.
-        run: uv python install ${{ env.PYTHON_LOWEST }}
+      - name: Install Python
+        # Required to link tests in crates that use pyo3.
+        run: |
+          uv python install ${{ env.PYTHON_LOWEST }}
+          echo "UV_PYTHON=${{ env.PYTHON_LOWEST }}" >> "$GITHUB_ENV"
       - name: Pin transitive dependencies not compatible with our MSRV
         # Add new dependencies as needed if the check fails due to
         # "package `XXX` cannot be built because it requires rustc YYY or newer, while the currently active rustc version is 1.91.0"
@@ -299,13 +307,13 @@ jobs:
           rm Cargo.lock
           # cargo add -p tket insta@2.4.1
       - name: Build with no features
-        run: cargo minimal-versions --direct test --verbose  --no-default-features --no-run
+        run: uv run --no-project cargo minimal-versions --direct test --verbose  --no-default-features --no-run
       - name: Tests with no features
-        run: cargo minimal-versions --direct test --verbose  --no-default-features
+        run: uv run --no-project cargo minimal-versions --direct test --verbose  --no-default-features
       - name: Build with all features
-        run: cargo minimal-versions --direct test --verbose  --all-features --no-run
+        run: uv run --no-project cargo minimal-versions --direct test --verbose  --all-features --no-run
       - name: Tests with all features
-        run: cargo minimal-versions --direct test --verbose  --all-features
+        run: uv run --no-project cargo minimal-versions --direct test --verbose  --all-features
 
   tests-py:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,14 @@ jobs:
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
       - uses: taiki-e/install-action@nextest
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - name: Install Python ${{ env.PYTHON_HIGHEST }}
+        # Required to compile tests in crates that use pyo3.
+        run: uv python install ${{ env.PYTHON_HIGHEST }}
       - name: Build with all features
         run: cargo nextest r --verbose --workspace --all-features --no-run
       - name: Tests with all features
@@ -191,6 +199,14 @@ jobs:
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: taiki-e/install-action@nextest
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - name: Install Python ${{ env.PYTHON_HIGHEST }}
+        # Required to compile tests in crates that use pyo3.
+        run: uv python install ${{ env.PYTHON_HIGHEST }}
       - name: Build with no features
         run: cargo nextest r --verbose --workspace --no-default-features --no-run
       - name: Tests with no features
@@ -217,6 +233,14 @@ jobs:
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - name: Install Python ${{ env.PYTHON_HIGHEST }}
+        # Required to compile tests in crates that use pyo3.
+        run: uv python install ${{ env.PYTHON_HIGHEST }}
       - name: Run tests with coverage instrumentation
         run: |
           cargo llvm-cov clean --workspace
@@ -260,6 +284,14 @@ jobs:
         run: |
           cargo binstall cargo-hack --force
           cargo binstall cargo-minimal-versions --force
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - name: Install Python ${{ env.PYTHON_LOWEST }}
+        # Required to compile tests in crates that use pyo3.
+        run: uv python install ${{ env.PYTHON_LOWEST }}
       - name: Pin transitive dependencies not compatible with our MSRV
         # Add new dependencies as needed if the check fails due to
         # "package `XXX` cannot be built because it requires rustc YYY or newer, while the currently active rustc version is 1.91.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,12 +162,12 @@ jobs:
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
       - uses: taiki-e/install-action@nextest
-      # qis-compiler requires libpython to link test binaries;
-      # it is tested separately in the tests-qis-compiler job.
+      # Crates using pyo3 cdylib require libpython to link test binaries;
+      # they are tested separately in their own jobs.
       - name: Build with all features
-        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features --no-run
+        run: cargo nextest r --verbose --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --all-features --no-run
       - name: Tests with all features
-        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features
+        run: cargo nextest r --verbose --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --all-features
 
   # Run tests on other toolchains
   tests-rs-other:
@@ -193,16 +193,16 @@ jobs:
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: taiki-e/install-action@nextest
-      # qis-compiler requires libpython to link test binaries;
-      # it is tested separately in the tests-qis-compiler job.
+      # Crates using pyo3 cdylib require libpython to link test binaries;
+      # they are tested separately in their own jobs.
       - name: Build with no features
-        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features --no-run
+        run: cargo nextest r --verbose --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --no-default-features --no-run
       - name: Tests with no features
-        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features
+        run: cargo nextest r --verbose --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --no-default-features
       - name: Build with all features
-        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features --no-run
+        run: cargo nextest r --verbose --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --all-features --no-run
       - name: Tests with all features
-        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features
+        run: cargo nextest r --verbose --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --all-features
 
   tests-nightly-coverage:
     needs: [changes]
@@ -221,15 +221,15 @@ jobs:
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      # qis-compiler requires libpython to link test binaries;
-      # it is tested separately in the tests-qis-compiler job.
+      # Crates using pyo3 cdylib require libpython to link test binaries;
+      # they are tested separately in their own jobs.
       - name: Run tests with coverage instrumentation
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features --doctests
-          cargo llvm-cov --no-report -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features --doctests
+          cargo llvm-cov --no-report --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --no-default-features --doctests
+          cargo llvm-cov --no-report --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --all-features --doctests
       - name: Generate coverage report
-        run: cargo llvm-cov -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features report --codecov --output-path coverage.json
+        run: cargo llvm-cov --workspace --exclude tket-py --exclude selene-hugr-qis-compiler --all-features report --codecov --output-path coverage.json
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v6
         with:
@@ -272,16 +272,16 @@ jobs:
         run: |
           rm Cargo.lock
           # cargo add -p tket insta@2.4.1
-      # qis-compiler requires libpython to link test binaries;
-      # it is tested separately in the tests-qis-compiler job.
+      # Crates using pyo3 cdylib require libpython to link test binaries;
+      # they are tested separately in their own jobs.
       - name: Build with no features
-        run: cargo minimal-versions --direct test --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features --no-run
+        run: cargo minimal-versions --direct test --verbose --exclude tket-py --exclude selene-hugr-qis-compiler --no-default-features --no-run
       - name: Tests with no features
-        run: cargo minimal-versions --direct test --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features
+        run: cargo minimal-versions --direct test --verbose --exclude tket-py --exclude selene-hugr-qis-compiler --no-default-features
       - name: Build with all features
-        run: cargo minimal-versions --direct test --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features --no-run
+        run: cargo minimal-versions --direct test --verbose --exclude tket-py --exclude selene-hugr-qis-compiler --all-features --no-run
       - name: Tests with all features
-        run: cargo minimal-versions --direct test --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features
+        run: cargo minimal-versions --direct test --verbose --exclude tket-py --exclude selene-hugr-qis-compiler --all-features
 
   tests-py:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,20 +162,12 @@ jobs:
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
       - uses: taiki-e/install-action@nextest
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-      - name: Install Python
-        # Required to link tests in crates that use pyo3.
-        run: |
-          uv python install ${{ env.PYTHON_HIGHEST }}
-          echo "UV_PYTHON=${{ env.PYTHON_HIGHEST }}" >> "$GITHUB_ENV"
+      # qis-compiler requires libpython to link test binaries;
+      # it is tested separately in the tests-qis-compiler job.
       - name: Build with all features
-        run: uv run --no-project cargo nextest r --verbose --workspace --all-features --no-run
+        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features --no-run
       - name: Tests with all features
-        run: uv run --no-project cargo nextest r --verbose --workspace --all-features
+        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features
 
   # Run tests on other toolchains
   tests-rs-other:
@@ -201,24 +193,16 @@ jobs:
       - name: Configure default rust toolchain
         run: rustup override set ${{steps.toolchain.outputs.name}}
       - uses: taiki-e/install-action@nextest
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-      - name: Install Python
-        # Required to link tests in crates that use pyo3.
-        run: |
-          uv python install ${{ env.PYTHON_HIGHEST }}
-          echo "UV_PYTHON=${{ env.PYTHON_HIGHEST }}" >> "$GITHUB_ENV"
+      # qis-compiler requires libpython to link test binaries;
+      # it is tested separately in the tests-qis-compiler job.
       - name: Build with no features
-        run: uv run --no-project cargo nextest r --verbose --workspace --no-default-features --no-run
+        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features --no-run
       - name: Tests with no features
-        run: uv run --no-project cargo nextest r --verbose --workspace --no-default-features
+        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features
       - name: Build with all features
-        run: uv run --no-project cargo nextest r --verbose --workspace --all-features --no-run
+        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features --no-run
       - name: Tests with all features
-        run: uv run --no-project cargo nextest r --verbose --workspace --all-features
+        run: cargo nextest r --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features
 
   tests-nightly-coverage:
     needs: [changes]
@@ -237,23 +221,15 @@ jobs:
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-      - name: Install Python
-        # Required to link tests in crates that use pyo3.
-        run: |
-          uv python install ${{ env.PYTHON_HIGHEST }}
-          echo "UV_PYTHON=${{ env.PYTHON_HIGHEST }}" >> "$GITHUB_ENV"
+      # qis-compiler requires libpython to link test binaries;
+      # it is tested separately in the tests-qis-compiler job.
       - name: Run tests with coverage instrumentation
         run: |
-          uv run --no-project cargo llvm-cov clean --workspace
-          uv run --no-project cargo llvm-cov --no-report --workspace --no-default-features --doctests
-          uv run --no-project cargo llvm-cov --no-report --workspace --all-features --doctests
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --no-report -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features --doctests
+          cargo llvm-cov --no-report -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features --doctests
       - name: Generate coverage report
-        run: cargo llvm-cov --all-features report --codecov --output-path coverage.json
+        run: cargo llvm-cov -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features report --codecov --output-path coverage.json
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v6
         with:
@@ -290,30 +266,22 @@ jobs:
         run: |
           cargo binstall cargo-hack --force
           cargo binstall cargo-minimal-versions --force
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-      - name: Install Python
-        # Required to link tests in crates that use pyo3.
-        run: |
-          uv python install ${{ env.PYTHON_LOWEST }}
-          echo "UV_PYTHON=${{ env.PYTHON_LOWEST }}" >> "$GITHUB_ENV"
       - name: Pin transitive dependencies not compatible with our MSRV
         # Add new dependencies as needed if the check fails due to
         # "package `XXX` cannot be built because it requires rustc YYY or newer, while the currently active rustc version is 1.91.0"
         run: |
           rm Cargo.lock
           # cargo add -p tket insta@2.4.1
+      # qis-compiler requires libpython to link test binaries;
+      # it is tested separately in the tests-qis-compiler job.
       - name: Build with no features
-        run: uv run --no-project cargo minimal-versions --direct test --verbose  --no-default-features --no-run
+        run: cargo minimal-versions --direct test --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features --no-run
       - name: Tests with no features
-        run: uv run --no-project cargo minimal-versions --direct test --verbose  --no-default-features
+        run: cargo minimal-versions --direct test --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --no-default-features
       - name: Build with all features
-        run: uv run --no-project cargo minimal-versions --direct test --verbose  --all-features --no-run
+        run: cargo minimal-versions --direct test --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features --no-run
       - name: Tests with all features
-        run: uv run --no-project cargo minimal-versions --direct test --verbose  --all-features
+        run: cargo minimal-versions --direct test --verbose -p badger-optimiser -p compile-rewriter -p tket -p tket1-passes -p tket-py -p tket-qsystem -p tket-qec --all-features
 
   tests-py:
     needs: changes
@@ -369,7 +337,13 @@ jobs:
           enable-cache: true
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
       - name: Install Python ${{ env.PYTHON_LOWEST }}
-        run: uv python install ${{ env.PYTHON_LOWEST }}
+        run: |
+          uv python install ${{ env.PYTHON_LOWEST }}
+          PYTHON=$(uv python find ${{ env.PYTHON_LOWEST }})
+          echo "PYO3_PYTHON=$PYTHON" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$($PYTHON -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')" >> "$GITHUB_ENV"
+      - name: Run Rust unit tests
+        run: cargo test -p selene-hugr-qis-compiler
       - name: Run qis-compiler tests
         run: uv run --python ${{ env.PYTHON_LOWEST }} --exact --package selene_hugr_qis_compiler pytest --cov=./ --cov-report=xml qis-compiler
       - name: Upload python coverage to codecov.io

--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   # Pinned version for the uv package manager
-  UV_VERSION: "0.9.7"
+  UV_VERSION: "0.11.15"
 
 jobs:
   # Check if the tag matches the package name,

--- a/.github/workflows/python-qis-wheels.yml
+++ b/.github/workflows/python-qis-wheels.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  UV_VERSION: "0.9.7"
+  UV_VERSION: "0.11.15"
 jobs:
   # Check if the tag matches the package name,
   # or if the workflow is running on a non-release event.

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -23,7 +23,7 @@ permissions:
 env:
   MODULE_DIR: tket-py
   # Pinned version for the uv package manager
-  UV_VERSION: "0.9.7"
+  UV_VERSION: "0.11.15"
   UV_FROZEN: 1
   # Python version used to build the wheels
   # We use abi3-compatible building, so this still supports newer Python versions

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -15,7 +15,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   # Pinned version for the uv package manager
-  UV_VERSION: "0.9.7"
+  UV_VERSION: "0.11.15"
 
 jobs:
   py-release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,6 @@ build-backend = "hatchling.build"
 manifest-path = "tket-py/Cargo.toml"
 python-source = "tket-py"
 module-name = "tket._tket"
-# "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
-features = ["pyo3/extension-module"]
 
 [tool.mypy]
 exclude = '''(?x)(

--- a/qis-compiler/Cargo.toml
+++ b/qis-compiler/Cargo.toml
@@ -30,7 +30,6 @@ workspace = true
 
 [features]
 default = []
-extension-module = ["pyo3/extension-module"]
 
 [build-dependencies]
 cbindgen.workspace = true

--- a/qis-compiler/pyproject.toml
+++ b/qis-compiler/pyproject.toml
@@ -45,7 +45,6 @@ repository = "https://github.com/quantinuum/tket2/tree/main/qis-compiler"
 
 [tool.maturin]
 profile = "release"
-features = ["pyo3/extension-module"]
 python-source = "python"
 manifest-path = "Cargo.toml"
 include = ["python/selene_hugr_qis_compiler/py.typed"]
@@ -115,9 +114,7 @@ repair-wheel-command = [
 PATH = '$HOME/.cargo/bin:${HUGRENV_PATH}/bin:$PATH'
 MACOSX_DEPLOYMENT_TARGET = "15.0"
 [tool.cibuildwheel.macos]
-before-all = [
-    'curl -sSf https://sh.rustup.rs | sh -s -- -y',
-]
+before-all = ['curl -sSf https://sh.rustup.rs | sh -s -- -y']
 repair-wheel-command = [
     'DYLD_FALLBACK_LIBRARY_PATH=${LLVM_SYS_211_PREFIX}/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}',
     'uvx abi3audit --strict --report {wheel}',
@@ -126,9 +123,7 @@ repair-wheel-command = [
 [tool.cibuildwheel.windows.environment]
 PATH = '${HUGRENV_PATH}\\bin;$PATH'
 [tool.cibuildwheel.windows]
-before-all = [
-    'rustup update',
-]
+before-all = ['rustup update']
 repair-wheel-command = [
     'uvx delvewheel repair -w {dest_dir} {wheel}',
     'uvx abi3audit --strict --report {wheel}',

--- a/tket-py/pyproject.toml
+++ b/tket-py/pyproject.toml
@@ -64,8 +64,6 @@ docs = [
 # Make sure to copy any changes to the root `pyproject.toml` config too.
 module-name = "tket._tket"
 manifest-path = "Cargo.toml"
-# "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
-features = ["pyo3/extension-module"]
 
 [tool.pytest.ini_options]
 # Lark throws deprecation warnings for `src_parse` and `src_constants`.


### PR DESCRIPTION
#1606 added rust unit tests to `qis-compiler`. That is a crate that uses `pyo3` and links against `libpython`, so CI started failing due to not being able to link to python.
This is a quick patch to that by whitelisting which packages get tested where. We could do something more thorough by fully building the python project before running `cargo test`, but we need to evaluate how does that impact CI runtimes.

- `pyo3`'s extension-module feature is deprecated, we can remove its uses. https://pyo3.rs/main/features#extension-module
- Updated `uv` versions used in CI
- Whitelisted cargo test runs to avoid compiling `qis-compiler`, since it requires running maturin with a fully setup uv package environment.