### PR TITLE
fix: Include helios and sol extensions in qis-compiler registry

### DIFF
--- a/qis-compiler/rust/lib.rs
+++ b/qis-compiler/rust/lib.rs
@@ -72,6 +72,8 @@ static REGISTRY: std::sync::LazyLock<ExtensionRegistry> = std::sync::LazyLock::n
         qsystem_futures::EXTENSION.to_owned(),
         qsystem_result::EXTENSION.to_owned(),
         qsystem::EXTENSION.to_owned(),
+        qsystem::helios::EXTENSION.to_owned(),
+        qsystem::sol::EXTENSION.to_owned(),
         ROTATION_EXTENSION.to_owned(),
         TKET_EXTENSION.to_owned(),
         TKET1_EXTENSION.to_owned(),


### PR DESCRIPTION
Closes #1645