### PR TITLE
feat!: Remove deprecated definitions

### DIFF
--- a/tket-exts/src/tket_exts/tket/qsystem/__init__.py
+++ b/tket-exts/src/tket_exts/tket/qsystem/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 
 
 class QSystemExtension(TketExtension):
-    """Deprecated (since 0.2.7): use :class:`QSystemHeliosExtension` or :class:`QSystemSolExtension` instead.
+    """Deprecated (since 0.13.0): use :class:`QSystemHeliosExtension` or :class:`QSystemSolExtension` instead.
 
     The combined ``tket.qsystem`` extension has been split into platform-specific
     extensions. Use ``tket_exts.qsystem_helios`` or ``tket_exts.qsystem_sol`` instead.

--- a/tket-exts/src/tket_exts/tket/qsystem/__init__.py
+++ b/tket-exts/src/tket_exts/tket/qsystem/__init__.py
@@ -23,7 +23,7 @@ __all__ = [
 
 
 class QSystemExtension(TketExtension):
-    """Deprecated: use :class:`QSystemHeliosExtension` or :class:`QSystemSolExtension` instead.
+    """Deprecated (since 0.2.7): use :class:`QSystemHeliosExtension` or :class:`QSystemSolExtension` instead.
 
     The combined ``tket.qsystem`` extension has been split into platform-specific
     extensions. Use ``tket_exts.qsystem_helios`` or ``tket_exts.qsystem_sol`` instead.

--- a/tket-qsystem/src/extension/qsystem/lower.rs
+++ b/tket-qsystem/src/extension/qsystem/lower.rs
@@ -95,8 +95,11 @@ pub enum LowerTk2Error {
     ///
     /// Deprecated: Helios-specific ops are now handled via the cross-platform
     /// lowering path; `lower_tk2_ops` will no longer return this error.
-    #[deprecated = "Helios-specific ops are now handled by the cross-platform lowering path; \
-                    this error variant will no longer be returned by lower_tk2_ops."]
+    #[deprecated(
+        since = "0.26.0",
+        note = "Helios-specific ops are now handled by the cross-platform lowering path; \
+                    this error variant will no longer be returned by lower_tk2_ops."
+    )]
     #[display(
         "Helios-specific legacy tket.qsystem ops cannot be lowered to Sol via direct remapping; \
          use cross-platform lowering instead."

