### PR TITLE
feat: add scoped exhaustive rule matching and Cliffordize pass

### DIFF
--- a/tket-py/docs/examples/Cliffordize.md
+++ b/tket-py/docs/examples/Cliffordize.md
@@ -1,0 +1,39 @@
+# Cliffordize for debugging
+
+`Cliffordize` replaces selected non-Clifford operations with deterministic
+Clifford operations. It is intended for testing and debugging workflows that
+need input suitable for Clifford-only tooling.
+
+The transformation is **not semantics-preserving**.
+
+The initial replacement table is:
+
+| Input operation | Replacement |
+| --------------- | ----------- |
+| `tket.quantum.T` | `tket.quantum.S` |
+| `tket.quantum.Tdg` | `tket.quantum.Sdg` |
+
+Other operations are left unchanged. In particular, this pass does not replace
+arbitrary or symbolic rotations, `PhasedX`, or `ZZPhase`.
+
+```python
+from tket._state.build import from_coms
+from tket.passes import Cliffordize
+from tket_exts import quantum
+
+hugr = from_coms(quantum.T(0), quantum.H(0), quantum.Tdg(0)).to_python().modules[0]
+result = Cliffordize().run(hugr, inplace=False)
+
+print(result.results[-1][1])  # 2 replacements
+```
+
+By default, `Cliffordize` uses `GlobalScope.PRESERVE_PUBLIC`. Use
+`with_scope(...)` to restrict which regions are rewritten:
+
+```python
+from hugr.passes.scope import LocalScope
+
+local_result = Cliffordize().with_scope(LocalScope.FLAT).run(
+    hugr, inplace=False
+)
+```

--- a/tket-py/docs/index.md
+++ b/tket-py/docs/index.md
@@ -19,6 +19,7 @@
 .. toctree::
    :caption: Examples
 
