### PR TITLE
refactor!: Deprecate commands iterator

### DIFF
--- a/tket-py/src/passes.rs
+++ b/tket-py/src/passes.rs
@@ -5,6 +5,7 @@ mod inline_funcs;
 mod scope;
 pub mod tket1;
 
+use hugr::HugrView;
 pub(crate) use scope::PyPassScope;
 
 use std::{cmp::min, convert::TryInto, fs, num::NonZeroUsize, path::PathBuf};
@@ -12,7 +13,7 @@ use std::{cmp::min, convert::TryInto, fs, num::NonZeroUsize, path::PathBuf};
 use pyo3::prelude::*;
 use tket::optimiser::badger::BadgerOptions;
 use tket::passes::composable::{ComposablePass, WithScope};
-use tket::{Circuit, TketOp, op_matches};
+use tket::{Circuit, TketOp};
 
 use tket::passes;
 
@@ -175,8 +176,9 @@ fn badger_optimise(
     // Optimise
     let c = Circuit::new(&circ.hugr);
     let n_cx = c
-        .commands()
-        .filter(|c| op_matches(c.optype(), TketOp::CX))
+        .toposorted_children(c.parent())
+        .expect("circuit entrypoint should be dataflow region")
+        .filter(|&n| c.hugr().get_optype(n).cast::<TketOp>() == Some(TketOp::CX))
         .count();
     let n_threads = min(
         (n_cx / 50).try_into().unwrap_or(1.try_into().unwrap()),

--- a/tket-py/src/state/cost.rs
+++ b/tket-py/src/state/cost.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Sub};
 
+use pyo3::types::PyAnyMethods;
 use pyo3::{Py, PyAny, PyResult, Python, pyclass, pymethods};
 use tket::circuit::cost::{CircuitCost, CostDelta};
 
@@ -31,11 +32,22 @@ impl Default for PyCircuitCost {
     }
 }
 
