### PR TITLE
fix: Bundle extra extensions when exporting a CompilationState

### DIFF
--- a/tket-py/src/state/base.rs
+++ b/tket-py/src/state/base.rs
@@ -83,9 +83,10 @@ impl CompilationState {
             Some(cfg) => envelope_config_from_py(cfg)?,
             None => EnvelopeConfig::binary(),
         };
+        let bundled_extensions = extra_extensions(&self.hugr);
         let mut buf = Vec::new();
         self.hugr
-            .store(&mut buf, config)
+            .store_with_exts(&mut buf, config, &bundled_extensions)
             .context("Could not encode CompilationState to bytes")?;
         Ok(buf)
     }
@@ -99,8 +100,9 @@ impl CompilationState {
             Some(cfg) => envelope_config_from_py(cfg)?,
             None => EnvelopeConfig::text(),
         };
+        let bundled_extensions = extra_extensions(&self.hugr);
         self.hugr
-            .store_str(config)
+            .store_str_with_exts(config, &bundled_extensions)
             .context("Could not encode CompilationState to string")
     }
 
@@ -215,6 +217,20 @@ pub fn envelope_config_from_py(config: Bound<'_, PyAny>) -> anyhow::Result<Envel
     });
 
     Ok(res)
+}
+
+/// Returns an extension registry with the extensions required to load a Hugr,
+/// minus the ones in [`embedded_extensions`].
+fn extra_extensions(hugr: &Hugr) -> ExtensionRegistry {
+    let mut registry = ExtensionRegistry::default();
+
+    for ext in hugr.extensions().iter_all() {
+        if REGISTRY.get_compatible(&ext.name, &ext.version).is_none() {
+            registry.register(ext.clone());
+        }
+    }
+
+    registry
 }
 
 /// Extension registry used for loading circuits.

--- a/tket-py/test/test_state.py
+++ b/tket-py/test/test_state.py
@@ -1,0 +1,36 @@
+from semver import Version
+
+from hugr import tys
+from hugr.ext import Extension, OpDef, OpDefSig
+from hugr.build.dfg import Function
+from hugr.hugr import Hugr
+from tket._state import (
+    CompilationState,
+)
+
+
+def _custom_extension_hugr() -> Hugr:
+    """Build a small HUGR using a Python-defined extension op."""
+    extension = Extension("test.custom", Version.parse("0.1.0"))
+    op_def = extension.add_op_def(
+        OpDef(
+            "gate",
+            OpDefSig(tys.FunctionType([tys.Qubit], [tys.Qubit])),
+        )
+    )
+
+    fn = Function("custom_op", [tys.Qubit])
+    [q] = fn.inputs()
+    [q] = fn.add_op(op_def.instantiate()).outputs()
+    fn.set_outputs(q)
+    return fn.hugr
+
+
+def test_custom_ext_roundtrip() -> None:
+    state = CompilationState.from_python(_custom_extension_hugr())
+
+    binary_roundtrip = CompilationState.from_bytes(state.to_bytes()).to_python()
+    text_roundtrip = CompilationState.from_str(state.to_str()).to_python()
+
+    assert "test.custom" in binary_roundtrip.used_extensions().ids()
+    assert "test.custom" in text_roundtrip.used_extensions().ids()


### PR DESCRIPTION
When exporting rust hugrs to python, we weren't including any extension in the package.

This change adds extensions not in the `embedded_extensions` set.