### PR TITLE
chore: Swap and upgrade action for artifact attestations

### DIFF
--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -121,7 +121,7 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-path: "dist/*"
       - name: Report

--- a/.github/workflows/python-qis-wheels.yml
+++ b/.github/workflows/python-qis-wheels.yml
@@ -104,7 +104,7 @@ jobs:
           path: wheelhouse
           merge-multiple: true
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-path: "wheelhouse/*"
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -307,7 +307,7 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-path: 'dist/*'
       - name: Report


### PR DESCRIPTION
In light of the pending upgrade in #1616, swaps the `attest-build-provenance` for the `attest` action, since the former is (after the upgrade) only a wrapper around the latter, and this way we may more frequently receive updates.