+   examples/Cliffordize
    examples/Guppy-opt-example
 
 ```

--- a/tket-py/src/pattern.rs
+++ b/tket-py/src/pattern.rs
@@ -12,7 +12,7 @@ use crate::utils::{ConvertPyErr, create_py_exception};
 use hugr::{HugrView, Node, hugr::hugrmut::HugrMut};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use tket::Circuit;
+use tket::{Circuit, CircuitError};
 use tket::portmatching::{CircuitPattern, PatternMatch, PatternMatcher};
 
 /// The module definition
@@ -127,7 +127,8 @@ impl RuleMatcher {
     }
 
     pub fn find_match(&self, target: &CompilationState) -> PyResult<Option<PyCircuitRewrite>> {
-        let circ = Circuit::new(&target.hugr);
+        let circ = Circuit::try_new(&target.hugr)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
         let Some(pmatch) = self.matcher.find_matches_iter(&circ).next() else {
             return Ok(None);
         };
@@ -135,16 +136,19 @@ impl RuleMatcher {
     }
 
     pub fn find_matches(&self, target: &CompilationState) -> PyResult<Vec<PyCircuitRewrite>> {
-        let circ = Circuit::new(&target.hugr);
+        let circ = Circuit::try_new(&target.hugr)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
         self.matcher
             .find_matches_iter(&circ)
             .map(|m| self.match_to_rewrite(m, &circ))
             .collect()
     }
 
-    /// Apply the first matching rule repeatedly within the selected scope.
+    /// Apply the first matching rule repeatedly within each circuit-compatible
+    /// region in the selected scope.
     ///
-    /// Returns the number of rewrites applied.
+    /// Non-circuit regions are skipped. Returns the number of rewrites applied
+    /// and restores the original HUGR entrypoint before returning.
     #[pyo3(signature = (target, scope = None))]
     pub fn apply_exhaustive(
         &self,
@@ -159,6 +163,12 @@ impl RuleMatcher {
             let mut rewrite_count = 0;
             for region in regions {
                 target.hugr.set_entrypoint(region);
+                match Circuit::try_new(&target.hugr) {
+                    Ok(_) => {}
+                    Err(CircuitError::InvalidParentOp { .. }) => continue,
+                    Err(error) => return Err(anyhow::Error::msg(error.to_string())),
+                }
+
                 while let Some(rewrite) = self.find_match(target)? {
                     target
                         .apply_rewrite(rewrite)

--- a/tket-py/src/pattern.rs
+++ b/tket-py/src/pattern.rs
@@ -2,11 +2,15 @@
 
 pub mod portmatching;
 
+use anyhow::Context;
+
+use crate::passes::PyPassScope;
 use crate::rewrite::PyCircuitRewrite;
 use crate::state::CompilationState;
 use crate::utils::{ConvertPyErr, create_py_exception};
 
-use hugr::{HugrView, Node};
+use hugr::{HugrView, Node, hugr::hugrmut::HugrMut};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use tket::Circuit;
 use tket::portmatching::{CircuitPattern, PatternMatch, PatternMatcher};
@@ -50,12 +54,38 @@ create_py_exception!(
 /// A rewrite rule defined by a left hand side and right hand side of an equation.
 pub struct Rule(pub [Circuit; 2]);
 
+fn rule_circuit(state: &CompilationState) -> PyResult<Circuit> {
+    let mut hugr = state.hugr.clone();
+
+    if hugr.get_optype(hugr.entrypoint()).is_module() {
+        let module = hugr.entrypoint();
+        let entrypoint = {
+            let mut children = hugr.children(module);
+            let entrypoint = children
+                .next()
+                .ok_or_else(|| PyValueError::new_err("Rule module contains no circuit"))?;
+
+            if children.next().is_some() {
+                return Err(PyValueError::new_err(
+                    "Rule module must contain exactly one circuit",
+                ));
+            }
+
+            entrypoint
+        };
+
+        hugr.set_entrypoint(entrypoint);
+    }
+
+    Circuit::try_new(hugr).map_err(|error| PyValueError::new_err(error.to_string()))
+}
+
 #[pymethods]
 impl Rule {
     #[new]
     fn new_rule(l: &CompilationState, r: &CompilationState) -> PyResult<Rule> {
-        let l = Circuit::new(l.hugr.clone());
-        let r = Circuit::new(r.hugr.clone());
+        let l = rule_circuit(l)?;
+        let r = rule_circuit(r)?;
         Ok(Rule([l, r]))
     }
 
@@ -110,6 +140,37 @@ impl RuleMatcher {
             .find_matches_iter(&circ)
             .map(|m| self.match_to_rewrite(m, &circ))
             .collect()
+    }
+
+    /// Apply the first matching rule repeatedly within the selected scope.
+    ///
+    /// Returns the number of rewrites applied.
+    #[pyo3(signature = (target, scope = None))]
+    pub fn apply_exhaustive(
+        &self,
+        target: &mut CompilationState,
+        scope: Option<PyPassScope>,
+    ) -> anyhow::Result<usize> {
+        let scope = scope.unwrap_or_default().scope;
+        let original_entrypoint = target.hugr.entrypoint();
+        let regions: Vec<_> = scope.regions(&target.hugr).collect();
+
+        let result = (|| {
+            let mut rewrite_count = 0;
+            for region in regions {
+                target.hugr.set_entrypoint(region);
+                while let Some(rewrite) = self.find_match(target)? {
+                    target
+                        .apply_rewrite(rewrite)
+                        .context("Could not apply exhaustive rule rewrite")?;
+                    rewrite_count += 1;
+                }
+            }
+            Ok(rewrite_count)
+        })();
+
+        target.hugr.set_entrypoint(original_entrypoint);
+        result
     }
 }
 

--- a/tket-py/src/pattern.rs
+++ b/tket-py/src/pattern.rs
@@ -149,6 +149,8 @@ impl RuleMatcher {
     ///
     /// Non-circuit regions are skipped. Returns the number of rewrites applied
     /// and restores the original HUGR entrypoint before returning.
+    ///
+    /// Returns a count of applied rewrites.
     #[pyo3(signature = (target, scope = None))]
     pub fn apply_exhaustive(
         &self,

--- a/tket-py/test/test_cliffordize.py
+++ b/tket-py/test/test_cliffordize.py
@@ -1,0 +1,90 @@
+from hugr import Hugr
+from hugr import tys
+from hugr.build.function import Module
+from hugr.passes.scope import LocalScope
+from tket_exts import quantum
+
+from tket._state.build import H, OneQbGate, from_coms
+from tket.passes import Cliffordize
+
+
+S = OneQbGate("S")
+Sdg = OneQbGate("Sdg")
+T = OneQbGate("T")
+Tdg = OneQbGate("Tdg")
+
+
+def _count_gate(hugr: Hugr, gate: str) -> int:
+    return sum(
+        data.op.name().rsplit(".", maxsplit=1)[-1] == gate for _, data in hugr.nodes()
+    )
+
+
+def test_cliffordize_replaces_supported_gates() -> None:
+    input_hugr = from_coms(T(0), Tdg(1), H(0), S(0), Sdg(1)).to_python().modules[0]
+
+    result = Cliffordize().run(input_hugr, inplace=False)
+
+    assert result.results == [("Cliffordize", 2)]
+    assert _count_gate(result.hugr, "T") == 0
+    assert _count_gate(result.hugr, "Tdg") == 0
+    assert _count_gate(result.hugr, "S") == 2
+    assert _count_gate(result.hugr, "Sdg") == 2
+    assert _count_gate(result.hugr, "H") == 1
+
+
+def test_cliffordize_reaches_fixed_point() -> None:
+    input_hugr = from_coms(T(0), Tdg(1)).to_python().modules[0]
+
+    first_result = Cliffordize().run(input_hugr, inplace=False)
+    second_result = Cliffordize().run(first_result.hugr, inplace=False)
+
+    assert first_result.results == [("Cliffordize", 2)]
+    assert second_result.results == [("Cliffordize", 0)]
+
+
+def _nested_t_hugr() -> Hugr:
+    module = Module()
+
+    nested = module.define_function("nested", [tys.Qubit])
+    [nested_q] = nested.inputs()
+    nested_t = nested.add(T(nested_q))
+    nested.set_outputs(nested_t.out(0))
+
+    main = module.define_function("main", [tys.Qubit], visibility="Public")
+    [main_q] = main.inputs()
+    nested_call = main.call(nested.parent_node, main_q)
+    main.set_outputs(nested_call.out(0))
+
+    module.hugr.entrypoint = main.parent_node
+    return module.hugr
+
+
+def test_cliffordize_respects_scope_and_restores_entrypoint() -> None:
+    input_hugr = _nested_t_hugr()
+    original_entrypoint = input_hugr.entrypoint
+
+    local_result = (
+        Cliffordize().with_scope(LocalScope.FLAT).run(input_hugr, inplace=False)
+    )
+    global_result = Cliffordize().run(input_hugr, inplace=False)
+
+    assert local_result.results == [("Cliffordize", 0)]
+    assert _count_gate(local_result.hugr, "T") == 1
+    assert local_result.hugr.entrypoint == original_entrypoint
+
+    assert global_result.results == [("Cliffordize", 1)]
+    assert _count_gate(global_result.hugr, "T") == 0
+    assert _count_gate(global_result.hugr, "S") == 1
+    assert global_result.hugr.entrypoint == original_entrypoint
+
+
+def test_cliffordize_leaves_unsupported_operations_unchanged() -> None:
+    input_hugr = from_coms(quantum.toffoli(0, 1, 2), T(0)).to_python().modules[0]
+
+    result = Cliffordize().run(input_hugr, inplace=False)
+
+    assert result.results == [("Cliffordize", 1)]
+    assert _count_gate(result.hugr, "Toffoli") == 1
+    assert _count_gate(result.hugr, "T") == 0
+    assert _count_gate(result.hugr, "S") == 1

--- a/tket-py/test/test_cliffordize.py
+++ b/tket-py/test/test_cliffordize.py
@@ -60,6 +60,23 @@ def _nested_t_hugr() -> Hugr:
     return module.hugr
 
 
+def _cfg_t_hugr() -> Hugr:
+    module = Module()
+    main = module.define_function("main", [tys.Qubit], visibility="Public")
+    [main_q] = main.inputs()
+
+    cfg = main.add_cfg(main_q)
+    entry = cfg.add_entry()
+    [entry_q] = entry.inputs()
+    entry_t = entry.add(T(entry_q))
+    entry.set_single_succ_outputs(entry_t.out(0))
+    cfg.branch_exit(entry[0])
+
+    main.set_outputs(cfg.parent_node.out(0))
+    module.hugr.entrypoint = main.parent_node
+    return module.hugr
+
+
 def test_cliffordize_respects_scope_and_restores_entrypoint() -> None:
     input_hugr = _nested_t_hugr()
     original_entrypoint = input_hugr.entrypoint
@@ -77,6 +94,16 @@ def test_cliffordize_respects_scope_and_restores_entrypoint() -> None:
     assert _count_gate(global_result.hugr, "T") == 0
     assert _count_gate(global_result.hugr, "S") == 1
     assert global_result.hugr.entrypoint == original_entrypoint
+
+
+def test_cliffordize_skips_non_circuit_scope_regions() -> None:
+    input_hugr = _cfg_t_hugr()
+
+    result = Cliffordize().run(input_hugr, inplace=False)
+
+    assert result.results == [("Cliffordize", 1)]
+    assert _count_gate(result.hugr, "T") == 0
+    assert _count_gate(result.hugr, "S") == 1
 
 
 def test_cliffordize_leaves_unsupported_operations_unchanged() -> None:

--- a/tket-py/test/test_pass.py
+++ b/tket-py/test/test_pass.py
@@ -168,15 +168,29 @@ def test_multiple_rules():
     )
     matcher = RuleMatcher([rule1, rule2])
 
-    match_count = 0
-    while match := matcher.find_match(circ._inner):
-        match_count += 1
-        circ._inner.apply_rewrite(match)
+    match_count = matcher.apply_exhaustive(circ._inner)
 
     assert match_count == 3
 
     out = circ.to_tket1()
     assert out == Circuit(3).CX(0, 1).X(0)
+
+
+def test_apply_exhaustive_reaches_fixed_point() -> None:
+    circ = CompilationState.from_tket1(Circuit(3).H(0).H(0).H(1).H(1).H(2).H(2))
+
+    rule = Rule(
+        CompilationState.from_tket1(Circuit(1).H(0).H(0))._inner,
+        CompilationState.from_tket1(Circuit(1).X(0))._inner,
+    )
+    matcher = RuleMatcher([rule])
+
+    rewrite_count = matcher.apply_exhaustive(circ._inner)
+
+    assert rewrite_count == 3
+    assert circ.to_tket1() == Circuit(3).X(0).X(1).X(2)
+
+    assert matcher.apply_exhaustive(circ._inner) == 0
 
 
 def test_clifford_simp_no_swaps():

--- a/tket-py/test/test_pattern.py
+++ b/tket-py/test/test_pattern.py
@@ -1,0 +1,77 @@
+import pytest
+
+from hugr import tys
+from hugr.build.function import Module
+
+from tket._pattern import InvalidReplacementError, Rule, RuleMatcher
+from tket._state import CompilationState
+from tket._state.build import CX, OneQbGate, from_coms
+
+
+S = OneQbGate("S")
+T = OneQbGate("T")
+
+
+def _single_gate_module(gate: OneQbGate) -> CompilationState:
+    return from_coms(gate(0))
+
+
+def test_rule_accepts_single_circuit_module() -> None:
+    rule = Rule(_single_gate_module(T)._inner, _single_gate_module(S)._inner)
+
+    assert rule.lhs().num_operations() == 1
+    assert rule.rhs().num_operations() == 1
+
+
+def test_rule_rejects_empty_module() -> None:
+    empty = CompilationState.from_python(Module().hugr)
+    valid = _single_gate_module(T)
+
+    with pytest.raises(ValueError, match="contains no circuit"):
+        Rule(empty._inner, valid._inner)
+
+
+def test_rule_rejects_multiple_circuit_module() -> None:
+    module = Module()
+    for name in ("first", "second"):
+        function = module.define_function(name, [tys.Qubit])
+        [qubit] = function.inputs()
+        function.set_outputs(qubit)
+
+    multiple = CompilationState.from_python(module.hugr)
+    valid = _single_gate_module(T)
+
+    with pytest.raises(ValueError, match="exactly one circuit"):
+        Rule(multiple._inner, valid._inner)
+
+
+def test_find_methods_reject_non_circuit_entrypoint() -> None:
+    matcher = RuleMatcher(
+        [Rule(_single_gate_module(T)._inner, _single_gate_module(S)._inner)]
+    )
+    module = CompilationState.from_python(Module().hugr)
+
+    with pytest.raises(ValueError, match="cannot be used as a circuit parent"):
+        matcher.find_match(module._inner)
+
+    with pytest.raises(ValueError, match="cannot be used as a circuit parent"):
+        matcher.find_matches(module._inner)
+
+
+def test_apply_exhaustive_restores_entrypoint_after_error() -> None:
+    module = Module()
+    function = module.define_function("contains_t", [tys.Qubit])
+    [qubit] = function.inputs()
+    t_gate = function.add(T(qubit))
+    function.set_outputs(t_gate.out(0))
+
+    state = CompilationState.from_python(module.hugr)
+    original_entrypoint = state.to_python().modules[0].entrypoint
+    invalid_matcher = RuleMatcher(
+        [Rule(_single_gate_module(T)._inner, from_coms(CX(0, 1))._inner)]
+    )
+
+    with pytest.raises(InvalidReplacementError, match="Replacement graph type mismatch"):
+        invalid_matcher.apply_exhaustive(state._inner)
+
+    assert state.to_python().modules[0].entrypoint == original_entrypoint

--- a/tket-py/test/test_pattern.py
+++ b/tket-py/test/test_pattern.py
@@ -71,7 +71,9 @@ def test_apply_exhaustive_restores_entrypoint_after_error() -> None:
         [Rule(_single_gate_module(T)._inner, from_coms(CX(0, 1))._inner)]
     )
 
-    with pytest.raises(InvalidReplacementError, match="Replacement graph type mismatch"):
+    with pytest.raises(
+        InvalidReplacementError, match="Replacement graph type mismatch"
+    ):
         invalid_matcher.apply_exhaustive(state._inner)
 
     assert state.to_python().modules[0].entrypoint == original_entrypoint

--- a/tket-py/tket/_tket/pattern.pyi
+++ b/tket-py/tket/_tket/pattern.pyi
@@ -43,6 +43,8 @@ class RuleMatcher:
         """Apply the first matching rule repeatedly within the selected scope.
 
         Mutates the provided circuit and returns the number of rewrites applied.
+        Non-circuit scope regions are skipped, and the original HUGR entrypoint
+        is restored before returning, including when an error occurs.
         """
 
 class CircuitPattern:

--- a/tket-py/tket/_tket/pattern.pyi
+++ b/tket-py/tket/_tket/pattern.pyi
@@ -1,4 +1,5 @@
 from typing import Iterator
+from hugr.passes.scope import PassScope
 from .state import Node, CompilationState
 from .rewrite import CircuitRewrite
 
@@ -35,6 +36,14 @@ class RuleMatcher:
 
     def find_matches(self, circ: CompilationState) -> list[CircuitRewrite]:
         """Find all matches of the rules in the circuit."""
+
+    def apply_exhaustive(
+        self, circ: CompilationState, scope: PassScope | None = None
+    ) -> int:
+        """Apply the first matching rule repeatedly within the selected scope.
+
+        Mutates the provided circuit and returns the number of rewrites applied.
+        """
 
 class CircuitPattern:
     """A pattern that matches a circuit exactly."""

--- a/tket-py/tket/passes/__init__.py
+++ b/tket-py/tket/passes/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cache
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -9,6 +10,8 @@ from hugr import Hugr
 
 from tket import _state
 from . import inline_funcs
+from .._pattern import Rule, RuleMatcher
+from .._state.build import OneQbGate, from_coms
 from .._tket import passes as _passes, optimiser as _optimiser
 
 from hugr.passes.composable import (
@@ -150,15 +153,45 @@ class NormalizeGuppy(ComposablePass):
         return program
 
 
+@cache
+def _cliffordize_matcher() -> RuleMatcher:
+    """Build the matcher containing the supported Cliffordize rules."""
+    replacements = [
+        ("T", "S"),
+        ("Tdg", "Sdg"),
+    ]
+
+    rules = [
+        Rule(
+            from_coms(OneQbGate(source)(0))._inner,
+            from_coms(OneQbGate(replacement)(0))._inner,
+        )
+        for source, replacement in replacements
+    ]
+
+    return RuleMatcher(rules)
+
+
 @dataclass
 class Cliffordize(ComposablePass):
-    _scope: PassScope = GlobalScope.PRESERVE_PUBLIC
+    """Replace supported non-Clifford operations with Clifford operations.
 
-    """v1: Replace supported non-Clifford operations with Clifford operations.
-    This pass is intended for debugging and Clifford-only simulation workflows. It is not semantics-preserving.
+    This pass is intended for debugging and workflows that require Clifford-only
+    circuits. It is not semantics-preserving.
+
+    The currently supported replacements are:
+
+    - `T` with `S`
+    - `Tdg` with `Sdg`
+
+    Other non-Clifford operations, including arbitrary rotations, symbolic
+    rotations, `PhasedX`, and `ZZPhase`, are left unchanged.
     """
 
+    _scope: PassScope = GlobalScope.PRESERVE_PUBLIC
+
     def run(self, hugr: Hugr, *, inplace: bool = True) -> PassResult:
+        """Run the pass and return the transformed HUGR and rewrite count."""
         return implement_pass_run(
             self,
             hugr=hugr,
@@ -178,12 +211,18 @@ class Cliffordize(ComposablePass):
 
         package = tk_program.to_python()
         return PassResult.for_pass(
-            self, hugr=package.modules[0], inplace=inplace, result=rewrite_count
+            self,
+            hugr=package.modules[0],
+            inplace=inplace,
+            result=rewrite_count,
         )
 
     def _run_tk(self, program: _state.CompilationState) -> int:
-        """Run the pass in the CompilationState."""
-        raise NotImplementedError("Cliffordize rewrite rules are not implemented yet.")
+        """Run the pass on a CompilationState and return the rewrite count."""
+        return _cliffordize_matcher().apply_exhaustive(
+            program._inner,
+            scope=self._scope,
+        )
 
 
 @dataclass

--- a/tket-py/tket/passes/__init__.py
+++ b/tket-py/tket/passes/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "NormalizeGuppy",
     "ModifierResolverPass",
     "QSystemPass",
+    "Cliffordize",
 ]
 
 
@@ -147,6 +148,42 @@ class NormalizeGuppy(ComposablePass):
             scope=self._scope,
         )
         return program
+
+
+@dataclass
+class Cliffordize(ComposablePass):
+    _scope: PassScope = GlobalScope.PRESERVE_PUBLIC
+
+    """v1: Replace supported non-Clifford operations with Clifford operations.
+    This pass is intended for debugging and Clifford-only simulation workflows. It is not semantics-preserving.
+    """
+
+    def run(self, hugr: Hugr, *, inplace: bool = True) -> PassResult:
+        return implement_pass_run(
+            self,
+            hugr=hugr,
+            inplace=inplace,
+            copy_call=lambda h: self._cliffordize(h, inplace),
+        )
+
+    def with_scope(self, scope: PassScope) -> Cliffordize:
+        """Set the scope of this pass and return self."""
+        self._scope = scope
+        return self
+
+    def _cliffordize(self, hugr: Hugr, inplace: bool) -> PassResult:
+        tk_program = _state.CompilationState.from_python(hugr)
+
+        rewrite_count = self._run_tk(tk_program)
+
+        package = tk_program.to_python()
+        return PassResult.for_pass(
+            self, hugr=package.modules[0], inplace=inplace, result=rewrite_count
+        )
+
+    def _run_tk(self, program: _state.CompilationState) -> int:
+        """Run the pass in the CompilationState."""
+        raise NotImplementedError("Cliffordize rewrite rules are not implemented yet.")
 
 
 @dataclass


### PR DESCRIPTION
Closes #1315

## Summary

Adds a `Cliffordize` pass that replaces:

- `T` with `S`
- `Tdg` with `Sdg`

This pass is intended for debugging and preparing circuits for Clifford-only tooling. It is intentionally not semantics-preserving. Other non-Clifford operations are left unchanged.

The pass uses a new scope-aware `RuleMatcher.apply_exhaustive(...)` helper, which repeatedly applies matching rules and returns the number of rewrites performed.

This is an alternative rewrite-based approach to #1653, following the architecture discussed in #1315.

## Changes

- Add scoped exhaustive rule matching
- Add the Python `Cliffordize` pass
- Restore the original HUGR entrypoint after matching, including on errors
- Add focused tests and API documentation

## Testing

- Focused `Cliffordize` and pattern tests pass
- Formatting, Ruff, mypy, Cargo check, Clippy, and Cargo docs pass

## Notes
The full Python suite had one unrelated local environment failure involving `uv` and `_rjem_malloc`.

---

> Portions of this pull request were generated or modified with the help of OpenAI Codex (GPT-5.5). Changes were reviewed and validated by a human developer