### PR TITLE
fix: skip test_nested_array to resolve miri unsoundness

### DIFF
--- a/tket/src/passes/borrow_squash.rs
+++ b/tket/src/passes/borrow_squash.rs
@@ -493,7 +493,7 @@ mod test {
     }
 
     #[rstest]
-    #[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
+    #[cfg_attr(miri, ignore)] // Opening compressed HUGR files is not supported in (isolated) miri
     fn test_nested_array() {
         let inner_array_type = BorrowArray::ty(5, qb_t());
         let outer_array_type = BorrowArray::ty(3, inner_array_type.clone());

--- a/tket/src/passes/borrow_squash.rs
+++ b/tket/src/passes/borrow_squash.rs
@@ -493,7 +493,7 @@ mod test {
     }
 
     #[rstest]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
     fn test_nested_array() {
         let inner_array_type = BorrowArray::ty(5, qb_t());
         let outer_array_type = BorrowArray::ty(3, inner_array_type.clone());

--- a/tket/src/passes/borrow_squash.rs
+++ b/tket/src/passes/borrow_squash.rs
@@ -493,6 +493,7 @@ mod test {
     }
 
     #[rstest]
+    #[cfg_attr(miri, ignore)]
     fn test_nested_array() {
         let inner_array_type = BorrowArray::ty(5, qb_t());
         let outer_array_type = BorrowArray::ty(3, inner_array_type.clone());


### PR DESCRIPTION
I think the previous unsoundness checks were timing out until https://github.com/Quantinuum/tket2/pull/1565 was merged. Now I think this additonal test has shown up as something which fails the unsoundness check. 

I think an extra skip is needed here. See https://github.com/Quantinuum/tket2/issues/1622#issuecomment-4542319079

closes #1622  