### PR TITLE
feat: Option to include/omit tket registers in CompilerState.to_bytes

### DIFF
--- a/tket-py/src/state/base.rs
+++ b/tket-py/src/state/base.rs
@@ -77,13 +77,22 @@ impl CompilationState {
     /// Encode the circuit as a HUGR envelope.
     ///
     /// If no config is given, it defaults to the default binary envelope.
-    #[pyo3(signature = (config = None))]
-    pub fn to_bytes(&self, config: Option<Bound<'_, PyAny>>) -> anyhow::Result<Vec<u8>> {
+    ///
+    /// If `omit_tket_exts` is true, the extensions in [`embedded_extensions`]
+    /// will not be not be included in the envelope even when they are used in the
+    /// HUGR. This is useful when sending the HUGR to other components that
+    /// already have the tket extensions available.
+    #[pyo3(signature = (config = None, *, omit_tket_exts = true))]
+    pub fn to_bytes(
+        &self,
+        config: Option<Bound<'_, PyAny>>,
+        omit_tket_exts: bool,
+    ) -> anyhow::Result<Vec<u8>> {
         let config = match config {
             Some(cfg) => envelope_config_from_py(cfg)?,
             None => EnvelopeConfig::binary(),
         };
-        let bundled_extensions = extra_extensions(&self.hugr);
+        let bundled_extensions = extra_extensions(&self.hugr, omit_tket_exts);
         let mut buf = Vec::new();
         self.hugr
             .store_with_exts(&mut buf, config, &bundled_extensions)
@@ -94,13 +103,22 @@ impl CompilationState {
     /// Encode the circuit as a HUGR envelope.
     ///
     /// If no config is given, it defaults to the default text envelope.
-    #[pyo3(signature = (config = None))]
-    pub fn to_str(&self, config: Option<Bound<'_, PyAny>>) -> anyhow::Result<String> {
+    ///
+    /// If `omit_tket_exts` is true, the extensions in [`embedded_extensions`]
+    /// will not be not be included in the envelope even when they are used in the
+    /// HUGR. This is useful when sending the HUGR to other components that
+    /// already have the tket extensions available.
+    #[pyo3(signature = (config = None, *, omit_tket_exts = true))]
+    pub fn to_str(
+        &self,
+        config: Option<Bound<'_, PyAny>>,
+        omit_tket_exts: bool,
+    ) -> anyhow::Result<String> {
         let config = match config {
             Some(cfg) => envelope_config_from_py(cfg)?,
             None => EnvelopeConfig::text(),
         };
-        let bundled_extensions = extra_extensions(&self.hugr);
+        let bundled_extensions = extra_extensions(&self.hugr, omit_tket_exts);
         self.hugr
             .store_str_with_exts(config, &bundled_extensions)
             .context("Could not encode CompilationState to string")
@@ -219,9 +237,14 @@ pub fn envelope_config_from_py(config: Bound<'_, PyAny>) -> anyhow::Result<Envel
     Ok(res)
 }
 
-/// Returns an extension registry with the extensions required to load a Hugr,
-/// minus the ones in [`embedded_extensions`].
-fn extra_extensions(hugr: &Hugr) -> ExtensionRegistry {
+/// Returns an extension registry with the extensions required to load a Hugr.
+///
+/// If `omit_tket_exts` is true, ignore the extensions in [`embedded_extensions`].
+fn extra_extensions(hugr: &Hugr, omit_tket_exts: bool) -> ExtensionRegistry {
+    if !omit_tket_exts {
+        return hugr.extensions().clone();
+    }
+
     let mut registry = ExtensionRegistry::default();
 
     for ext in hugr.extensions().iter_all() {

--- a/tket-py/tket/_state/__init__.py
+++ b/tket-py/tket/_state/__init__.py
@@ -148,20 +148,40 @@ class CompilationState:
             _py_extensions=None,
         )
 
-    def to_bytes(self, config: EnvelopeConfig | None = None) -> bytes:
+    def to_bytes(
+        self, config: EnvelopeConfig | None = None, *, omit_tket_exts: bool = True
+    ) -> bytes:
         """Serialize the program to a HUGR envelope byte string.
 
         Some envelope formats can be encoded into a string. See :meth:`to_str`.
-        """
-        return self._inner.to_bytes(config)
 
-    def to_str(self, config: EnvelopeConfig | None = None) -> str:
+        Args:
+            config: The envelope configuration to use.
+                If not given, uses the default binary encoding.
+            omit_tket_exts: If true, the extensions in :meth:`embedded_extensions`
+                will not be not be included in the envelope even when they are used in the
+                HUGR. This is useful when sending the HUGR to other components that
+                already have the tket extensions available.
+        """
+        return self._inner.to_bytes(config, omit_tket_exts=omit_tket_exts)
+
+    def to_str(
+        self, config: EnvelopeConfig | None = None, *, omit_tket_exts: bool = True
+    ) -> str:
         """Serialize the program to a HUGR envelope string.
 
         Not all envelope formats can be encoded into a string.
         See :meth:`to_bytes` for a more general method.
+
+        Args:
+            config: The envelope configuration to use.
+                If not given, uses the default textual encoding.
+            omit_tket_exts: If true, the extensions in :meth:`embedded_extensions`
+                will not be not be included in the envelope even when they are used in the
+                HUGR. This is useful when sending the HUGR to other components that
+                already have the tket extensions available.
         """
-        return self._inner.to_str(config)
+        return self._inner.to_str(config, omit_tket_exts=omit_tket_exts)
 
     def apply_rewrite(self, rewrite: CircuitRewrite) -> None:
         """Apply a rewrite command to this program."""

--- a/tket-py/tket/_tket/state.pyi
+++ b/tket-py/tket/_tket/state.pyi
@@ -29,7 +29,9 @@ class CompilationState:
     def apply_rewrite(self, rw) -> None:
         """Apply a rewrite on the circuit."""
 
-    def to_bytes(self, config: EnvelopeConfig | None = None) -> bytes:
+    def to_bytes(
+        self, config: EnvelopeConfig | None = None, *, omit_tket_exts: bool = True
+    ) -> bytes:
         """Encode the circuit as a HUGR envelope.
 
         Some envelope formats can be encoded into a string. See :meth:`to_str`.
@@ -37,9 +39,15 @@ class CompilationState:
         Args:
             config: The envelope configuration to use.
                 If not given, uses the default binary encoding.
+            omit_tket_exts: If true, the extensions in :meth:`embedded_extensions`
+                will not be not be included in the envelope even when they are used in the
+                HUGR. This is useful when sending the HUGR to other components that
+                already have the tket extensions available.
         """
 
-    def to_str(self, config: EnvelopeConfig | None = None) -> str:
+    def to_str(
+        self, config: EnvelopeConfig | None = None, *, omit_tket_exts: bool = True
+    ) -> str:
         """Encode the circuit as a HUGR envelope string.
 
         Not all envelope formats can be encoded into a string.
@@ -48,6 +56,10 @@ class CompilationState:
         Args:
             config: The envelope configuration to use.
                 If not given, uses the default textual encoding.
+            omit_tket_exts: If true, the extensions in :meth:`embedded_extensions`
+                will not be not be included in the envelope even when they are used in the
+                HUGR. This is useful when sending the HUGR to other components that
+                already have the tket extensions available.
         """
 
     @staticmethod


### PR DESCRIPTION
`CompilerState.to_bytes` / `.to_str` encodes a package created from the hugr and includes any extension not in the prelude or in tket's `bundled_extensions`.

This is done to avoid the extra encoding/decoding overhead when passing hugrs across libraries that already have access to the tket extensions, but sometimes we may want encode a portable hugr envelope with all the extensions.

I kept this as default-omit since it's the existing behaviour. We can discuss wether it should include everything by default or not.