+/// Returns whether `cost` is the internal no-cost sentinel (a python `None` value).
+fn is_no_cost(cost: &Py<PyAny>, py: Python<'_>) -> bool {
+    cost.bind(py).is_none()
+}
+
 impl Add for PyCircuitCost {
     type Output = PyCircuitCost;
 
     fn add(self, rhs: PyCircuitCost) -> Self::Output {
         Python::attach(|py| {
+            if is_no_cost(&self.cost, py) {
+                return rhs;
+            }
+            if is_no_cost(&rhs.cost, py) {
+                return self;
+            }
             let cost = self
                 .cost
                 .call_method1(py, "__add__", (rhs.cost,))
@@ -48,6 +60,13 @@ impl Add for PyCircuitCost {
 impl AddAssign for PyCircuitCost {
     fn add_assign(&mut self, rhs: Self) {
         Python::attach(|py| {
+            if is_no_cost(&rhs.cost, py) {
+                return;
+            }
+            if is_no_cost(&self.cost, py) {
+                self.cost = rhs.cost;
+                return;
+            }
             let cost = self
                 .cost
                 .call_method1(py, "__add__", (rhs.cost,))
@@ -62,6 +81,9 @@ impl Sub for PyCircuitCost {
 
     fn sub(self, rhs: PyCircuitCost) -> Self::Output {
         Python::attach(|py| {
+            if is_no_cost(&rhs.cost, py) {
+                return self;
+            }
             let cost = self
                 .cost
                 .call_method1(py, "__sub__", (rhs.cost,))
@@ -76,6 +98,9 @@ impl Sum for PyCircuitCost {
         Python::attach(|py| {
             let cost = iter
                 .fold(None, |acc: Option<Py<PyAny>>, c| {
+                    if is_no_cost(&c.cost, py) {
+                        return acc;
+                    }
                     Some(match acc {
                         None => c.cost,
                         Some(cost) => cost

--- a/tket-qsystem/src/extension/qsystem/lower.rs
+++ b/tket-qsystem/src/extension/qsystem/lower.rs
@@ -392,8 +392,9 @@ mod test {
         assert_eq!(lowered.len(), 5);
         let circ = Circuit::new(&h);
         let ops: Vec<QSystemOp> = circ
-            .commands()
-            .filter_map(|com| com.optype().cast())
+            .toposorted_children(circ.parent())
+            .expect("circuit entrypoint should be dataflow region")
+            .filter_map(|n| circ.hugr().get_optype(n).cast())
             .collect();
         assert_eq!(
             ops,
@@ -437,8 +438,9 @@ mod test {
         let h = build_func(t2op).unwrap();
         let circ = Circuit::new(&h);
         let ops: Vec<QSystemOp> = circ
-            .commands()
-            .filter_map(|com| com.optype().cast())
+            .toposorted_children(circ.parent())
+            .expect("circuit entrypoint should be dataflow region")
+            .filter_map(|n| circ.hugr().get_optype(n).cast())
             .collect();
         if let Some(qsystem_ops) = qsystem_ops {
             assert_eq!(ops, qsystem_ops);

--- a/tket/src/circuit.rs
+++ b/tket/src/circuit.rs
@@ -318,7 +318,7 @@ impl<T: HugrView<Node = Node>> Circuit<T> {
     #[inline]
     #[deprecated(
         since = "0.19.0",
-        note = "This is a limited API that will be dropped soon. Use toposorting over `hugr.scheduling_graph()` instead."
+        note = "This is a limited API that will be dropped soon. Use toposorting over `HugrView::scheduling_graph` instead.\n<https://docs.rs/hugr/latest/hugr/trait.HugrView.html#method.scheduling_graph>"
     )]
     #[expect(deprecated)]
     pub fn commands(&self) -> CommandIterator<'_, T>
@@ -339,7 +339,7 @@ impl<T: HugrView<Node = Node>> Circuit<T> {
     #[inline]
     #[deprecated(
         since = "0.19.0",
-        note = "This is a limited API that will be dropped soon. Use toposorting over `hugr.scheduling_graph()` instead."
+        note = "This is a limited API that will be dropped soon. Use toposorting over `HugrView::scheduling_graph` instead.\n<https://docs.rs/hugr/latest/hugr/trait.HugrView.html#method.scheduling_graph>"
     )]
     #[expect(deprecated)]
     pub fn operations(&self) -> impl Iterator<Item = Command<'_, T>> + '_

--- a/tket/src/circuit.rs
+++ b/tket/src/circuit.rs
@@ -10,6 +10,7 @@ use std::collections::HashSet;
 use std::iter::Sum;
 
 use crate::passes::utils::hash::{HashError, HugrHash};
+#[expect(deprecated)]
 pub use command::{Command, CommandIterator};
 use hugr::extension::prelude::{NoopDef, TupleOpDef};
 use hugr::extension::simple_op::MakeOpDef;
@@ -27,6 +28,7 @@ use hugr::{Hugr, PortIndex};
 use hugr::{HugrView, OutgoingPort};
 use itertools::Itertools;
 use lazy_static::lazy_static;
+use petgraph::visit::{Topo, Walker as _};
 
 pub use hugr::ops::OpType;
 pub use hugr::types::{EdgeKind, Type, TypeRow};
@@ -314,6 +316,11 @@ impl<T: HugrView<Node = Node>> Circuit<T> {
     ///
     /// Ignores the Input and Output nodes.
     #[inline]
+    #[deprecated(
+        since = "0.19.0",
+        note = "This is a limited API that will be dropped soon. Use toposorting over `hugr.scheduling_graph()` instead."
+    )]
+    #[expect(deprecated)]
     pub fn commands(&self) -> CommandIterator<'_, T>
     where
         Self: Sized,
@@ -330,6 +337,11 @@ impl<T: HugrView<Node = Node>> Circuit<T> {
     ///
     ///   [`TketOp`]: crate::TketOp
     #[inline]
+    #[deprecated(
+        since = "0.19.0",
+        note = "This is a limited API that will be dropped soon. Use toposorting over `hugr.scheduling_graph()` instead."
+    )]
+    #[expect(deprecated)]
     pub fn operations(&self) -> impl Iterator<Item = Command<'_, T>> + '_
     where
         Self: Sized,
@@ -366,6 +378,8 @@ impl<T: HugrView<Node = Node>> Circuit<T> {
     }
 
     /// Compute the cost of the circuit based on a per-operation cost function.
+    ///
+    /// This will include all operations in the circuit, including nested regions.
     #[inline]
     pub fn circuit_cost<F, C>(&self, op_cost: F) -> C
     where
@@ -373,7 +387,53 @@ impl<T: HugrView<Node = Node>> Circuit<T> {
         C: Sum,
         F: Fn(&OpType) -> C,
     {
-        self.commands().map(|cmd| op_cost(cmd.optype())).sum()
+        self.hugr
+            .entry_descendants()
+            .map(|node| op_cost(self.hugr.get_optype(node)))
+            .sum()
+    }
+
+    /// Count the number of operations that match the predicate in the Hugr.
+    ///
+    /// This will include all operations in the circuit, including nested regions.
+    #[inline]
+    pub fn count_ops<P>(&self, predicate: P) -> usize
+    where
+        Self: Sized,
+        P: Fn(&OpType) -> bool,
+    {
+        self.hugr
+            .entry_descendants()
+            .filter(|&node| predicate(self.hugr.get_optype(node)))
+            .count()
+    }
+
+    /// Returns the nodes in a dataflow region, in topological order.
+    ///
+    /// The region Input and Output nodes are omitted.
+    ///
+    /// Returns `None` if `parent` is not a dataflow region.
+    pub fn toposorted_children(&self, parent: Node) -> Option<impl Iterator<Item = Node> + '_>
+    where
+        Self: Sized,
+    {
+        let io_nodes = self.hugr.get_io(parent)?;
+        let scheduling_graph = self.hugr.scheduling_graph(parent);
+        let petgraph = scheduling_graph.petgraph();
+        Some(
+            Topo::new(petgraph)
+                .iter(petgraph)
+                .filter_map(|pg_node| {
+                    let node = scheduling_graph.pg_to_node(pg_node);
+                    (node != io_nodes[0] && node != io_nodes[1]).then_some(node)
+                })
+                // We cannot currently keep a `Topo` alive outside of this function,
+                // since the return type of `SchedulingGraph::petgraph` cannot be named.
+                //
+                // Instead we are forced to eagerly compute the node list.
+                .collect_vec()
+                .into_iter(),
+        )
     }
 }
 

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -233,7 +233,7 @@ impl<T: HugrView> std::hash::Hash for Command<'_, T> {
 #[derive(Clone)]
 #[deprecated(
     since = "0.19.0",
-    note = "This is a limited API that will be dropped soon. Use toposorting over `hugr.scheduling_graph()` instead."
+    note = "This is a limited API that will be dropped soon. Use toposorting over `HugrView::scheduling_graph` instead.\n<https://docs.rs/hugr/latest/hugr/trait.HugrView.html#method.scheduling_graph>"
 )]
 pub struct CommandIterator<'circ, T: HugrView> {
     /// The circuit.

--- a/tket/src/circuit/command.rs
+++ b/tket/src/circuit/command.rs
@@ -230,9 +230,11 @@ impl<T: HugrView> std::hash::Hash for Command<'_, T> {
 }
 
 /// An iterator over the commands of a circuit.
-// TODO: this can only be made generic over node type once `SiblingGraph` is
-// generic over node type. See https://github.com/quantinuum/hugr/issues/1926
 #[derive(Clone)]
+#[deprecated(
+    since = "0.19.0",
+    note = "This is a limited API that will be dropped soon. Use toposorting over `hugr.scheduling_graph()` instead."
+)]
 pub struct CommandIterator<'circ, T: HugrView> {
     /// The circuit.
     circ: &'circ Circuit<T>,
@@ -262,13 +264,12 @@ pub struct CommandIterator<'circ, T: HugrView> {
     delayed_node: Option<Node>,
 }
 
+#[expect(deprecated)]
 impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     /// Create a new iterator over the commands of a circuit.
     pub(super) fn new(circ: &'circ Circuit<T>) -> Self {
         // Initialize the map assigning linear units to the input's linear
         // ports.
-        //
-        // TODO: `with_wires` combinator for `Units`?
         let wire_unit = circ
             .linear_units()
             .map(|(linear_unit, port, _)| (Wire::new(circ.input_node(), port), linear_unit.index()))
@@ -443,6 +444,7 @@ impl<'circ, T: HugrView<Node = Node>> CommandIterator<'circ, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'circ, T: HugrView<Node = Node>> Iterator for CommandIterator<'circ, T> {
     type Item = Command<'circ, T>;
 
@@ -469,8 +471,10 @@ impl<'circ, T: HugrView<Node = Node>> Iterator for CommandIterator<'circ, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: HugrView<Node = Node>> FusedIterator for CommandIterator<'_, T> {}
 
+#[expect(deprecated)]
 impl<T: HugrView<Node = Node>> std::fmt::Debug for CommandIterator<'_, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CommandIterator")
@@ -482,6 +486,7 @@ impl<T: HugrView<Node = Node>> std::fmt::Debug for CommandIterator<'_, T> {
 }
 
 #[cfg(test)]
+#[expect(deprecated)]
 mod test {
     use hugr::builder::{Container, DFGBuilder, Dataflow, DataflowHugr};
     use hugr::extension::prelude::qb_t;

--- a/tket/src/circuit/cost.rs
+++ b/tket/src/circuit/cost.rs
@@ -8,7 +8,6 @@ use std::num::NonZeroUsize;
 use std::ops::{Add, AddAssign};
 
 use crate::TketOp;
-use crate::ops::op_matches;
 
 /// The cost for a group of operations in a circuit, each with cost `OpCost`.
 pub trait CircuitCost: Add<Output = Self> + Sum<Self> + Debug + Default + Clone + Ord {
@@ -183,15 +182,12 @@ impl CircuitCost for usize {
 
 /// Returns true if the operation is a controlled X operation.
 pub fn is_cx(op: &OpType) -> bool {
-    op_matches(op, TketOp::CX)
+    op.cast::<TketOp>() == Some(TketOp::CX)
 }
 
 /// Returns true if the operation is a quantum operation.
 pub fn is_quantum(op: &OpType) -> bool {
-    let Some(op): Option<TketOp> = op.cast() else {
-        return false;
-    };
-    op.is_quantum()
+    op.cast::<TketOp>().is_some_and(|op| op.is_quantum())
 }
 
 #[cfg(test)]

--- a/tket/src/lib.rs
+++ b/tket/src/lib.rs
@@ -68,7 +68,9 @@ mod utils;
 pub use circuit::{Circuit, CircuitError, CircuitMutError};
 pub use hugr;
 pub use hugr::Hugr;
-pub use ops::{Pauli, TketOp, op_matches, symbolic_constant_op};
+#[expect(deprecated)]
+pub use ops::op_matches;
+pub use ops::{Pauli, TketOp, symbolic_constant_op};
 
 #[doc = include_str!("../README.md")]
 #[cfg(doctest)]

--- a/tket/src/lib.rs
+++ b/tket/src/lib.rs
@@ -30,9 +30,9 @@
 //! assert_eq!(circ.qubit_count(), 9);
 //! assert_eq!(circ.num_operations(), 170);
 //!
-//! // Traverse the circuit and print the gates.
-//! for command in circ.commands() {
-//!     println!("{:?}", command.optype());
+//! // Traverse the circuit nodes and print the gates.
+//! for node in circ.toposorted_children(circ.parent()).unwrap() {
+//!     println!("{}", circ.hugr().get_optype(node));
 //! }
 //!
 //! // Render the circuit as a mermaid diagram.

--- a/tket/src/ops.rs
+++ b/tket/src/ops.rs
@@ -361,7 +361,7 @@ pub(crate) mod test {
     use hugr::types::Signature;
     use hugr::{CircuitUnit, HugrView, type_row};
     use itertools::Itertools;
-    use rstest::{fixture, rstest};
+    use rstest::fixture;
     use strum::IntoEnumIterator;
 
     use super::TketOp;
@@ -393,11 +393,6 @@ pub(crate) mod test {
         h.unwrap()
     }
 
-    #[rstest]
-    fn check_t2_bell(t2_bell_circuit: Circuit) {
-        assert_eq!(t2_bell_circuit.commands().count(), 2);
-    }
-
     #[test]
     fn ancilla_circ() {
         let h = build_simple_circuit(1, |circ| {
@@ -416,8 +411,7 @@ pub(crate) mod test {
         })
         .unwrap();
 
-        // 5 commands: alloc, reset, cx, measure, free
-        assert_eq!(h.commands().count(), 5);
+        assert_eq!(h.count_ops(|op| op.cast::<TketOp>().is_some()), 5);
     }
 
     #[test]

--- a/tket/src/ops.rs
+++ b/tket/src/ops.rs
@@ -353,7 +353,7 @@ pub fn symbolic_constant_op(arg: String) -> OpType {
 }
 
 #[cfg(test)]
-pub(crate) mod test {
+pub mod test {
 
     use std::str::FromStr;
     use std::sync::Arc;
@@ -365,12 +365,10 @@ pub(crate) mod test {
     use hugr::types::Signature;
     use hugr::{CircuitUnit, HugrView, type_row};
     use itertools::Itertools;
-    use rstest::fixture;
     use strum::IntoEnumIterator;
 
     use super::TketOp;
     use crate::Pauli;
-    use crate::circuit::Circuit;
     use crate::extension::bool::bool_type;
     use crate::extension::{TKET_EXTENSION as EXTENSION, TKET_EXTENSION_ID as EXTENSION_ID};
     use crate::utils::build_simple_circuit;
@@ -384,17 +382,6 @@ pub(crate) mod test {
         for o in TketOp::iter() {
             assert_eq!(TketOp::from_def(get_opdef(o).unwrap()), Ok(o));
         }
-    }
-
-    #[fixture]
-    pub(crate) fn t2_bell_circuit() -> Circuit {
-        let h = build_simple_circuit(2, |circ| {
-            circ.append(TketOp::H, [0])?;
-            circ.append(TketOp::CX, [0, 1])?;
-            Ok(())
-        });
-
-        h.unwrap()
     }
 
     #[test]

--- a/tket/src/ops.rs
+++ b/tket/src/ops.rs
@@ -240,6 +240,10 @@ impl TketOp {
 }
 
 /// Whether an op is a given TketOp.
+#[deprecated(
+    since = "0.19.0",
+    note = "Use `op.cast::<TketOp>() == Some(TketOp::...)` instead"
+)]
 pub fn op_matches(op: &OpType, tket_op: TketOp) -> bool {
     op.to_string() == tket_op.exposed_name()
 }

--- a/tket/src/optimiser/badger.rs
+++ b/tket/src/optimiser/badger.rs
@@ -538,8 +538,9 @@ mod tests {
 
     use super::{BadgerOptimiser, ECCBadgerOptimiser};
 
-    /// Returns a vector of `TketOp` nodes in the entrypoint region, in topological order.
-    fn entrypoint_tket_ops(circ: &Circuit) -> Vec<Node> {
+    /// Returns a vector of `TketOp` or `RotationOp` nodes in the entrypoint
+    /// region, in topological order.
+    fn entrypoint_tket_or_rotation_ops(circ: &Circuit) -> Vec<Node> {
         circ.toposorted_children(circ.parent())
             .expect("circuit entrypoint should be dataflow region")
             .filter(|&n| {
@@ -619,8 +620,6 @@ mod tests {
     #[case::compiled(badger_opt_compiled())]
     #[case::json(badger_opt_json())]
     fn rz_rz_cancellation(rz_rz: Circuit, #[case] badger_opt: ECCBadgerOptimiser) {
-        use hugr::ops::OpType;
-
         let opt_rz = badger_opt.optimise(
             &rz_rz,
             BadgerOptions {
@@ -628,7 +627,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let [op1, op2]: [&OpType; 2] = entrypoint_tket_ops(&opt_rz)
+        let [op1, op2] = entrypoint_tket_or_rotation_ops(&opt_rz)
             .into_iter()
             .map(|node| opt_rz.hugr().get_optype(node))
             .collect_array()
@@ -670,7 +669,7 @@ mod tests {
             },
         );
         opt_rz.hugr().validate().unwrap();
-        assert_eq!(entrypoint_tket_ops(&opt_rz).len(), 2);
+        assert_eq!(entrypoint_tket_or_rotation_ops(&opt_rz).len(), 2);
     }
 
     #[rstest]

--- a/tket/src/optimiser/badger.rs
+++ b/tket/src/optimiser/badger.rs
@@ -520,20 +520,34 @@ pub use badger_default::{DefaultBadgerStrategy, ECCBadgerOptimiser};
 #[cfg(test)]
 #[cfg(feature = "portmatching")]
 mod tests {
+    use hugr::Node;
     use hugr::{
         HugrView,
         builder::{DFGBuilder, Dataflow, DataflowHugr},
         extension::prelude::qb_t,
         types::Signature,
     };
+    use itertools::Itertools;
     use rstest::{fixture, rstest};
 
+    use crate::extension::rotation::RotationOp;
     use crate::serialize::load_tk1_json_str;
     use crate::serialize::pytket::DecodeOptions;
     use crate::{Circuit, TketOp};
     use crate::{extension::rotation::rotation_type, optimiser::badger::BadgerOptions};
 
     use super::{BadgerOptimiser, ECCBadgerOptimiser};
+
+    /// Returns a vector of `TketOp` nodes in the entrypoint region, in topological order.
+    fn entrypoint_tket_ops(circ: &Circuit) -> Vec<Node> {
+        circ.toposorted_children(circ.parent())
+            .expect("circuit entrypoint should be dataflow region")
+            .filter(|&n| {
+                let op = circ.hugr().get_optype(n);
+                op.cast::<TketOp>().is_some() || op.cast::<RotationOp>().is_some()
+            })
+            .collect_vec()
+    }
 
     #[fixture]
     fn rz_rz() -> Circuit {
@@ -616,11 +630,10 @@ mod tests {
                 ..Default::default()
             },
         );
-        let [op1, op2]: [&OpType; 2] = opt_rz
-            .commands()
-            .map(|cmd| cmd.optype())
-            .collect::<Vec<_>>()
-            .try_into()
+        let [op1, op2]: [&OpType; 2] = entrypoint_tket_ops(&opt_rz)
+            .into_iter()
+            .map(|node| opt_rz.hugr().get_optype(node))
+            .collect_array()
             .unwrap();
 
         // Rzs combined into a single one.
@@ -659,7 +672,7 @@ mod tests {
             },
         );
         opt_rz.hugr().validate().unwrap();
-        assert_eq!(opt_rz.commands().count(), 2);
+        assert_eq!(entrypoint_tket_ops(&opt_rz).len(), 2);
     }
 
     #[rstest]

--- a/tket/src/optimiser/badger.rs
+++ b/tket/src/optimiser/badger.rs
@@ -621,8 +621,6 @@ mod tests {
     fn rz_rz_cancellation(rz_rz: Circuit, #[case] badger_opt: ECCBadgerOptimiser) {
         use hugr::ops::OpType;
 
-        use crate::{extension::rotation::RotationOp, op_matches};
-
         let opt_rz = badger_opt.optimise(
             &rz_rz,
             BadgerOptions {
@@ -638,7 +636,7 @@ mod tests {
 
         // Rzs combined into a single one.
         assert_eq!(op1.cast(), Some(RotationOp::radd));
-        assert!(op_matches(op2, TketOp::Rz));
+        assert_eq!(op2.cast(), Some(TketOp::Rz));
     }
 
     #[rstest]

--- a/tket/src/passes/commutation.rs
+++ b/tket/src/passes/commutation.rs
@@ -6,58 +6,64 @@ use derive_more::{Display, Error, From};
 use hugr::hugr::Patch;
 use hugr::hugr::patch::PatchVerification;
 use hugr::hugr::{HugrError, hugrmut::HugrMut};
-use hugr::{CircuitUnit, Direction, HugrView, Node, Port, PortIndex};
+use hugr::{Direction, HugrView, Node, Port, PortIndex};
 use itertools::Itertools;
-use portgraph::PortOffset;
 
 use crate::Circuit;
 use crate::{
-    circuit::command::Command,
     ops::{Pauli, TketOp},
+    resource::{ResourceId, ResourceScope},
 };
 
-type Qb = crate::circuit::units::LinearUnit;
+type Qb = ResourceId;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 // remove once https://github.com/quantinuum-DEV/tket2/issues/126 is resolved
 struct ComCommand {
     /// The operation node.
     node: Node,
-    /// An assignment of linear units to the node's ports.
+    /// The resources connected to the node's input ports.
     //
     // We'll need something more complex if `follow_linear_port` stops being a
     // direct map from input to output.
-    inputs: Vec<CircuitUnit>,
+    resources: Vec<ResourcePorts>,
 }
 
-impl<'c, T: HugrView<Node = Node>> From<Command<'c, T>> for ComCommand {
-    fn from(com: Command<'c, T>) -> Self {
-        ComCommand {
-            node: com.node(),
-            inputs: com.inputs().map(|(c, _, _)| c).collect(),
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct ResourcePorts {
+    resource: Qb,
+    input: Port,
+    output: Option<Port>,
 }
+
 impl ComCommand {
+    fn from_scope<H: HugrView<Node = Node>>(scope: &ResourceScope<H>, node: Node) -> Option<Self> {
+        let resources = scope
+            .get_resources(node, Direction::Incoming)
+            .map(|resource| ResourcePorts {
+                resource,
+                input: scope
+                    .get_port(node, resource, Direction::Incoming)
+                    .expect("resource comes from an input port"),
+                output: scope.get_port(node, resource, Direction::Outgoing),
+            })
+            .collect_vec();
+
+        (!resources.is_empty()).then_some(Self { node, resources })
+    }
+
     fn node(&self) -> Node {
         self.node
     }
     fn qubits(&self) -> impl Iterator<Item = Qb> + '_ {
-        self.inputs.iter().filter_map(|u| {
-            let CircuitUnit::Linear(i) = u else {
-                return None;
-            };
-            Some(Qb::new(*i))
-        })
+        self.resources.iter().map(|ports| ports.resource)
     }
     fn port_of_qb(&self, qb: Qb, direction: Direction) -> Option<Port> {
-        self.inputs
-            .iter()
-            .position(|cu| {
-                let q_cu: CircuitUnit = qb.into();
-                cu == &q_cu
-            })
-            .map(|i| PortOffset::new(direction, i).into())
+        let ports = self.resources.iter().find(|ports| ports.resource == qb)?;
+        match direction {
+            Direction::Incoming => Some(ports.input),
+            Direction::Outgoing => ports.output,
+        }
     }
 }
 
@@ -66,33 +72,54 @@ type SliceVec = Vec<Slice>;
 
 fn add_to_slice(slice: &mut Slice, com: Rc<ComCommand>) {
     for q in com.qubits() {
-        slice[q.index()] = Some(com.clone());
+        slice[q.as_usize()] = Some(com.clone());
     }
 }
 
-fn load_slices(circ: &Circuit<impl HugrView<Node = Node>>) -> SliceVec {
+fn ensure_resource_slot(
+    qubit_free_slice: &mut Vec<usize>,
+    slices: &mut SliceVec,
+    resource: ResourceId,
+) {
+    let resource_index = resource.as_usize();
+    if resource_index < qubit_free_slice.len() {
+        return;
+    }
+    let new_len = resource_index + 1;
+    qubit_free_slice.resize(new_len, 0);
+    for slice in slices {
+        slice.resize(new_len, None);
+    }
+}
+
+fn load_slices(circ: &Circuit) -> SliceVec {
     let mut slices = vec![];
+    let scope = ResourceScope::from_circuit_ref(circ);
 
     let n_qbs = circ.qubit_count();
     let mut qubit_free_slice = vec![0; n_qbs];
 
     for command in circ
-        .commands()
-        .filter(|c| is_slice_op(circ.hugr(), c.node()))
+        .toposorted_children(circ.parent())
+        .expect("circuit entrypoint should be dataflow region")
+        .filter(|&node| is_slice_op(circ.hugr(), node))
+        .filter_map(|node| ComCommand::from_scope(&scope, node))
     {
-        let command: ComCommand = command.into();
+        for q in command.qubits() {
+            ensure_resource_slot(&mut qubit_free_slice, &mut slices, q);
+        }
         let free_slice = command
             .qubits()
-            .map(|qb| qubit_free_slice[qb.index()])
+            .map(|qb| qubit_free_slice[qb.as_usize()])
             .max()
             .unwrap();
 
         for q in command.qubits() {
-            qubit_free_slice[q.index()] = free_slice + 1;
+            qubit_free_slice[q.as_usize()] = free_slice + 1;
         }
         if free_slice >= slices.len() {
             debug_assert!(free_slice == slices.len());
-            slices.push(vec![None; n_qbs]);
+            slices.push(vec![None; qubit_free_slice.len()]);
         }
         let command = Rc::new(command);
         add_to_slice(&mut slices[free_slice], command);
@@ -120,7 +147,7 @@ fn available_slice(
         // if all qubit slots are empty here the command can be moved here
         if command
             .qubits()
-            .all(|q| slice_vec[slice_index][q.index()].is_none())
+            .all(|q| slice_vec[slice_index][q.as_usize()].is_none())
         {
             available = Some((slice_index, prev_nodes.clone()));
         } else if slice_index == 0 {
@@ -152,7 +179,7 @@ fn commutes_at_slice(
 
     for q in command.qubits() {
         // if slot is empty, continue checking.
-        let Some(other_com) = &slice[q.index()] else {
+        let Some(other_com) = &slice[q.as_usize()] else {
             continue;
         };
 
@@ -241,7 +268,9 @@ impl<H: HugrMut<Node = Node>> Patch<H> for PullForward {
         let qb_port = |command: &ComCommand, qb, direction| {
             command
                 .port_of_qb(qb, direction)
-                .ok_or(PullForwardError::NoQbInCommand { qubit: qb.index() })
+                .ok_or(PullForwardError::NoQbInCommand {
+                    qubit: qb.as_usize(),
+                })
         };
         // for each qubit, disconnect node and reconnect at destination.
         for qb in command.qubits() {
@@ -260,7 +289,9 @@ impl<H: HugrMut<Node = Node>> Patch<H> for PullForward {
                 .unwrap();
 
             let Some(new_neighbour_com) = new_nexts.get(&qb) else {
-                return Err(PullForwardError::NoCommandForQb { qubit: qb.index() });
+                return Err(PullForwardError::NoCommandForQb {
+                    qubit: qb.as_usize(),
+                });
             };
             if new_neighbour_com == &command {
                 // do not need to commute along this qubit.
@@ -322,8 +353,8 @@ pub fn apply_greedy_commutation(circ: &mut Circuit) -> Result<u32, PullForwardEr
                 "Avoid mutating slices we haven't got to yet."
             );
             for q in command.qubits() {
-                let com = slice_vec[slice_index][q.index()].take();
-                slice_vec[destination][q.index()] = com;
+                let com = slice_vec[slice_index][q.as_usize()].take();
+                slice_vec[destination][q.as_usize()] = com;
             }
             let rewrite = PullForward { command, new_nexts };
             circ.hugr_mut().apply_patch(rewrite)?;
@@ -340,6 +371,7 @@ mod test {
         extension::rotation::rotation_type, ops::test::t2_bell_circuit, utils::build_simple_circuit,
     };
     use hugr::{
+        CircuitUnit,
         builder::{DFGBuilder, Dataflow, DataflowHugr},
         extension::prelude::{bool_t, qb_t},
         types::Signature,
@@ -516,10 +548,19 @@ mod test {
             .collect()
     }
 
+    fn slice_commands(circ: &Circuit) -> Vec<ComCommand> {
+        let scope = ResourceScope::from_circuit_ref(circ);
+        circ.toposorted_children(circ.parent())
+            .expect("circuit entrypoint should be dataflow region")
+            .filter(|&node| is_slice_op(circ.hugr(), node))
+            .filter_map(|node| ComCommand::from_scope(&scope, node))
+            .collect()
+    }
+
     #[rstest]
     fn test_load_slices_cx(example_cx: Circuit) {
         let circ = example_cx;
-        let commands: Vec<ComCommand> = circ.commands().map_into().collect();
+        let commands = slice_commands(&circ);
         let slices = load_slices(&circ);
         let correct = slice_from_command(&commands, 4, &[&[0], &[1], &[2]]);
 
@@ -529,7 +570,7 @@ mod test {
     #[rstest]
     fn test_load_slices_cx_better(example_cx_better: Circuit) {
         let circ = example_cx_better;
-        let commands: Vec<ComCommand> = circ.commands().map_into().collect();
+        let commands = slice_commands(&circ);
 
         let slices = load_slices(&circ);
         let correct = slice_from_command(&commands, 4, &[&[0, 1], &[2]]);
@@ -540,7 +581,7 @@ mod test {
     #[rstest]
     fn test_load_slices_bell(t2_bell_circuit: Circuit) {
         let circ = t2_bell_circuit;
-        let commands: Vec<ComCommand> = circ.commands().map_into().collect();
+        let commands = slice_commands(&circ);
 
         let slices = load_slices(&circ);
         let correct = slice_from_command(&commands, 2, &[&[0], &[1]]);

--- a/tket/src/passes/commutation.rs
+++ b/tket/src/passes/commutation.rs
@@ -367,9 +367,7 @@ pub fn apply_greedy_commutation(circ: &mut Circuit) -> Result<u32, PullForwardEr
 #[cfg(test)]
 mod test {
 
-    use crate::{
-        extension::rotation::rotation_type, ops::test::t2_bell_circuit, utils::build_simple_circuit,
-    };
+    use crate::{extension::rotation::rotation_type, utils::build_simple_circuit};
     use hugr::{
         CircuitUnit,
         builder::{DFGBuilder, Dataflow, DataflowHugr},
@@ -516,6 +514,17 @@ mod test {
             dfg.finish_hugr_with_outputs(outs)
         };
         build().unwrap().into()
+    }
+
+    #[fixture]
+    fn t2_bell_circuit() -> Circuit {
+        let h = build_simple_circuit(2, |circ| {
+            circ.append(TketOp::H, [0])?;
+            circ.append(TketOp::CX, [0, 1])?;
+            Ok(())
+        });
+
+        h.unwrap()
     }
 
     // bug https://github.com/quantinuum/tket2/issues/253

--- a/tket/src/passes/commutation.rs
+++ b/tket/src/passes/commutation.rs
@@ -18,7 +18,7 @@ use crate::{
 type Qb = ResourceId;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-// remove once https://github.com/quantinuum-DEV/tket2/issues/126 is resolved
+// remove once https://github.com/quantinuum/tket2/issues/126 is resolved
 struct ComCommand {
     /// The operation node.
     node: Node,

--- a/tket/src/passes/utils/chunks.rs
+++ b/tket/src/passes/utils/chunks.rs
@@ -287,16 +287,20 @@ impl CircuitChunks {
         let convex_checker = SchedGraphChecker::new(circ.sched_graph());
         let mut running_cost = C::default();
         let mut current_group = 0;
-        for (_, commands) in &circ.commands().map(|cmd| cmd.node()).chunk_by(|&node| {
-            let new_cost = running_cost.clone() + op_cost(hugr.get_optype(node));
-            if new_cost.sub_cost(&max_cost).as_isize() > 0 {
-                running_cost = C::default();
-                current_group += 1;
-            } else {
-                running_cost = new_cost;
-            }
-            current_group
-        }) {
+        for (_, commands) in &circ
+            .toposorted_children(circ.parent())
+            .expect("circuit entrypoint should be a dataflow region")
+            .chunk_by(|&node| {
+                let new_cost = running_cost.clone() + op_cost(hugr.get_optype(node));
+                if new_cost.sub_cost(&max_cost).as_isize() > 0 {
+                    running_cost = C::default();
+                    current_group += 1;
+                } else {
+                    running_cost = new_cost;
+                }
+                current_group
+            })
+        {
             chunks.push(Chunk::extract(circ, commands, &convex_checker));
         }
         Self {
@@ -553,8 +557,19 @@ mod test {
 
         reassembled.hugr_mut().validate().unwrap();
 
-        assert_eq!(reassembled.commands().count(), 1);
-        let h = reassembled.commands().next().unwrap().node();
+        let ops = reassembled
+            .toposorted_children(reassembled.parent())
+            .expect("circuit entrypoint should be dataflow region")
+            .filter(|&node| {
+                reassembled
+                    .hugr()
+                    .get_optype(node)
+                    .cast::<TketOp>()
+                    .is_some()
+            })
+            .collect_vec();
+        assert_eq!(ops.len(), 1);
+        let h = ops[0];
 
         let [inp, out] = reassembled.io_nodes();
         assert_eq!(

--- a/tket/src/portmatching/matcher.rs
+++ b/tket/src/portmatching/matcher.rs
@@ -277,8 +277,9 @@ impl PatternMatcher {
     ) -> impl Iterator<Item = PatternMatch> + 'a {
         let checker = SchedGraphChecker::new(circuit.sched_graph());
         circuit
-            .commands()
-            .flat_map(move |cmd| self.find_rooted_matches(circuit, cmd.node(), &checker))
+            .toposorted_children(circuit.parent())
+            .expect("circuit entrypoint should be dataflow region")
+            .flat_map(move |node| self.find_rooted_matches(circuit, node, &checker))
     }
 
     /// Find all convex pattern matches in a circuit.and collect in to a vector

--- a/tket/src/portmatching/pattern.rs
+++ b/tket/src/portmatching/pattern.rs
@@ -36,27 +36,31 @@ impl CircuitPattern {
             return Err(InvalidPattern::EmptyCircuit);
         }
         let mut pattern = Pattern::new();
-        for cmd in circuit.commands() {
-            let op = cmd.optype().clone();
-            pattern.require(cmd.node().into(), op.into());
-            for in_offset in 0..cmd.input_count() {
+        for node in circuit
+            .toposorted_children(circuit.parent())
+            .expect("circuit entrypoint should be dataflow region")
+        {
+            let op = hugr.get_optype(node).clone();
+            let input_count = op.value_input_count() + op.static_input_port().is_some() as usize;
+            pattern.require(node.into(), op.into());
+            for in_offset in 0..input_count {
                 let in_offset: IncomingPort = in_offset.into();
-                let edge_prop = PEdge::try_from_port(cmd.node(), in_offset.into(), circuit)
+                let edge_prop = PEdge::try_from_port(node, in_offset.into(), circuit)
                     .unwrap_or_else(|e| panic!("Invalid HUGR, {e}"));
                 let (prev_node, prev_port) = hugr
-                    .linked_outputs(cmd.node(), in_offset)
+                    .linked_outputs(node, in_offset)
                     .exactly_one()
                     .unwrap_or_else(|_| {
                         panic!(
                             "{} input port {in_offset} does not have a single neighbour",
-                            cmd.node()
+                            node
                         )
                     });
                 let prev_node = match edge_prop {
                     PEdge::InternalEdge { .. } => NodeID::HugrNode(prev_node),
                     PEdge::InputEdge { .. } => NodeID::new_copy(prev_node, prev_port),
                 };
-                pattern.add_edge(cmd.node().into(), prev_node, edge_prop);
+                pattern.add_edge(node.into(), prev_node, edge_prop);
             }
         }
         pattern.set_any_root()?;

--- a/tket/src/rewrite/strategy.rs
+++ b/tket/src/rewrite/strategy.rs
@@ -29,7 +29,7 @@ use hugr::{HugrView, Node};
 use itertools::Itertools;
 
 use crate::circuit::cost::{CircuitCost, CostDelta, LexicographicCost, is_cx, is_quantum};
-use crate::{Circuit, TketOp, op_matches};
+use crate::{Circuit, TketOp};
 
 use super::CircuitRewrite;
 use super::trace::RewriteTrace;
@@ -369,7 +369,7 @@ impl LexicographicCostFunction<fn(&OpType) -> usize, 2> {
     pub fn rz_count() -> Self {
         Self {
             cost_fns: [
-                |op| op_matches(op, TketOp::Rz) as usize,
+                |op| (op.cast() == Some(TketOp::Rz)) as usize,
                 |op| is_quantum(op) as usize,
             ],
         }

--- a/tket/src/rewrite/strategy.rs
+++ b/tket/src/rewrite/strategy.rs
@@ -520,10 +520,18 @@ mod tests {
         create_rewrite(&subcirc, circ, n_cx(10))
     }
 
+    /// Returns a vector of `TketOp` nodes in the entrypoint region, in topological order.
+    fn entrypoint_tket_ops(circ: &Circuit) -> Vec<Node> {
+        circ.toposorted_children(circ.parent())
+            .expect("circuit entrypoint should be dataflow region")
+            .filter(|&n| circ.hugr().get_optype(n).cast::<TketOp>().is_some())
+            .collect_vec()
+    }
+
     #[test]
     fn test_greedy_strategy() {
         let mut circ = n_cx(10);
-        let cx_gates = circ.commands().map(|cmd| cmd.node()).collect_vec();
+        let cx_gates = entrypoint_tket_ops(&circ);
 
         assert!(circ.rewrite_trace().is_none());
         circ.enable_rewrite_tracing();
@@ -552,7 +560,7 @@ mod tests {
     #[test]
     fn test_exhaustive_default_strategy() {
         let mut circ = n_cx(10);
-        let cx_gates = circ.commands().map(|cmd| cmd.node()).collect_vec();
+        let cx_gates = entrypoint_tket_ops(&circ);
         circ.enable_rewrite_tracing();
 
         let rws = [
@@ -589,7 +597,7 @@ mod tests {
     #[test]
     fn test_exhaustive_gamma_strategy() {
         let circ = n_cx(10);
-        let cx_gates = circ.commands().map(|cmd| cmd.node()).collect_vec();
+        let cx_gates = entrypoint_tket_ops(&circ);
 
         let rws = [
             rw_to_empty(&circ, cx_gates[0..2].to_vec()),

--- a/tket/tests/badger_termination.rs
+++ b/tket/tests/badger_termination.rs
@@ -55,7 +55,6 @@ fn simple_circ() -> Circuit {
 }
 
 #[rstest]
-//#[ignore = "Takes 200ms"]
 fn badger_termination(simple_circ: Circuit, nam_4_2: ECCBadgerOptimiser) {
     let opt_circ = nam_4_2.optimise(
         &simple_circ,

--- a/tket/tests/badger_termination.rs
+++ b/tket/tests/badger_termination.rs
@@ -2,11 +2,11 @@
 #![cfg(feature = "portmatching")]
 
 use rstest::{fixture, rstest};
-use tket::Circuit;
 use tket::optimiser::badger::BadgerOptions;
 use tket::optimiser::{BadgerOptimiser, ECCBadgerOptimiser};
 use tket::serialize::TKETDecode;
 use tket::serialize::pytket::DecodeOptions;
+use tket::{Circuit, TketOp};
 use tket_json_rs::circuit_json::SerialCircuit;
 
 /// A set of equivalence circuit classes (ECC)
@@ -64,5 +64,6 @@ fn badger_termination(simple_circ: Circuit, nam_4_2: ECCBadgerOptimiser) {
             ..Default::default()
         },
     );
-    assert_eq!(opt_circ.commands().count(), 11);
+
+    assert_eq!(opt_circ.count_ops(|op| op.cast::<TketOp>().is_some()), 4);
 }


### PR DESCRIPTION
The `CommandsIterator` was one of the first utilities defined in this repo, and is quite focused on pytket-style flat circuits with basic quantum operations, qubit wires, and bit wires.
This definition grew stale quickly, but it was used throughout the repo nonetheless.

This PR removes such uses and marks the definition as `deprecated`. We should be able to remove it on `tket 0.20.0`.

I added a `toposorted_children` and a `count_ops` method to `Circuit` to replace commands usage.
These will be moved to an extension trait in the future as part of #1060.

BREAKING CHANGE: `Circuit::circuit_cost` now computes the cost of all descendant nodes of a circuit, not just `TketOp`s.