### PR TITLE
fix: Deduplicate lowering replacement functions by using Visibility::Public

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1776245669,
-        "narHash": "sha256-vK5IG4QgfbtYhIo0KlHgTJmDbHZCYU1ELIbHoK/Ap94=",
+        "lastModified": 1781627264,
+        "narHash": "sha256-TPj5d5MUyvuQZjsfDAAoYJ0SB+tNNNBrdCpD8XL0WeU=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "99d2072320398af5ce4eaefb11f71e03f0f6d9a8",
+        "rev": "0fe5629a2955141c336b95e384e2c793c01214fb",
         "type": "github"
       },
       "original": {
@@ -17,69 +17,13 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778507602,
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762808025,
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -92,11 +36,7 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ],
         "rust-overlay": "rust-overlay"
       }
     },
@@ -107,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776222810,
-        "narHash": "sha256-5TD8MYqLMcJi9yV/9jq2dVUPtnu/lKZPD61esQCgvqs=",
+        "lastModified": 1781752752,
+        "narHash": "sha256-kVG5tV9hddPviGAgqf9sGSuStvv+HAB9onfKqGptV0k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4d6fee71fea68418a48992409b47f1183d0dd111",
+        "rev": "c06d86dabe5b92982b9d67acccb9990d58da3a0e",
         "type": "github"
       },
       "original": {

--- a/tket-qsystem/src/extension/qsystem/lower.rs
+++ b/tket-qsystem/src/extension/qsystem/lower.rs
@@ -3,8 +3,7 @@ use hugr::builder::{Container, HugrBuilder};
 use hugr::core::Visibility;
 use hugr::extension::prelude::{Barrier, Noop, bool_t};
 use hugr::extension::simple_op::{MakeExtensionOp, MakeRegisteredOp};
-use hugr::hugr::linking::NameLinkingPolicy;
-use hugr::hugr::linking::OnMultiDefn;
+use hugr::hugr::linking::{NameLinkingPolicy, OnMultiDefn};
 use hugr::hugr::patch::insert_cut::InsertCutError;
 use hugr::ops::handle::{FuncID, NodeHandle};
 use hugr::{
@@ -357,7 +356,7 @@ fn build_func(platform: QSystemPlatform, op: TketOp) -> Result<Hugr, LowerTk2Err
         platform_str(platform),
         op.op_id().to_lowercase()
     );
-    let mut f_build = FunctionBuilder::new(f_name, sig)?;
+    let mut f_build = FunctionBuilder::new_vis(f_name, sig, hugr::core::Visibility::Public)?;
     let outputs = build_func_outputs(platform, &mut f_build, op)?;
     Ok(f_build.finish_hugr_with_outputs(outputs)?)
 }
@@ -418,6 +417,13 @@ where
     Ok(outputs)
 }
 
+fn build_to_radians(b: &mut impl Dataflow, rotation: Wire) -> Result<Wire, BuildError> {
+    let turns = b.add_to_halfturns(rotation)?;
+    let pi = pi_mul_f64(b, 1.0);
+    let float = b.add_dataflow_op(FloatOps::fmul, [turns, pi])?.out_wire(0);
+    Ok(float)
+}
+
 /// Given a hugr with a function definition as entrypoint, constructs a
 /// [`NodeTemplate::LinkedHugr`] that produces a call to the function.
 //
@@ -443,13 +449,6 @@ fn func_as_node_template(func_def: Hugr) -> NodeTemplate {
         Box::new(call_hugr),
         NameLinkingPolicy::default().on_multiple_defn(OnMultiDefn::UseTarget),
     )
-}
-
-fn build_to_radians(b: &mut impl Dataflow, rotation: Wire) -> Result<Wire, BuildError> {
-    let turns = b.add_to_halfturns(rotation)?;
-    let pi = pi_mul_f64(b, 1.0);
-    let float = b.add_dataflow_op(FloatOps::fmul, [turns, pi])?.out_wire(0);
-    Ok(float)
 }
 
 /// Map a [`TketOp`] to the [`SharedOp`] it directly corresponds to, if any.
