### PR TITLE
chore: Ignore IO tests in soundness checks and improve test runtime

### DIFF
--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -28,8 +28,6 @@ env:
   LD_LIBRARY_PATH: "/tmp/hugrverse/lib:/tmp/hugrverse/lib64"
   LLVM_SYS_211_PREFIX: "/tmp/hugrverse"
 
-
-
 jobs:
   miri:
     name: "Miri"
@@ -43,7 +41,6 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - uses: quantinuum/hugrverse-env/install-hugrenv-action@main
-
       - name: Install nextest
         uses: taiki-e/install-action@nextest
 
@@ -52,7 +49,7 @@ jobs:
       # Skip tests that take over 5mins in CI.
       - name: Test with Miri
         run: |
-          cargo miri nextest run --no-default-features -- \
+          cargo miri nextest run --no-default-features --no-fail-fast -- \
             `# -------- tket::passes` \
             --skip "dataflow::partial_value::test::bounded_lattice" \
             --skip "dataflow::partial_value::test::lattice" \

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Test with Miri
         run: |
           cargo miri nextest run --no-default-features --no-fail-fast -- \
+            `# -------- tket::modifier` \
+            --skip "modifier::modifier_resolver::call_modify::tests::test_call_modify" \
+            --skip "modifier::modifier_resolver::dfg_modify::test::test_dfg_modify" \
+            --skip "modifier::modifier_resolver::global_phase_modify::tests::test_global_phase_modify" \
             `# -------- tket::passes` \
             --skip "dataflow::partial_value::test::bounded_lattice" \
             --skip "dataflow::partial_value::test::lattice" \
@@ -60,9 +64,24 @@ jobs:
             --skip "merge_bbs::test::check_ext_id_wellformed" \
             --skip "monomorphize::test::test_recursion_module" \
             --skip "normalize_cfgs::test::check_ext_id_wellformed" \
+            --skip "replace_types::linearize::test::sum_nway_copy" \
+            --skip "replace_types::linearize::test::test_copy_borrow_array" \
+            --skip "replace_types::linearize::test::use_in_op_callback" \
+            --skip "replace_types::test::compositionality" \
             --skip "replace_types::test::dfg_conditional_case" \
             --skip "replace_types::test::module_func_cfg_call" \
             --skip "replace_types::test::op_to_call" \
+            --skip "replace_types::test::regions" \
+            --skip "serialize::pytket::tests::circuit_standalone_roundtrip" \
+            --skip "serialize::tests::func_circuit_store" \
+            --skip "serialize::tests::root_circuit_store" \
+            --skip "serialize::tests::serialize_package_errors" \
+            `# -------- tket_qsystem` \
+            --skip "extension::qsystem::barrier::test::test_barrier" \
+            --skip "extension::qsystem::lower::test::test_array_clone_discard_measurement" \
+            --skip "extension::qsystem::lower::test::test_barray_get_measurement" \
+            --skip "extension::qsystem::lower::test::test_mixed" \
+            --skip "test::no_public_funcs" \
             #
 
   create-issue:

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Run miri unsoundness checks.
       #
-      # Skip tests that take over 5mins in CI.
+      # Skip tests that take over 60s in CI.
       - name: Test with Miri
         run: |
           cargo miri nextest run --no-default-features --no-fail-fast -- \

--- a/tket-qsystem/tests/guppy_opt.rs
+++ b/tket-qsystem/tests/guppy_opt.rs
@@ -189,6 +189,7 @@ fn flatten_guppy(#[case] name: &str) {
 #[case::nested("nested")]
 #[should_panic]
 #[case::ranges("ranges")]
+#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 fn optimize_guppy(#[case] name: &str) {
     let mut hugr = load_guppy_circuit(name, HugrFileType::Original).unwrap();
     let flat = count_gates(
@@ -217,6 +218,7 @@ fn optimize_guppy(#[case] name: &str) {
 
 /// Regression test for <http://github.com/CQCL/tket2/issues/1577>
 #[rstest]
+#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
 fn issue_1577_remove_barriers_reassembles_nested_circuits() {
     let mut hugr = load_guppy_example("../guppy_examples/issue_1577.hugr").unwrap();
     run_pytket(&mut hugr, REMOVE_BARRIERS_STR);


### PR DESCRIPTION
Fixes https://github.com/Quantinuum/tket2/issues/1660.

drive-by: Add `--no-fail-fast` so we get all errors at once next time.
drive-by: Add more slow tests to the skip list.

Run before skips (1h 41min): https://github.com/Quantinuum/tket2/actions/runs/27147141561/job/80127920500
Run after skips (55min): https://github.com/Quantinuum/tket2/actions/runs/27153371724/job/80149847542