### PR TITLE
feat: Export extension registries from tket and tket-qsystem

### DIFF
--- a/qis-compiler/rust/lib.rs
+++ b/qis-compiler/rust/lib.rs
@@ -27,20 +27,11 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::vec::Vec;
 use std::{fs, str, vec};
-use tket::extension::{TKET_EXTENSION, TKET1_EXTENSION, rotation};
-use tket::hugr::extension::{ExtensionRegistry, prelude};
-use tket::hugr::std_extensions::arithmetic::{
-    conversions, float_ops, float_types, int_ops, int_types,
-};
-use tket::hugr::std_extensions::{collections, logic, ptr};
 use tket::hugr::{self, llvm::inkwell};
 use tket::hugr::{Hugr, HugrView, Node};
 use tket::llvm::rotation::RotationCodegenExtension;
 use tket_qsystem::QSystemPass;
-use tket_qsystem::extension::{
-    futures as qsystem_futures, gpu as qsystem_gpu, qsystem, random as qsystem_random,
-    result as qsystem_result, utils as qsystem_utils, wasm as qsystem_wasm,
-};
+use tket_qsystem::extension::{REGISTRY, qsystem};
 use tket_qsystem::llvm::array_utils::ArrayLowering;
 pub use tket_qsystem::llvm::futures::FuturesCodegenExtension;
 use tket_qsystem::llvm::{
@@ -56,37 +47,6 @@ mod utils;
 
 const LLVM_MAIN: &str = "qmain";
 const METADATA: &[(&str, &[&str])] = &[("name", &["mainlib"])];
-
-static REGISTRY: std::sync::LazyLock<ExtensionRegistry> = std::sync::LazyLock::new(|| {
-    ExtensionRegistry::new([
-        prelude::PRELUDE.to_owned(),
-        int_types::EXTENSION.to_owned(),
-        int_ops::EXTENSION.to_owned(),
-        float_types::EXTENSION.to_owned(),
-        float_ops::EXTENSION.to_owned(),
-        conversions::EXTENSION.to_owned(),
-        logic::EXTENSION.to_owned(),
-        ptr::EXTENSION.to_owned(),
-        collections::list::EXTENSION.to_owned(),
-        collections::array::EXTENSION.to_owned(),
-        collections::static_array::EXTENSION.to_owned(),
-        collections::borrow_array::EXTENSION.to_owned(),
-        qsystem_futures::EXTENSION.to_owned(),
-        qsystem_result::EXTENSION.to_owned(),
-        qsystem::EXTENSION.to_owned(),
-        qsystem::helios::EXTENSION.to_owned(),
-        qsystem::sol::EXTENSION.to_owned(),
-        qsystem_random::EXTENSION.to_owned(),
-        qsystem_utils::EXTENSION.to_owned(),
-        qsystem_gpu::EXTENSION.to_owned(),
-        qsystem_wasm::EXTENSION.to_owned(),
-        rotation::ROTATION_EXTENSION.to_owned(),
-        TKET_EXTENSION.to_owned(),
-        TKET1_EXTENSION.to_owned(),
-        tket::extension::debug::DEBUG_EXTENSION.to_owned(),
-        tket::extension::guppy::GUPPY_EXTENSION.to_owned(),
-    ])
-});
 
 #[derive(Debug)]
 /// Handles a series of errors

--- a/tket-py/src/state/base.rs
+++ b/tket-py/src/state/base.rs
@@ -1,7 +1,6 @@
 //! Rust-backed representation of circuits
 
 use std::num::NonZeroU8;
-use std::sync::LazyLock;
 
 use anyhow::Context;
 use hugr::envelope::{EnvelopeConfig, EnvelopeFormat, ZstdConfig};
@@ -17,6 +16,7 @@ use tket::serialize::pytket::{DecodeOptions, EncodeOptions};
 use tket::{Circuit, TketOp};
 use tket_json_rs::circuit_json::SerialCircuit;
 use tket_qsystem::QSystemPlatform;
+use tket_qsystem::extension::REGISTRY;
 use tket_qsystem::pytket::{qsystem_decoder_config, qsystem_encoder_config};
 
 use crate::ops::PyTketOp;
@@ -232,38 +232,6 @@ fn extra_extensions(hugr: &Hugr) -> ExtensionRegistry {
 
     registry
 }
-
-/// Extension registry used for loading circuits.
-///
-/// TODO: If we want to keep these synchronized with the extensions defined in
-/// tket and tket-qsystem, we should consider exporting public
-/// ExtensionRegistries from the crates.
-/// <https://github.com/Quantinuum/tket2/issues/1679>
-pub static REGISTRY: LazyLock<ExtensionRegistry> = LazyLock::new(|| {
-    let mut registry = hugr::std_extensions::std_reg();
-    registry.extend([
-        // tket extensions
-        tket::extension::TKET_EXTENSION.to_owned(),
-        tket::extension::TKET1_EXTENSION.to_owned(),
-        tket::extension::rotation::ROTATION_EXTENSION.to_owned(),
-        tket::extension::debug::DEBUG_EXTENSION.to_owned(),
-        tket::extension::guppy::GUPPY_EXTENSION.to_owned(),
-        tket::extension::global_phase::GLOBAL_PHASE_EXTENSION.to_owned(),
-        tket::extension::modifier::MODIFIER_EXTENSION.to_owned(),
-        tket::extension::measurement::MEASUREMENT_EXTENSION.to_owned(),
-        // tket-qsystem extensions
-        tket_qsystem::extension::gpu::EXTENSION.to_owned(),
-        tket_qsystem::extension::qsystem::EXTENSION.to_owned(),
-        tket_qsystem::extension::qsystem::helios::EXTENSION.to_owned(),
-        tket_qsystem::extension::qsystem::sol::EXTENSION.to_owned(),
-        tket_qsystem::extension::futures::EXTENSION.to_owned(),
-        tket_qsystem::extension::random::EXTENSION.to_owned(),
-        tket_qsystem::extension::result::EXTENSION.to_owned(),
-        tket_qsystem::extension::utils::EXTENSION.to_owned(),
-        tket_qsystem::extension::wasm::EXTENSION.to_owned(),
-    ]);
-    registry
-});
 
 /// Returns a list of extension ids supported by the CompilationState loader.
 ///

--- a/tket-py/test/test_state.py
+++ b/tket-py/test/test_state.py
@@ -52,6 +52,7 @@ def test_tket_exts_registry_matches_embedded_tket_extensions() -> None:
 
     # Currently missing from tket_exts
     # TODO: Add to tket_exts
+    # <https://github.com/Quantinuum/tket2/issues/1693>
     rust_tket_ids.discard("TKET1")
 
     assert python_tket_ids == rust_tket_ids

--- a/tket-py/test/test_state.py
+++ b/tket-py/test/test_state.py
@@ -4,9 +4,12 @@ from hugr import tys
 from hugr.ext import Extension, OpDef, OpDefSig
 from hugr.build.dfg import Function
 from hugr.hugr import Hugr
+from hugr.std import _std_extensions
 from tket._state import (
     CompilationState,
+    embedded_extensions,
 )
+from tket_exts import tket_registry
 
 
 def _custom_extension_hugr() -> Hugr:
@@ -34,3 +37,21 @@ def test_custom_ext_roundtrip() -> None:
 
     assert "test.custom" in binary_roundtrip.used_extensions().ids()
     assert "test.custom" in text_roundtrip.used_extensions().ids()
+
+
+def test_tket_exts_registry_matches_embedded_tket_extensions() -> None:
+    """Keep tket-py's embedded extension registry in sync with tket_exts."""
+    python_tket_ids = set(tket_registry().ids())
+    prelude = set(_std_extensions().ids())
+
+    rust_tket_ids = set(
+        extension_id
+        for extension_id in embedded_extensions()
+        if extension_id not in prelude
+    )
+
+    # Currently missing from tket_exts
+    # TODO: Add to tket_exts
+    rust_tket_ids.discard("TKET1")
+
+    assert python_tket_ids == rust_tket_ids

--- a/tket-qsystem/src/bin/tket-qsystem.rs
+++ b/tket-qsystem/src/bin/tket-qsystem.rs
@@ -2,32 +2,12 @@
 
 use anyhow::Result;
 use clap::Parser as _;
-use hugr::extension::ExtensionRegistry;
 use tket_qsystem::cli::CliArgs;
 
 fn main() -> Result<()> {
     match CliArgs::parse() {
         CliArgs::GenExtensions(args) => {
-            let reg = ExtensionRegistry::new([
-                tket::extension::TKET_EXTENSION.to_owned(),
-                tket::extension::rotation::ROTATION_EXTENSION.to_owned(),
-                tket::extension::debug::DEBUG_EXTENSION.to_owned(),
-                tket::extension::guppy::GUPPY_EXTENSION.to_owned(),
-                tket::extension::global_phase::GLOBAL_PHASE_EXTENSION.to_owned(),
-                tket::extension::modifier::MODIFIER_EXTENSION.to_owned(),
-                tket::extension::measurement::MEASUREMENT_EXTENSION.to_owned(),
-                tket_qsystem::extension::gpu::EXTENSION.to_owned(),
-                tket_qsystem::extension::qsystem::EXTENSION.to_owned(),
-                tket_qsystem::extension::qsystem::helios::EXTENSION.to_owned(),
-                tket_qsystem::extension::qsystem::sol::EXTENSION.to_owned(),
-                tket_qsystem::extension::futures::EXTENSION.to_owned(),
-                tket_qsystem::extension::random::EXTENSION.to_owned(),
-                tket_qsystem::extension::result::EXTENSION.to_owned(),
-                tket_qsystem::extension::utils::EXTENSION.to_owned(),
-                tket_qsystem::extension::wasm::EXTENSION.to_owned(),
-            ]);
-
-            args.run_dump(&reg)?;
+            args.run_dump(&tket_qsystem::extension::REGISTRY)?;
         }
         _ => {
             eprintln!("Unknown command");

--- a/tket-qsystem/src/extension.rs
+++ b/tket-qsystem/src/extension.rs
@@ -1,4 +1,9 @@
 //! This module defines the Hugr extensions used by tket-qsystem.
+use std::sync::{Arc, LazyLock};
+
+use hugr::Extension;
+use hugr::extension::ExtensionRegistry;
+
 pub mod classical_compute;
 pub use classical_compute::gpu;
 pub use classical_compute::wasm;
@@ -7,3 +12,32 @@ pub mod qsystem;
 pub mod random;
 pub mod result;
 pub mod utils;
+
+/// Extension registry including std, tket, and qsystem extensions.
+///
+/// This is the default registry for consumers that need to load HUGRs using
+/// the extensions embedded in the tket-qsystem distribution.
+pub static REGISTRY: LazyLock<ExtensionRegistry> = LazyLock::new(|| {
+    let mut registry = tket::extension::REGISTRY.to_owned();
+    registry.extend(qsystem_extensions());
+    registry
+});
+
+/// Returns the extension definitions owned by the `tket-qsystem` crate.
+///
+/// The list intentionally excludes std and base tket extensions so callers can
+/// combine it with [`tket::extension::tket_extensions`] or another base
+/// registry without duplicating either list.
+pub fn qsystem_extensions() -> [Arc<Extension>; 9] {
+    [
+        gpu::EXTENSION.to_owned(),
+        qsystem::EXTENSION.to_owned(),
+        qsystem::helios::EXTENSION.to_owned(),
+        qsystem::sol::EXTENSION.to_owned(),
+        futures::EXTENSION.to_owned(),
+        random::EXTENSION.to_owned(),
+        result::EXTENSION.to_owned(),
+        utils::EXTENSION.to_owned(),
+        wasm::EXTENSION.to_owned(),
+    ]
+}

--- a/tket/src/extension.rs
+++ b/tket/src/extension.rs
@@ -54,19 +54,29 @@ pub static ref TKET1_EXTENSION: Arc<Extension>  = {
     })
 };
 
-/// Extension registry including the prelude, std, TKET1, and TketOps extensions.
-pub(crate) static ref REGISTRY: ExtensionRegistry = ExtensionRegistry::new(
-    STD_REG.iter_all().cloned().chain([
-    TKET1_EXTENSION.to_owned(),
-    TKET_EXTENSION.to_owned(),
-    debug::DEBUG_EXTENSION.to_owned(),
-    global_phase::GLOBAL_PHASE_EXTENSION.to_owned(),
-    guppy::GUPPY_EXTENSION.to_owned(),
-    modifier::MODIFIER_EXTENSION.to_owned(),
-    measurement::MEASUREMENT_EXTENSION.to_owned(),
-    rotation::ROTATION_EXTENSION.to_owned()
-]));
+/// Extension registry including the prelude, std, TKET1, and tket extensions.
+pub static ref REGISTRY: ExtensionRegistry = ExtensionRegistry::new(
+    STD_REG.iter_all().cloned().chain(tket_extensions())
+);
 
+}
+
+/// Returns the extension definitions owned by the `tket` crate.
+///
+/// The list is used to build [`REGISTRY`] and by downstream crates that need to
+/// extend the same base set without maintaining a second copy of the tket
+/// extension list.
+pub fn tket_extensions() -> [Arc<Extension>; 8] {
+    [
+        TKET1_EXTENSION.to_owned(),
+        TKET_EXTENSION.to_owned(),
+        debug::DEBUG_EXTENSION.to_owned(),
+        global_phase::GLOBAL_PHASE_EXTENSION.to_owned(),
+        guppy::GUPPY_EXTENSION.to_owned(),
+        modifier::MODIFIER_EXTENSION.to_owned(),
+        measurement::MEASUREMENT_EXTENSION.to_owned(),
+        rotation::ROTATION_EXTENSION.to_owned(),
+    ]
 }
 
 struct Tk1Signature([TypeParam; 1]);


### PR DESCRIPTION
Centralizes the multiple extension registry definitions used around the crates:

- `tket` now exports a public `tket_extensions` list as well as a `REGISTRY` with those + prelude extensions.
- `tket-qsystem` exports a `qsystem_extensions` and a registry with `qsystem_extensions + tket_extensions + prelude`.
- The rest of the crates use those definitions, instead of redefining the lists.

Fixes an issue where `qis-compiler`'s registry was missing `tket.measurement`.
Fixes #1679.
Adds a test to check that `tket_exts` is in sync with these lists (it's currently missing `TKET1`, but I'll fix that in another PR).