### PR TITLE
chore: Update python docs entries, and fix some __all__s

### DIFF
--- a/tket-py/docs/index.md
+++ b/tket-py/docs/index.md
@@ -8,13 +8,10 @@
    :template: autosummary/module.rst
    :recursive:
 
-   tket.circuit
-   tket.ops
-   tket.optimiser
-   tket.pattern
-   tket.rewrite
+   tket.extensions
+   tket.metadata
    tket.passes
-   tket.types
+   tket.util
 
 .. toctree::
    :caption: Examples

--- a/tket-py/tket/__init__.py
+++ b/tket-py/tket/__init__.py
@@ -9,11 +9,13 @@ working with quantum circuits. See also the Rust library with the same name on
 [crates.io](https://crates.io/crates/tket).
 """
 
-from . import passes, metadata
+from . import extensions, metadata, passes, util
 
 __all__ = [
-    "passes",
+    "extensions",
     "metadata",
+    "passes",
+    "util",
 ]
 
 

--- a/tket-py/tket/extensions/__init__.py
+++ b/tket-py/tket/extensions/__init__.py
@@ -1,8 +1,11 @@
 from tket_exts import (
     debug,
-    guppy,
-    rotation,
     futures,
+    global_phase,
+    gpu,
+    guppy,
+    measurement,
+    modifier,
     qsystem,
     qsystem_helios,
     qsystem_sol,
@@ -10,23 +13,19 @@ from tket_exts import (
     qsystem_utils,
     quantum,
     result,
+    rotation,
     wasm,
 )
-
-# TODO: Remove once tket no longer supports tket-exts 0.10.*
-try:
-    from tket_exts import gpu  # type: ignore[attr-defined] # noqa: F401
-
-    new_exts = ["gpu"]
-except ImportError:
-    new_exts = []
 
 
 __all__ = [
     "debug",
-    "guppy",
-    "rotation",
     "futures",
+    "global_phase",
+    "gpu",
+    "guppy",
+    "measurement",
+    "modifier",
     "qsystem",
     "qsystem_helios",
     "qsystem_sol",
@@ -34,6 +33,6 @@ __all__ = [
     "qsystem_utils",
     "quantum",
     "result",
+    "rotation",
     "wasm",
-    *new_exts,
 ]


### PR DESCRIPTION
Some pre-release cleanups:

- The sphinx index was missing public modules, and listing other modules that have been hidden.
- The `__all__` definitions at the package root and `tket.extensions` were missing stuff