### PR TITLE
ci: Create py releases as draft until wheels are built

### DIFF
--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -40,18 +40,10 @@ jobs:
           RUN_EXTS: ${{ github.ref_type != 'tag' || startsWith(github.ref, 'refs/tags/tket-exts-v') }}
           RUN_ECCS: ${{ github.ref_type != 'tag' || startsWith(github.ref, 'refs/tags/tket-eccs-v') }}
 
-  build-publish:
-    name: Package and publish wheels
+  build:
+    name: Build and test wheels
     needs: check-tag
     runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-      # Used to upload release artifacts
-      contents: write
-      # Used to generate artifact attestation
-      attestations: write
     strategy:
       matrix:
         target:
@@ -101,30 +93,51 @@ jobs:
           uv run -f dist --with ${{ matrix.target.name }} --refresh-package ${{ matrix.target.name }} --no-project -- python -c "import ${{ matrix.target.name }}"
           uvx twine check --strict dist/*
 
+  release:
+    name: Release
+    needs: [check-tag, build]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-eccs-v') || github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-exts-v') }}
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+      # Used to upload release artifacts
+      contents: write
+      # Used to generate artifact attestation
+      attestations: write
+    steps:
+      - name: Check if the tag has an associated release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view ${{ github.ref_name }}
+          if [ $? -ne 0 ]; then
+            echo "No release found for tag ${{ github.ref_name }}"
+            exit 1
+          fi
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
       - name: Report
-        if: ${{ github.ref_type == 'tag' && matrix.target.run == 'true' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) }}
         run: |
           echo "Publishing to PyPI..."
           echo "Based on the following workflow variables, this is a new version tag push:"
           echo "  - event_name: ${{ github.event_name }}"
           echo "  - ref_type: ${{ github.ref_type }}"
           echo "  - ref: ${{ github.ref }}"
-
-      - name: Generate artifact attestation
-        if: ${{ github.ref_type == 'tag' && matrix.target.run == 'true' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) }}
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: "dist/*"
-
       - name: Publish package distributions to PyPI
-        if: ${{ github.ref_type == 'tag' && matrix.target.run == 'true' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
           skip-existing: true
 
       - name: Upload wheels to the release and un-draft it
-        if: ${{ github.ref_type == 'tag' && matrix.target.run == 'true' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -97,7 +97,7 @@ jobs:
     name: Release
     needs: [check-tag, build]
     runs-on: ubuntu-latest
-    if: ${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-eccs-v') || github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-exts-v') }}
+    if: ${{ github.ref_type == 'tag' && (startsWith(github.ref, 'refs/tags/tket-eccs-v') || startsWith(github.ref, 'refs/tags/tket-exts-v')) }}
     environment: release
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing

--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -4,8 +4,7 @@ name: Pure Python wheels 🐍
 # This does not include the main `tket-py` package, which is built using maturin.
 # See `python-wheels.yml` for that workflow.
 #
-# When running on a release event or as a workflow dispatch for a tag,
-# and if the tag matches `{package}-v*`,
+# When running on a tag push matching `{package}-v*`,
 # this workflow will publish the wheels to pypi.
 # If the version is already published, pypi just ignores it.
 
@@ -14,9 +13,9 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
+    tags:
+      - "tket-eccs-v*"
+      - "tket-exts-v*"
 
 env:
   # Pinned version for the uv package manager
@@ -24,7 +23,7 @@ env:
 
 jobs:
   # Check if the tag matches the package name,
-  # or if the workflow is running on a non-release event.
+  # or if the workflow is running on a non-tag event.
   check-tag:
     name: Check tag
     runs-on: ubuntu-latest
@@ -38,8 +37,8 @@ jobs:
           echo "run_exts=$RUN_EXTS" >> $GITHUB_OUTPUT
           echo "run_eccs=$RUN_ECCS" >> $GITHUB_OUTPUT
         env:
-          RUN_EXTS: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-exts-v') ) }}
-          RUN_ECCS: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-eccs-v') ) }}
+          RUN_EXTS: ${{ github.ref_type != 'tag' || startsWith(github.ref, 'refs/tags/tket-exts-v') }}
+          RUN_ECCS: ${{ github.ref_type != 'tag' || startsWith(github.ref, 'refs/tags/tket-eccs-v') }}
 
   build-publish:
     name: Package and publish wheels
@@ -49,6 +48,10 @@ jobs:
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+      # Used to upload release artifacts
+      contents: write
+      # Used to generate artifact attestation
+      attestations: write
     strategy:
       matrix:
         target:
@@ -99,7 +102,7 @@ jobs:
           uvx twine check --strict dist/*
 
       - name: Report
-        if: ${{ (github.event_name == 'release' && matrix.target.run == 'true') || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) ) }}
+        if: ${{ github.ref_type == 'tag' && matrix.target.run == 'true' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) }}
         run: |
           echo "Publishing to PyPI..."
           echo "Based on the following workflow variables, this is a new version tag push:"
@@ -107,9 +110,25 @@ jobs:
           echo "  - ref_type: ${{ github.ref_type }}"
           echo "  - ref: ${{ github.ref }}"
 
+      - name: Generate artifact attestation
+        if: ${{ github.ref_type == 'tag' && matrix.target.run == 'true' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*"
+
       - name: Publish package distributions to PyPI
-        if: ${{ (github.event_name == 'release' && matrix.target.run == 'true') || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) ) }}
+        if: ${{ github.ref_type == 'tag' && matrix.target.run == 'true' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
           skip-existing: true
+
+      - name: Upload wheels to the release and un-draft it
+        if: ${{ github.ref_type == 'tag' && matrix.target.run == 'true' && startsWith(github.ref, format('refs/tags/{0}-v', matrix.target.dir)) }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Upload wheels to the release assets
+          gh release upload ${{ github.ref_name }} dist/*
+          # Un-draft the release on GitHub now that the package has been published to PyPI
+          gh release edit ${{ github.ref_name }} --draft=false

--- a/.github/workflows/python-qis-wheels.yml
+++ b/.github/workflows/python-qis-wheels.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
+    tags:
+      - "qis-compiler-v*"
   pull_request:
     # check builds work if qis-compiler build config changes
     paths:
@@ -23,7 +22,7 @@ env:
   UV_VERSION: "0.11.15"
 jobs:
   # Check if the tag matches the package name,
-  # or if the workflow is running on a non-release event.
+  # or if the workflow is running on a non-tag event.
   check-tag:
     name: Check tag
     runs-on: ubuntu-latest
@@ -35,7 +34,7 @@ jobs:
         run: |
           echo "run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         env:
-          SHOULD_RUN: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/qis-compiler-v') ) }}
+          SHOULD_RUN: ${{ github.ref_type != 'tag' || startsWith(github.ref, 'refs/tags/qis-compiler-v') }}
 
   build_qis_compiler_wheels:
     needs: check-tag
@@ -80,7 +79,7 @@ jobs:
   release:
     name: Release qis-compiler
     needs: [check-tag, build_qis_compiler_wheels]
-    if: ${{ needs.check-tag.outputs.run == 'true' && github.event_name == 'release' }}
+    if: ${{ needs.check-tag.outputs.run == 'true' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/qis-compiler-v') }}
     runs-on: ubuntu-latest
     # always do a full build and test before release of any package
     environment: release
@@ -88,11 +87,26 @@ jobs:
       contents: write
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
+      # Used to generate artifact attestation
+      attestations: write
     steps:
+      - name: Check if the tag has an associated release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view ${{ github.ref_name }}
+          if [ $? -ne 0 ]; then
+            echo "No release found for tag ${{ github.ref_name }}"
+            exit 1
+          fi
       - uses: actions/download-artifact@v8
         with:
           path: wheelhouse
           merge-multiple: true
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "wheelhouse/*"
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -100,3 +114,12 @@ jobs:
           verbose: true
           skip-existing: true
           packages-dir: wheelhouse
+
+      - name: Upload wheels to the release and un-draft it
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Upload wheels to the release assets
+          gh release upload ${{ github.ref_name }} wheelhouse/*
+          # Un-draft the release on GitHub now that the package has been published to PyPI
+          gh release edit ${{ github.ref_name }} --draft=false

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -12,9 +12,8 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - published
+    tags:
+      - "tket-py-v*"
   workflow_dispatch:
 
 permissions:
@@ -34,7 +33,7 @@ env:
 
 jobs:
   # Check if the tag matches the package name,
-  # or if the workflow is running on a non-release event.
+  # or if the workflow is running on a non-tag event.
   check-tag:
     name: Check tag
     runs-on: ubuntu-latest
@@ -46,7 +45,7 @@ jobs:
         run: |
           echo "run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         env:
-          SHOULD_RUN: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-py-v') ) }}
+          SHOULD_RUN: ${{ github.ref_type != 'tag' || startsWith(github.ref, 'refs/tags/tket-py-v') }}
 
   build:
     name: ${{ matrix.platform.target }}
@@ -283,7 +282,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-py-v') ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-py-v') ) }}
+    if: ${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/tket-py-v') }}
     needs: [build, sdist]
     environment: release
     permissions:
@@ -294,10 +293,23 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
+      - name: Check if the tag has an associated release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view ${{ github.ref_name }}
+          if [ $? -ne 0 ]; then
+            echo "No release found for tag ${{ github.ref_name }}"
+            exit 1
+          fi
       - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'dist/*'
       - name: Report
         run: |
           echo "Publishing to PyPI..."
@@ -310,3 +322,12 @@ jobs:
         with:
           verbose: true
           skip-existing: true
+
+      - name: Upload wheels to the release and un-draft it
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Upload wheels to the release assets
+          gh release upload ${{ github.ref_name }} dist/*
+          # Un-draft the release on GitHub now that the package has been published to PyPI
+          gh release edit ${{ github.ref_name }} --draft=false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,7 +30,8 @@
             "component": "tket-eccs",
             "package-name": "tket_eccs",
             "include-component-in-tag": true,
-            "draft": false,
+            "draft": true,
+            "force-tag-creation": true,
             "prerelease": false,
             "draft-pull-request": true,
             "extra-files": [
@@ -46,7 +47,8 @@
             "component": "tket-exts",
             "package-name": "tket_exts",
             "include-component-in-tag": true,
-            "draft": false,
+            "draft": true,
+            "force-tag-creation": true,
             "prerelease": false,
             "draft-pull-request": true,
             "extra-files": [
@@ -62,7 +64,8 @@
             "component": "qis-compiler",
             "package-name": "selene_hugr_qis_compiler",
             "include-component-in-tag": true,
-            "draft": false,
+            "draft": true,
+            "force-tag-creation": true,
             "prerelease": false,
             "draft-pull-request": true,
             "extra-files": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,8 @@
             "component": "tket-py",
             "package-name": "tket",
             "include-component-in-tag": true,
-            "draft": false,
+            "draft": true,
+            "force-tag-creation": true,
             "prerelease": false,
             "draft-pull-request": true,
             "extra-files": [


### PR DESCRIPTION
Sets the `draft: true` option of release-please so python gh releases are first created as `draft` while the wheels are being built. We mark it as ready only after submitting to pypi.

I tried this once before but had problems with github not triggering workflows on draft releases. The solution is to set `force-tag-creation: true` in release-please, and use the tag as a trigger instead.

Additionally:
- Added provenance attestations to the built wheels.
- We now upload the wheels to the release artifacts in addition to Pypi.
- Splits the `python-pure-wheels` workflow so only the actual publishing is run inside the `release` environment. We do this already in the other two workflows.

This is a better solution that what we do now in `hugr`; creating a full release and marking it as draft at the start of the wheels building workflow. I'll migrate this new config once we verify it works correctly.