### PR TITLE
refactor: Replace hardcoded modifier names with qualified names

### DIFF
--- a/qis-compiler/Cargo.toml
+++ b/qis-compiler/Cargo.toml
@@ -25,6 +25,7 @@ tket-qsystem = { path = "../tket-qsystem", version = "0.26.0", features = [
     "llvm",
 ] }
 
+
 [lints]
 workspace = true
 

--- a/qis-compiler/pyproject.toml
+++ b/qis-compiler/pyproject.toml
@@ -8,6 +8,7 @@ dev = [
     "pytest-snapshot~=0.9.0",
     "cibuildwheel>=2.23.2",
     "hugr~=0.17.1",
+    "tket-exts>=0.13.1",
 ]
 
 [project]
@@ -70,6 +71,9 @@ select = [
 ]
 ignore = ["F403", "F405", "PYI021", "PYI048"]
 
+
+[tool.uv.sources]
+tket-exts = { workspace = true }
 
 [tool.uv]
 # Rebuild package when any rust files change

--- a/qis-compiler/python/tests/test_basic_generation.py
+++ b/qis-compiler/python/tests/test_basic_generation.py
@@ -6,7 +6,7 @@ from hugr.ops import CFG
 from hugr.package import Package
 from pytest_snapshot.plugin import Snapshot
 from selene_hugr_qis_compiler import HugrReadError, check_hugr, compile_to_llvm_ir
-from tket.extensions import modifier
+from tket_exts import modifier
 
 resources_dir = Path(__file__).parent / "resources"
 

--- a/qis-compiler/python/tests/test_basic_generation.py
+++ b/qis-compiler/python/tests/test_basic_generation.py
@@ -6,6 +6,7 @@ from hugr.ops import CFG
 from hugr.package import Package
 from pytest_snapshot.plugin import Snapshot
 from selene_hugr_qis_compiler import HugrReadError, check_hugr, compile_to_llvm_ir
+from tket.extensions import modifier
 
 resources_dir = Path(__file__).parent / "resources"
 
@@ -33,8 +34,8 @@ def contains_modifiers(hugr_envelope: bytes) -> bool:
     for module in package.modules:
         for _, node_data in module.nodes():
             if (
-                "tket.modifier.ControlModifier" in node_data.op.name()
-                or "tket.modifier.DaggerModifier" in node_data.op.name()
+                modifier.control.qualified_name() in node_data.op.name()
+                or modifier.dagger.qualified_name() in node_data.op.name()
             ):
                 return True
     return False

--- a/uv.lock
+++ b/uv.lock
@@ -2698,6 +2698,7 @@ dev = [
     { name = "hugr" },
     { name = "pytest" },
     { name = "pytest-snapshot" },
+    { name = "tket-exts" },
 ]
 
 [package.metadata]
@@ -2708,6 +2709,7 @@ dev = [
     { name = "hugr", specifier = "~=0.17.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-snapshot", specifier = "~=0.9.0" },
+    { name = "tket-exts", editable = "tket-exts" },
 ]
 
 [[package]]


### PR DESCRIPTION
Addressing this comment: https://github.com/Quantinuum/tket2/pull/1741#discussion_r3466456310

To be able to run the test on CI, this PR adds the tket-ext dependency version 0.14.1 to the dev group