### PR TITLE
ci: Don't fail if codecov rejects tokenless upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
           files: coverage.json
           name: rust
           flags: rust
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # Run tests on the minimum supported rust version, with minimal dependency versions
@@ -317,7 +317,7 @@ jobs:
           disable_search: true
           name: python
           flags: python
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   tests-qis-compiler:
@@ -355,7 +355,7 @@ jobs:
           disable_search: true
           name: python
           flags: qis-compiler
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # Ensure that serialized extensions match rust implementation


### PR DESCRIPTION
Fork-based PRs cannot access the CODECOV_TOKEN secret, so coverage information would normally be submitted via the tokenless upload flow.

This somehow stopped working, even though tokenless uploads are enabled on the codecov side.A

Related issues:
- https://github.com/codecov/codecov-action/issues/1782
- https://github.com/codecov/codecov-action/issues/1842
- https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/232

Apparently the solution there was to ping someone from the codecov team to "sync" the repo config.

As a temporary measure, this PR disables the `fail_ci_if_error` option so we can still merge external PRs while the underlaying issue is solved. 