### PR TITLE
ci: Fix missing repo error on wheels build CI

### DIFF
--- a/.github/workflows/python-pure-wheels.yml
+++ b/.github/workflows/python-pure-wheels.yml
@@ -107,12 +107,12 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
+      - uses: actions/checkout@v6
       - name: Check if the tag has an associated release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release view ${{ github.ref_name }}
-          if [ $? -ne 0 ]; then
+          if ! gh release view ${{ github.ref_name }}; then
             echo "No release found for tag ${{ github.ref_name }}"
             exit 1
           fi

--- a/.github/workflows/python-qis-wheels.yml
+++ b/.github/workflows/python-qis-wheels.yml
@@ -90,12 +90,12 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
+      - uses: actions/checkout@v6
       - name: Check if the tag has an associated release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release view ${{ github.ref_name }}
-          if [ $? -ne 0 ]; then
+          if ! gh release view ${{ github.ref_name }}; then
             echo "No release found for tag ${{ github.ref_name }}"
             exit 1
           fi

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -293,12 +293,12 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
+      - uses: actions/checkout@v6
       - name: Check if the tag has an associated release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release view ${{ github.ref_name }}
-          if [ $? -ne 0 ]; then
+          if ! gh release view ${{ github.ref_name }}; then
             echo "No release found for tag ${{ github.ref_name }}"
             exit 1
           fi


### PR DESCRIPTION
The `tket-exts` and `tket-eccs` releases failed due to `gh release view` not being able to find the default repo.
I'm not sure what changed, since we haven't modified that part of the workflows in a bit (I though there was an env var with the repo name...).

We fix that here by manually checking out the repo first, so `gh` can see the `.git` dir.

Error: https://github.com/Quantinuum/tket2/actions/runs/27346814007/job/80798143094#step:2:12

drive-by: Replace `if [ $? -ne 0 ]` with `if ! {cmd}` so we actually run the `echo` before github aborts the job.