@@ -627,9 +626,10 @@ fn build_helios_op_for_sol() -> Result<Hugr, LowerTk2Error> {
         .expect("valid registered HeliosOp")
         .signature()
         .into_owned();
-    let mut f_build = FunctionBuilder::new(
+    let mut f_build = FunctionBuilder::new_vis(
         "__tk2_helios_to_sol_zzphase",
         Signature::new(sig.input, sig.output),
+        hugr::core::Visibility::Public,
     )?;
     let [qb1, qb2, angle] = f_build.input_wires_arr();
     let mut synth = SolSynthesizer::new(&mut f_build);
@@ -646,9 +646,10 @@ fn build_sol_op_for_helios() -> Result<Hugr, LowerTk2Error> {
         .expect("valid registered SolOp")
         .signature()
         .into_owned();
-    let mut f_build = FunctionBuilder::new(
+    let mut f_build = FunctionBuilder::new_vis(
         "__tk2_sol_to_helios_phasedxx",
         Signature::new(sig.input, sig.output),
+        hugr::core::Visibility::Public,
     )?;
     let [qb1, qb2, angle1, angle2] = f_build.input_wires_arr();
     let mut synth = HeliosSynthesizer::new(&mut f_build);
@@ -1207,7 +1208,6 @@ mod test {
     /// Two `TketOp::H` ops lowered to Helios should share exactly one
     /// `__tk2_helios_h` replacement function (deduplication via `OnMultiDefn::UseTarget`).
     #[test]
-    #[should_panic(expected = "Expected exactly one __tk2_helios_h replacement function")]
     fn test_duplicate_tket_ops_produce_single_replacement_func() {
         let mut b = FunctionBuilder::new("f", Signature::new_endo(type_row![])).unwrap();
         let [q] = b.add_dataflow_op(TketOp::QAlloc, []).unwrap().outputs_arr();

--- a/tket-qsystem/src/extension/qsystem/lower.rs
+++ b/tket-qsystem/src/extension/qsystem/lower.rs
@@ -1,11 +1,7 @@
 use derive_more::{Display, Error, From};
-use hugr::builder::{Container, HugrBuilder};
-use hugr::core::Visibility;
 use hugr::extension::prelude::{Barrier, Noop, bool_t};
 use hugr::extension::simple_op::{MakeExtensionOp, MakeRegisteredOp};
-use hugr::hugr::linking::{NameLinkingPolicy, OnMultiDefn};
 use hugr::hugr::patch::insert_cut::InsertCutError;
-use hugr::ops::handle::{FuncID, NodeHandle};
 use hugr::{
     Hugr, HugrView, Node, Wire,
     builder::{BuildError, Dataflow, DataflowHugr, FunctionBuilder},
@@ -293,7 +289,9 @@ pub fn lower_tk2_ops(
                     let template = match funcs.entry(tket_op) {
                         Entry::Occupied(e) => e.get().clone(),
                         Entry::Vacant(e) => {
-                            let t = func_as_node_template(build_func(platform, tket_op)?);
+                            let t =
+                                NodeTemplate::call_to_function(build_func(platform, tket_op)?, &[])
+                                    .map_err(LowerTk2Error::BuildError)?;
                             e.insert(t).clone()
                         }
                     };
@@ -424,33 +422,6 @@ fn build_to_radians(b: &mut impl Dataflow, rotation: Wire) -> Result<Wire, Build
     Ok(float)
 }
 
-/// Given a hugr with a function definition as entrypoint, constructs a
-/// [`NodeTemplate::LinkedHugr`] that produces a call to the function.
-//
-// TODO: Use [`NodeTemplate::call_to_function`] once it gets released in `hugr 0.25.6`.
-fn func_as_node_template(func_def: Hugr) -> NodeTemplate {
-    // Create a replacement hugr for the op nodes: Add a `call` node in the `func_def` hugr and set it as entrypoint.
-    let func_signature = func_def.inner_function_type().unwrap().into_owned();
-
-    // Build a new hugr and insert the function definition into it
-    let mut b = FunctionBuilder::new_vis("", func_signature, Visibility::Private).unwrap();
-    let func_id = FuncID::<true>::from(
-        b.module_root_builder()
-            .add_hugr(func_def)
-            .inserted_entrypoint,
-    );
-
-    // Build a call to the function in the new separate function.
-    let call = b.call(&func_id, &[], b.input_wires()).unwrap();
-    let mut call_hugr = b.finish_hugr_with_outputs(call.outputs()).unwrap();
-    call_hugr.set_entrypoint(call.node());
-
-    NodeTemplate::LinkedHugr(
-        Box::new(call_hugr),
-        NameLinkingPolicy::default().on_multiple_defn(OnMultiDefn::UseTarget),
-    )
-}
-
 /// Map a [`TketOp`] to the [`SharedOp`] it directly corresponds to, if any.
 ///
 /// These are the ops that have a platform-independent 1:1 replacement and
@@ -565,7 +536,8 @@ fn apply_cross_platform_helios(
             let template = match cache.entry(h_op) {
                 Entry::Occupied(e) => e.get().clone(),
                 Entry::Vacant(e) => {
-                    let t = func_as_node_template(build_helios_op_for_sol()?);
+                    let t = NodeTemplate::call_to_function(build_helios_op_for_sol()?, &[])
+                        .map_err(LowerTk2Error::BuildError)?;
                     e.insert(t).clone()
                 }
             };
@@ -603,7 +575,8 @@ fn apply_cross_platform_sol(
             let template = match cache.entry(s_op) {
                 Entry::Occupied(e) => e.get().clone(),
                 Entry::Vacant(e) => {
-                    let t = func_as_node_template(build_sol_op_for_helios()?);
+                    let t = NodeTemplate::call_to_function(build_sol_op_for_helios()?, &[])
+                        .map_err(LowerTk2Error::BuildError)?;
                     e.insert(t).clone()
                 }
             };

--- a/tket-qsystem/src/extension/qsystem/lower.rs
+++ b/tket-qsystem/src/extension/qsystem/lower.rs
@@ -1204,6 +1204,35 @@ mod test {
         );
     }
 
+    /// Two `TketOp::H` ops lowered to Helios should share exactly one
+    /// `__tk2_helios_h` replacement function (deduplication via `OnMultiDefn::UseTarget`).
+    #[test]
+    #[should_panic(expected = "Expected exactly one __tk2_helios_h replacement function")]
+    fn test_duplicate_tket_ops_produce_single_replacement_func() {
+        let mut b = FunctionBuilder::new("f", Signature::new_endo(type_row![])).unwrap();
+        let [q] = b.add_dataflow_op(TketOp::QAlloc, []).unwrap().outputs_arr();
+        let [q] = b.add_dataflow_op(TketOp::H, [q]).unwrap().outputs_arr();
+        let [q] = b.add_dataflow_op(TketOp::H, [q]).unwrap().outputs_arr();
+        b.add_dataflow_op(TketOp::QFree, [q]).unwrap();
+        let mut h = b.finish_hugr_with_outputs([]).unwrap();
+
+        lower_tk2_ops(&mut h, Preserve::Public, QSystemPlatform::Helios).unwrap();
+        h.validate().unwrap();
+
+        let h_func_count = h
+            .nodes()
+            .filter(|&n| {
+                h.get_optype(n)
+                    .as_func_defn()
+                    .is_some_and(|f| *f.func_name() == "__tk2_helios_h")
+            })
+            .count();
+        assert_eq!(
+            h_func_count, 1,
+            "Expected exactly one __tk2_helios_h replacement function"
+        );
+    }
+
     /// Legacy `tket.qsystem` ops that correspond to [`SharedOp`] variants
     /// (e.g. `Reset`, `TryQAlloc`) can be lowered to Sol directly. Helios-specific
     /// ops are remapped via the cross-platform decomposition path.

--- a/tket-qsystem/src/llvm/qsystem.rs
+++ b/tket-qsystem/src/llvm/qsystem.rs
@@ -577,6 +577,54 @@ mod test {
         check_emission!(hugr, llvm_ctx);
     }
 
+    /// Lowering two `TketOp::H` gates should produce a single shared
+    /// `__tk2_helios_h` replacement function. The emitted LLVM (snapshot
+    /// taken pre-inlining via `check_emission!`) should therefore contain
+    /// exactly one definition of that function rather than one per gate.
+    #[rstest]
+    fn emit_duplicate_h_codegen(mut llvm_ctx: TestContext) {
+        use crate::extension::qsystem::lower_tk2_ops;
+        use crate::llvm::{futures::FuturesCodegenExtension, prelude::QISPreludeCodegen};
+        use hugr::builder::{Dataflow, DataflowHugr, FunctionBuilder};
+        use hugr::extension::prelude::qb_t;
+        use hugr::types::Signature;
+        use tket::TketOp;
+        use tket::passes::composable::Preserve;
+
+        llvm_ctx.add_extensions(|ceb| {
+            ceb.add_extension(QSystemCodegenExtension::new(
+                QSystemPlatform::Helios,
+                QISPreludeCodegen,
+            ))
+            .add_extension(FuturesCodegenExtension)
+            .add_prelude_extensions(QISPreludeCodegen)
+            .add_float_extensions()
+            .add_logic_extensions()
+        });
+
+        let mut b = FunctionBuilder::new("main", Signature::new_endo(vec![qb_t()])).unwrap();
+        let [q] = b.input_wires_arr();
+        let [q] = b.add_dataflow_op(TketOp::H, [q]).unwrap().outputs_arr();
+        let [q] = b.add_dataflow_op(TketOp::H, [q]).unwrap().outputs_arr();
+        let mut hugr = b.finish_hugr_with_outputs([q]).unwrap();
+
+        // We invoke `lower_tk2_ops` directly rather than the full `QSystemPass`
+        // so that the snapshot stays small and pre-inlining (no monomorphize /
+        // dead-func / constant-fold passes to obscure the duplication). The
+        // meaningful signal here is the *number* of `__tk2_helios_h`
+        // definitions: one (shared) after the fix, two (one per gate) before.
+        //
+        // A side effect of skipping the full pass is that the replacement
+        // function keeps `external` (public) linkage in the snapshot. In the
+        // real `QSystemPass` pipeline `hide_non_pub_funcs` re-marks these new
+        // helpers private after lowering (giving `internal` linkage), as
+        // asserted by `lib::test::no_public_funcs`. So the linkage shown here
+        // does not reflect what ships; only the definition count does.
+        lower_tk2_ops(&mut hugr, Preserve::Public, QSystemPlatform::Helios).unwrap();
+
+        check_emission!(hugr, llvm_ctx);
+    }
+
     #[rstest]
     #[case::rz(1, SolOp::Rz)]
     #[case::phased_x(2, SolOp::PhasedX)]

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_duplicate_h_codegen@llvm21.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_duplicate_h_codegen@llvm21.snap
@@ -10,28 +10,18 @@ alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  %1 = call i64 @_hl.__tk2_helios_h.6(i64 %0), !dbg !8
-  %2 = call i64 @_hl.__tk2_helios_h.17(i64 %1), !dbg !9
+  %1 = call i64 @_hl.__tk2_helios_h.6(i64 %0), !dbg !7
+  %2 = call i64 @_hl.__tk2_helios_h.6(i64 %1), !dbg !8
   ret i64 %2
 }
 
-define internal i64 @_hl.__tk2_helios_h.6(i64 %0) !dbg !10 {
+define i64 @_hl.__tk2_helios_h.6(i64 %0) !dbg !9 {
 alloca_block:
   br label %entry_block
 
 entry_block:                                      ; preds = %alloca_block
-  call void @___rxy(i64 %0, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !11
-  call void @___rz(i64 %0, double 0x400921FB54442D18), !dbg !12
-  ret i64 %0
-}
-
-define internal i64 @_hl.__tk2_helios_h.17(i64 %0) !dbg !13 {
-alloca_block:
-  br label %entry_block
-
-entry_block:                                      ; preds = %alloca_block
-  call void @___rxy(i64 %0, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !14
-  call void @___rz(i64 %0, double 0x400921FB54442D18), !dbg !15
+  call void @___rxy(i64 %0, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !10
+  call void @___rz(i64 %0, double 0x400921FB54442D18), !dbg !11
   ret i64 %0
 }
 
@@ -44,17 +34,13 @@ declare void @___rz(i64, double)
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = distinct !DICompileUnit(language: DW_LANG_Python, file: !2, producer: "hugr_llvm_test", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-!2 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "/rhvZsHeDgUnyeIVwAutKJHaZEPSZwPX")
-!3 = distinct !DISubprogram(name: "_hl.main.1", linkageName: "_hl.main.1", scope: null, file: !4, line: 25254, type: !5, scopeLine: 25255, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
-!4 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "")
-!5 = !DISubroutineType(types: !6)
-!6 = !{!7, !7}
-!7 = !DIBasicType(name: "i64", size: 64, encoding: DW_ATE_unsigned)
-!8 = !DILocation(line: 27062, column: 402, scope: !3)
-!9 = !DILocation(line: 5388, column: 404, scope: !3)
-!10 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.6", linkageName: "_hl.__tk2_helios_h.6", scope: null, file: !4, line: 23594, type: !5, scopeLine: 23595, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
-!11 = !DILocation(line: 23807, column: 508, scope: !10)
-!12 = !DILocation(line: 6962, column: 212, scope: !10)
-!13 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.17", linkageName: "_hl.__tk2_helios_h.17", scope: null, file: !4, line: 1712, type: !5, scopeLine: 1713, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
-!14 = !DILocation(line: 21129, column: 412, scope: !13)
-!15 = !DILocation(line: 4112, column: 51, scope: !13)
+!2 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "")
+!3 = distinct !DISubprogram(name: "_hl.main.1", linkageName: "_hl.main.1", scope: null, file: !2, line: 25254, type: !4, scopeLine: 25255, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6, !6}
+!6 = !DIBasicType(name: "i64", size: 64, encoding: DW_ATE_unsigned)
+!7 = !DILocation(line: 27062, column: 402, scope: !3)
+!8 = !DILocation(line: 5388, column: 404, scope: !3)
+!9 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.6", linkageName: "_hl.__tk2_helios_h.6", scope: null, file: !2, line: 23594, type: !4, scopeLine: 23595, spFlags: DISPFlagDefinition, unit: !1)
+!10 = !DILocation(line: 23807, column: 508, scope: !9)
+!11 = !DILocation(line: 6962, column: 212, scope: !9)

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_duplicate_h_codegen@llvm21.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_duplicate_h_codegen@llvm21.snap
@@ -1,0 +1,60 @@
+---
+source: tket-qsystem/src/llvm/qsystem.rs
+expression: mod_str
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define internal i64 @_hl.main.1(i64 %0) !dbg !3 {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %1 = call i64 @_hl.__tk2_helios_h.6(i64 %0), !dbg !8
+  %2 = call i64 @_hl.__tk2_helios_h.17(i64 %1), !dbg !9
+  ret i64 %2
+}
+
+define internal i64 @_hl.__tk2_helios_h.6(i64 %0) !dbg !10 {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  call void @___rxy(i64 %0, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !11
+  call void @___rz(i64 %0, double 0x400921FB54442D18), !dbg !12
+  ret i64 %0
+}
+
+define internal i64 @_hl.__tk2_helios_h.17(i64 %0) !dbg !13 {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  call void @___rxy(i64 %0, double 0x3FF921FB54442D18, double 0xBFF921FB54442D18), !dbg !14
+  call void @___rz(i64 %0, double 0x400921FB54442D18), !dbg !15
+  ret i64 %0
+}
+
+declare void @___rxy(i64, double, double)
+
+declare void @___rz(i64, double)
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_Python, file: !2, producer: "hugr_llvm_test", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!2 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "/rhvZsHeDgUnyeIVwAutKJHaZEPSZwPX")
+!3 = distinct !DISubprogram(name: "_hl.main.1", linkageName: "_hl.main.1", scope: null, file: !4, line: 25254, type: !5, scopeLine: 25255, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
+!4 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "")
+!5 = !DISubroutineType(types: !6)
+!6 = !{!7, !7}
+!7 = !DIBasicType(name: "i64", size: 64, encoding: DW_ATE_unsigned)
+!8 = !DILocation(line: 27062, column: 402, scope: !3)
+!9 = !DILocation(line: 5388, column: 404, scope: !3)
+!10 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.6", linkageName: "_hl.__tk2_helios_h.6", scope: null, file: !4, line: 23594, type: !5, scopeLine: 23595, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
+!11 = !DILocation(line: 23807, column: 508, scope: !10)
+!12 = !DILocation(line: 6962, column: 212, scope: !10)
+!13 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.17", linkageName: "_hl.__tk2_helios_h.17", scope: null, file: !4, line: 1712, type: !5, scopeLine: 1713, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
+!14 = !DILocation(line: 21129, column: 412, scope: !13)
+!15 = !DILocation(line: 4112, column: 51, scope: !13)

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_duplicate_h_codegen@pre-mem2reg@llvm21.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_duplicate_h_codegen@pre-mem2reg@llvm21.snap
@@ -16,18 +16,18 @@ alloca_block:
 entry_block:                                      ; preds = %alloca_block
   store i64 %0, ptr %"2_0", align 4
   %"2_01" = load i64, ptr %"2_0", align 4
-  %1 = call i64 @_hl.__tk2_helios_h.6(i64 %"2_01"), !dbg !8
-  store i64 %1, ptr %"4_0", align 4, !dbg !8
+  %1 = call i64 @_hl.__tk2_helios_h.6(i64 %"2_01"), !dbg !7
+  store i64 %1, ptr %"4_0", align 4, !dbg !7
   %"4_02" = load i64, ptr %"4_0", align 4
-  %2 = call i64 @_hl.__tk2_helios_h.17(i64 %"4_02"), !dbg !9
-  store i64 %2, ptr %"5_0", align 4, !dbg !9
+  %2 = call i64 @_hl.__tk2_helios_h.6(i64 %"4_02"), !dbg !8
+  store i64 %2, ptr %"5_0", align 4, !dbg !8
   %"5_03" = load i64, ptr %"5_0", align 4
   store i64 %"5_03", ptr %"0", align 4
   %"04" = load i64, ptr %"0", align 4
   ret i64 %"04"
 }
 
-define internal i64 @_hl.__tk2_helios_h.6(i64 %0) !dbg !10 {
+define i64 @_hl.__tk2_helios_h.6(i64 %0) !dbg !9 {
 alloca_block:
   %"0" = alloca i64, align 8
   %"14_0" = alloca double, align 8
@@ -46,45 +46,14 @@ entry_block:                                      ; preds = %alloca_block
   %"7_01" = load i64, ptr %"7_0", align 4
   %"12_02" = load double, ptr %"12_0", align 8
   %"14_03" = load double, ptr %"14_0", align 8
-  call void @___rxy(i64 %"7_01", double %"12_02", double %"14_03"), !dbg !11
-  store i64 %"7_01", ptr %"15_0", align 4, !dbg !11
+  call void @___rxy(i64 %"7_01", double %"12_02", double %"14_03"), !dbg !10
+  store i64 %"7_01", ptr %"15_0", align 4, !dbg !10
   %"15_04" = load i64, ptr %"15_0", align 4
   %"10_05" = load double, ptr %"10_0", align 8
-  call void @___rz(i64 %"15_04", double %"10_05"), !dbg !12
-  store i64 %"15_04", ptr %"16_0", align 4, !dbg !12
+  call void @___rz(i64 %"15_04", double %"10_05"), !dbg !11
+  store i64 %"15_04", ptr %"16_0", align 4, !dbg !11
   %"16_06" = load i64, ptr %"16_0", align 4
   store i64 %"16_06", ptr %"0", align 4
-  %"07" = load i64, ptr %"0", align 4
-  ret i64 %"07"
-}
-
-define internal i64 @_hl.__tk2_helios_h.17(i64 %0) !dbg !13 {
-alloca_block:
-  %"0" = alloca i64, align 8
-  %"25_0" = alloca double, align 8
-  %"23_0" = alloca double, align 8
-  %"21_0" = alloca double, align 8
-  %"18_0" = alloca i64, align 8
-  %"26_0" = alloca i64, align 8
-  %"27_0" = alloca i64, align 8
-  br label %entry_block
-
-entry_block:                                      ; preds = %alloca_block
-  store double 0xBFF921FB54442D18, ptr %"25_0", align 8
-  store double 0x3FF921FB54442D18, ptr %"23_0", align 8
-  store double 0x400921FB54442D18, ptr %"21_0", align 8
-  store i64 %0, ptr %"18_0", align 4
-  %"18_01" = load i64, ptr %"18_0", align 4
-  %"23_02" = load double, ptr %"23_0", align 8
-  %"25_03" = load double, ptr %"25_0", align 8
-  call void @___rxy(i64 %"18_01", double %"23_02", double %"25_03"), !dbg !14
-  store i64 %"18_01", ptr %"26_0", align 4, !dbg !14
-  %"26_04" = load i64, ptr %"26_0", align 4
-  %"21_05" = load double, ptr %"21_0", align 8
-  call void @___rz(i64 %"26_04", double %"21_05"), !dbg !15
-  store i64 %"26_04", ptr %"27_0", align 4, !dbg !15
-  %"27_06" = load i64, ptr %"27_0", align 4
-  store i64 %"27_06", ptr %"0", align 4
   %"07" = load i64, ptr %"0", align 4
   ret i64 %"07"
 }
@@ -98,17 +67,13 @@ declare void @___rz(i64, double)
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = distinct !DICompileUnit(language: DW_LANG_Python, file: !2, producer: "hugr_llvm_test", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-!2 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "/rhvZsHeDgUnyeIVwAutKJHaZEPSZwPX")
-!3 = distinct !DISubprogram(name: "_hl.main.1", linkageName: "_hl.main.1", scope: null, file: !4, line: 25254, type: !5, scopeLine: 25255, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
-!4 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "")
-!5 = !DISubroutineType(types: !6)
-!6 = !{!7, !7}
-!7 = !DIBasicType(name: "i64", size: 64, encoding: DW_ATE_unsigned)
-!8 = !DILocation(line: 27062, column: 402, scope: !3)
-!9 = !DILocation(line: 5388, column: 404, scope: !3)
-!10 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.6", linkageName: "_hl.__tk2_helios_h.6", scope: null, file: !4, line: 23594, type: !5, scopeLine: 23595, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
-!11 = !DILocation(line: 23807, column: 508, scope: !10)
-!12 = !DILocation(line: 6962, column: 212, scope: !10)
-!13 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.17", linkageName: "_hl.__tk2_helios_h.17", scope: null, file: !4, line: 1712, type: !5, scopeLine: 1713, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
-!14 = !DILocation(line: 21129, column: 412, scope: !13)
-!15 = !DILocation(line: 4112, column: 51, scope: !13)
+!2 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "")
+!3 = distinct !DISubprogram(name: "_hl.main.1", linkageName: "_hl.main.1", scope: null, file: !2, line: 25254, type: !4, scopeLine: 25255, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
+!4 = !DISubroutineType(types: !5)
+!5 = !{!6, !6}
+!6 = !DIBasicType(name: "i64", size: 64, encoding: DW_ATE_unsigned)
+!7 = !DILocation(line: 27062, column: 402, scope: !3)
+!8 = !DILocation(line: 5388, column: 404, scope: !3)
+!9 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.6", linkageName: "_hl.__tk2_helios_h.6", scope: null, file: !2, line: 23594, type: !4, scopeLine: 23595, spFlags: DISPFlagDefinition, unit: !1)
+!10 = !DILocation(line: 23807, column: 508, scope: !9)
+!11 = !DILocation(line: 6962, column: 212, scope: !9)

--- a/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_duplicate_h_codegen@pre-mem2reg@llvm21.snap
+++ b/tket-qsystem/src/llvm/snapshots/tket_qsystem__llvm__qsystem__test__emit_duplicate_h_codegen@pre-mem2reg@llvm21.snap
@@ -1,0 +1,114 @@
+---
+source: tket-qsystem/src/llvm/qsystem.rs
+expression: mod_str
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define internal i64 @_hl.main.1(i64 %0) !dbg !3 {
+alloca_block:
+  %"0" = alloca i64, align 8
+  %"2_0" = alloca i64, align 8
+  %"4_0" = alloca i64, align 8
+  %"5_0" = alloca i64, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store i64 %0, ptr %"2_0", align 4
+  %"2_01" = load i64, ptr %"2_0", align 4
+  %1 = call i64 @_hl.__tk2_helios_h.6(i64 %"2_01"), !dbg !8
+  store i64 %1, ptr %"4_0", align 4, !dbg !8
+  %"4_02" = load i64, ptr %"4_0", align 4
+  %2 = call i64 @_hl.__tk2_helios_h.17(i64 %"4_02"), !dbg !9
+  store i64 %2, ptr %"5_0", align 4, !dbg !9
+  %"5_03" = load i64, ptr %"5_0", align 4
+  store i64 %"5_03", ptr %"0", align 4
+  %"04" = load i64, ptr %"0", align 4
+  ret i64 %"04"
+}
+
+define internal i64 @_hl.__tk2_helios_h.6(i64 %0) !dbg !10 {
+alloca_block:
+  %"0" = alloca i64, align 8
+  %"14_0" = alloca double, align 8
+  %"12_0" = alloca double, align 8
+  %"10_0" = alloca double, align 8
+  %"7_0" = alloca i64, align 8
+  %"15_0" = alloca i64, align 8
+  %"16_0" = alloca i64, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double 0xBFF921FB54442D18, ptr %"14_0", align 8
+  store double 0x3FF921FB54442D18, ptr %"12_0", align 8
+  store double 0x400921FB54442D18, ptr %"10_0", align 8
+  store i64 %0, ptr %"7_0", align 4
+  %"7_01" = load i64, ptr %"7_0", align 4
+  %"12_02" = load double, ptr %"12_0", align 8
+  %"14_03" = load double, ptr %"14_0", align 8
+  call void @___rxy(i64 %"7_01", double %"12_02", double %"14_03"), !dbg !11
+  store i64 %"7_01", ptr %"15_0", align 4, !dbg !11
+  %"15_04" = load i64, ptr %"15_0", align 4
+  %"10_05" = load double, ptr %"10_0", align 8
+  call void @___rz(i64 %"15_04", double %"10_05"), !dbg !12
+  store i64 %"15_04", ptr %"16_0", align 4, !dbg !12
+  %"16_06" = load i64, ptr %"16_0", align 4
+  store i64 %"16_06", ptr %"0", align 4
+  %"07" = load i64, ptr %"0", align 4
+  ret i64 %"07"
+}
+
+define internal i64 @_hl.__tk2_helios_h.17(i64 %0) !dbg !13 {
+alloca_block:
+  %"0" = alloca i64, align 8
+  %"25_0" = alloca double, align 8
+  %"23_0" = alloca double, align 8
+  %"21_0" = alloca double, align 8
+  %"18_0" = alloca i64, align 8
+  %"26_0" = alloca i64, align 8
+  %"27_0" = alloca i64, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double 0xBFF921FB54442D18, ptr %"25_0", align 8
+  store double 0x3FF921FB54442D18, ptr %"23_0", align 8
+  store double 0x400921FB54442D18, ptr %"21_0", align 8
+  store i64 %0, ptr %"18_0", align 4
+  %"18_01" = load i64, ptr %"18_0", align 4
+  %"23_02" = load double, ptr %"23_0", align 8
+  %"25_03" = load double, ptr %"25_0", align 8
+  call void @___rxy(i64 %"18_01", double %"23_02", double %"25_03"), !dbg !14
+  store i64 %"18_01", ptr %"26_0", align 4, !dbg !14
+  %"26_04" = load i64, ptr %"26_0", align 4
+  %"21_05" = load double, ptr %"21_0", align 8
+  call void @___rz(i64 %"26_04", double %"21_05"), !dbg !15
+  store i64 %"26_04", ptr %"27_0", align 4, !dbg !15
+  %"27_06" = load i64, ptr %"27_0", align 4
+  store i64 %"27_06", ptr %"0", align 4
+  %"07" = load i64, ptr %"0", align 4
+  ret i64 %"07"
+}
+
+declare void @___rxy(i64, double, double)
+
+declare void @___rz(i64, double)
+
+!llvm.module.flags = !{!0}
+!llvm.dbg.cu = !{!1}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = distinct !DICompileUnit(language: DW_LANG_Python, file: !2, producer: "hugr_llvm_test", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+!2 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "/rhvZsHeDgUnyeIVwAutKJHaZEPSZwPX")
+!3 = distinct !DISubprogram(name: "_hl.main.1", linkageName: "_hl.main.1", scope: null, file: !4, line: 25254, type: !5, scopeLine: 25255, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
+!4 = !DIFile(filename: "/cmJrSnVYeXFf/zCkHdtWCCnkJhPKiWSKICgZuRNRvR/mbrfVq.gpy.py", directory: "")
+!5 = !DISubroutineType(types: !6)
+!6 = !{!7, !7}
+!7 = !DIBasicType(name: "i64", size: 64, encoding: DW_ATE_unsigned)
+!8 = !DILocation(line: 27062, column: 402, scope: !3)
+!9 = !DILocation(line: 5388, column: 404, scope: !3)
+!10 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.6", linkageName: "_hl.__tk2_helios_h.6", scope: null, file: !4, line: 23594, type: !5, scopeLine: 23595, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
+!11 = !DILocation(line: 23807, column: 508, scope: !10)
+!12 = !DILocation(line: 6962, column: 212, scope: !10)
+!13 = distinct !DISubprogram(name: "_hl.__tk2_helios_h.17", linkageName: "_hl.__tk2_helios_h.17", scope: null, file: !4, line: 1712, type: !5, scopeLine: 1713, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !1)
+!14 = !DILocation(line: 21129, column: 412, scope: !13)
+!15 = !DILocation(line: 4112, column: 51, scope: !13)


### PR DESCRIPTION
Replacement functions built for lowering (TketOp decompositions and
cross-platform PhasedXX/ZZPhase decompositions) were created as
Visibility::Private. The NameLinkingPolicy with OnMultiDefn::UseTarget
only deduplicates public FuncDefns; private ones are always re-inserted
as fresh copies.

Use FunctionBuilder::new_vis(..., Visibility::Public) so that when the
same op appears multiple times, insert_link_hugr reuses the existing
definition instead of adding a duplicate.

Closes #1704