--- a/tket-qsystem/src/lib.rs
+++ b/tket-qsystem/src/lib.rs
@@ -73,7 +73,7 @@ impl QSystemPass {
 #[non_exhaustive]
 /// An error reported from [QSystemPass].
 pub enum QSystemPassError {
-    /// An error from the component [force_order()] pass.
+    /// An error from the component [force_order] pass.
     ForceOrderError(HugrError),
     /// An error from the component [LowerTketToQSystemPass] pass.
     LowerTk2Error(LowerTk2Error),

--- a/tket-qsystem/src/lib.rs
+++ b/tket-qsystem/src/lib.rs
@@ -149,7 +149,7 @@ impl QSystemPass {
             return Ok(());
         };
 
-        force_order(hugr, root, |hugr, node| {
+        force_order::force_order(hugr, root, |hugr, node| {
             let optype = hugr.get_optype(node);
 
             let is_quantum =

--- a/tket/src/passes.rs
+++ b/tket/src/passes.rs
@@ -31,7 +31,6 @@ pub use dead_funcs::{RemoveDeadFuncsError, RemoveDeadFuncsPass};
 
 // Force a topological order on nodes.
 pub mod force_order;
-pub use force_order::{force_order, force_order_by_key};
 
 // Normalize the structure of Guppy-generated programs.
 pub mod guppy;
@@ -44,8 +43,6 @@ pub use inline_dfgs::InlineDFGsPass;
 // Inline function calls.
 pub mod inline_funcs;
 pub use inline_funcs::InlineFunctionsPass;
-#[expect(deprecated)]
-pub use inline_funcs::inline_acyclic;
 
 // Lower and replace operations.
 pub mod lower;

--- a/tket/src/passes/dataflow/datalog.rs
+++ b/tket/src/passes/dataflow/datalog.rs
@@ -7,7 +7,7 @@ use ascent::lattice::BoundedLattice;
 use itertools::Itertools;
 
 use hugr_core::extension::prelude::{MakeTuple, UnpackTuple};
-use hugr_core::ops::{DataflowOpTrait, OpTag, OpTrait, OpType, TailLoop};
+use hugr_core::ops::{DataflowOpTrait, OpTrait, OpType, TailLoop};
 use hugr_core::{HugrView, IncomingPort, OutgoingPort, PortIndex as _, Wire};
 
 use super::value_row::ValueRow;
@@ -104,53 +104,6 @@ impl<H: HugrView, V: AbstractValue> Machine<H, V> {
             op => return Err(op.clone()),
         }
         Ok(())
-    }
-
-    /// Run the analysis (iterate until a lattice fixpoint is reached)
-    /// and return results for the entrypoint-subtree.
-    ///
-    /// As a shortcut, for Hugrs whose [HugrView::entrypoint] is a
-    /// [`FuncDefn`](OpType::FuncDefn), [CFG](OpType::CFG), [DFG](OpType::DFG),
-    /// [Conditional](OpType::Conditional) or [`TailLoop`](OpType::TailLoop) only
-    /// (that is: *not* [Module](OpType::Module),
-    /// [`DataflowBlock`](OpType::DataflowBlock) or [Case](OpType::Case)),
-    /// `in_values` may provide initial values for the entrypoint-node inputs,
-    ///  equivalent to calling `prepopulate_inputs` with the entrypoint node.
-    ///
-    /// The context passed in allows interpretation of leaf operations.
-    ///
-    /// See also [`Self::run_subtree`] for running the analysis on an arbitrary subtree.
-    ///
-    /// # Panics
-    /// May panic in various ways if the Hugr is invalid;
-    /// or if any `in_values` are provided for a module-rooted Hugr.
-    #[deprecated(
-        note = "Use `run_subtree` and `prepopulate_wire` / `prepopulate_inputs` instead",
-        since = "0.18.0"
-    )]
-    pub fn run(
-        mut self,
-        context: impl DFContext<V, Node = H::Node>,
-        in_values: impl IntoIterator<Item = (IncomingPort, PartialValue<V, H::Node>)>,
-    ) -> AnalysisResults<V, H> {
-        if self.hugr.entrypoint_optype().is_module() {
-            assert!(
-                in_values.into_iter().next().is_none(),
-                "No inputs possible for Module"
-            );
-        } else {
-            let ep = self.hugr.entrypoint();
-            let have_value_for_entry = self.in_wire_proto.contains_key(&ep)
-                || (self.hugr.entrypoint_optype().tag() <= OpTag::DataflowParent
-                    && self.out_wire_proto.contains_key(&ep));
-            let mut p = in_values.into_iter().peekable();
-            // We must provide some inputs to the root so that they are Top rather than Bottom.
-            if p.peek().is_some() || !have_value_for_entry {
-                self.prepopulate_inputs(ep, p).unwrap();
-            }
-        }
-        let ep = self.hugr.entrypoint();
-        self.run_subtree(context, ep)
     }
 
     /// Run the analysis (iterate until a lattice fixpoint is reached).

--- a/tket/src/passes/dataflow/datalog.rs
+++ b/tket/src/passes/dataflow/datalog.rs
@@ -28,7 +28,7 @@ type NodeOutputs<V, N> = Vec<(OutgoingPort, PV<V, N>)>;
 ///    For example, to analyse a [Module](OpType::Module)-rooted Hugr,
 ///    [`Self::prepopulate_inputs`] can be used on each externally-callable
 ///    [`FuncDefn`](OpType::FuncDefn) to set all inputs to [`PartialValue::Top`].
-/// 3. Call [`Self::run`] to produce [`AnalysisResults`]
+/// 3. Call [`Self::run_subtree`] to produce [`AnalysisResults`]
 pub struct Machine<H: HugrView, V: AbstractValue> {
     pub(super) hugr: H,
     in_wire_proto: HashMap<H::Node, NodeInputs<V, H::Node>>,

--- a/tket/src/passes/inline_funcs.rs
+++ b/tket/src/passes/inline_funcs.rs
@@ -98,28 +98,6 @@ impl WithScope for InlineFunctionsPass {
 /// Inline (a subset of) [Call]s whose target [FuncDefn]s are not in cycles of the call
 /// graph.
 ///
-/// Processes any call nodes that are descendants of the entrypoint.
-///
-/// The function `call_predicate` is passed each such [Call] node and can return
-/// `false` to prevent that Call from being inlined. (Note the [Call] may be created as
-/// a result of previous inlinings so may not have existed in the original Hugr).
-///
-/// [Call]: hugr_core::ops::Call
-/// [FuncDefn]: hugr_core::ops::FuncDefn
-#[deprecated(
-    since = "0.18.1",
-    note = "Use `inline_acyclic_scoped` with an appropriate `PassScope` instead. For module hugrs, use `PassScope::Global(Preserve::Entrypoint)`."
-)]
-pub fn inline_acyclic<H: HugrMut>(
-    h: &mut H,
-    call_predicate: impl FnMut(&H, H::Node) -> bool,
-) -> Result<(), InlineFuncsError> {
-    inline_acyclic_scoped(h, PassScope::EntrypointRecursive, call_predicate)
-}
-
-/// Inline (a subset of) [Call]s whose target [FuncDefn]s are not in cycles of the call
-/// graph.
-///
 /// The function `call_predicate` is passed each such [Call] node and can return
 /// `false` to prevent that Call from being inlined. (Note the [Call] may be created as
 /// a result of previous inlinings so may not have existed in the original Hugr).

--- a/tket/src/passes/inline_funcs.rs
+++ b/tket/src/passes/inline_funcs.rs
@@ -11,7 +11,7 @@ use hugr_core::module_graph::{ModuleGraph, StaticNode};
 use crate::metadata::InlineAnnotation;
 use crate::passes::{ComposablePass, PassScope, WithScope};
 
-/// Error raised by [inline_acyclic]
+/// Error raised by [InlineFunctionsPass]
 #[derive(Clone, Debug, thiserror::Error, PartialEq)]
 #[non_exhaustive]
 pub enum InlineFuncsError {}

--- a/tket/src/serialize/pytket/error.rs
+++ b/tket/src/serialize/pytket/error.rs
@@ -102,16 +102,6 @@ pub enum PytketEncodeError<N: HugrNode = hugr::Node> {
         /// The head region operation that is not a dataflow container.
         head_op: String,
     },
-    /// No qubits or bits to attach the barrier command to for unsupported nodes.
-    #[display("An unsupported subgraph has no qubits or bits to attach the barrier command to{}",
-        if params.is_empty() {"".to_string()} else {format!(" alongside its parameters [{}]", params.iter().join(", "))}
-    )]
-    #[deprecated(since = "0.17.0", note = "No longer emitted since 0.17.0")]
-    #[from(ignore)]
-    UnsupportedSubgraphHasNoRegisters {
-        /// Parameter inputs to the unsupported subgraph.
-        params: Vec<String>,
-    },
 }
 
 impl<N: HugrNode> PytketEncodeError<N> {

--- a/tket/src/serialize/pytket/opaque.rs
+++ b/tket/src/serialize/pytket/opaque.rs
@@ -8,9 +8,6 @@ pub use subgraph::OpaqueSubgraph;
 
 pub use payload::{EncodedEdgeID, OpaqueSubgraphPayload};
 
-#[expect(deprecated)]
-pub use payload::OPGROUP_OPAQUE_HUGR;
-
 use std::collections::BTreeMap;
 use std::ops::Index;
 

--- a/tket/src/serialize/pytket/opaque/payload.rs
+++ b/tket/src/serialize/pytket/opaque/payload.rs
@@ -15,15 +15,6 @@ use crate::serialize::pytket::{PytketDecodeError, PytketEncodeError, PytketEncod
 
 use super::SubgraphId;
 
-/// Pytket opgroup used to identify opaque barrier operations that encode opaque HUGR subgraphs.
-///
-/// See [`OpaqueSubgraphPayload`].
-#[deprecated(
-    note = "Opaque barriers do not set an opgroup anymore",
-    since = "0.17.0"
-)]
-pub const OPGROUP_OPAQUE_HUGR: &str = "OPAQUE_HUGR";
-
 /// Identifier for a wire in the Hugr, encoded as a 64-bit hash that is
 /// detached from the node IDs of the in-memory Hugr.
 ///


### PR DESCRIPTION
Remove deprecated definitions before the new breaking release.

I'm leaving deprecations that were introduced on the previous release, only removing older code.

Also, adds `since` tags to some deprecation messages missing them.

BREAKING CHANGE: Removed deprecated definitions.