### PR TITLE
feat!: Split QSystemPass into QSRebasePass and QSLLVMPass

### DIFF
--- a/qis-compiler/rust/lib.rs
+++ b/qis-compiler/rust/lib.rs
@@ -20,6 +20,7 @@ use itertools::Itertools;
 use pyo3::prelude::*;
 use tket::hugr::ops::DataflowParent;
 use tket::passes::composable::ComposablePass;
+use tket_qsystem::{QSystemLLVMPass, QSystemRebasePass};
 
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
@@ -30,7 +31,6 @@ use std::{fs, str, vec};
 use tket::hugr::{self, llvm::inkwell};
 use tket::hugr::{Hugr, HugrView, Node};
 use tket::llvm::rotation::RotationCodegenExtension;
-use tket_qsystem::QSystemPass;
 use tket_qsystem::extension::{REGISTRY, qsystem};
 use tket_qsystem::llvm::array_utils::ArrayLowering;
 pub use tket_qsystem::llvm::futures::FuturesCodegenExtension;
@@ -112,7 +112,8 @@ fn get_hugr_llvm_module<'c, 'hugr, 'a: 'c>(
 }
 
 fn process_hugr(platform: qsystem::QSystemPlatform, hugr: &mut Hugr) -> Result<()> {
-    QSystemPass::defaults(platform).run(hugr)?;
+    QSystemRebasePass::defaults(platform).run(hugr)?;
+    QSystemLLVMPass::default().run(hugr)?;
     Ok(())
 }
 

--- a/tket-py/src/passes.rs
+++ b/tket-py/src/passes.rs
@@ -2,6 +2,7 @@
 
 pub mod chunks;
 mod inline_funcs;
+mod qsystem;
 mod scope;
 pub mod tket1;
 
@@ -34,7 +35,8 @@ pub fn module(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
     m.add_function(wrap_pyfunction!(self::chunks::chunks, &m)?)?;
     m.add_function(wrap_pyfunction!(self::tket1::tket1_pass, &m)?)?;
     m.add_function(wrap_pyfunction!(resolve_modifiers, &m)?)?;
-    m.add_function(wrap_pyfunction!(qsystem_rebase_pass, &m)?)?;
+    m.add_function(wrap_pyfunction!(qsystem::qsystem_rebase_pass, &m)?)?;
+    m.add_function(wrap_pyfunction!(qsystem::qsystem_llvm_pass, &m)?)?;
     m.add("PullForwardError", py.get_type::<PyPullForwardError>())?;
     m.add(
         "InlineFunctionsError",
@@ -69,9 +71,15 @@ create_py_exception!(
 );
 
 create_py_exception!(
-    tket_qsystem::QSystemPassError,
-    PyQSystemPassError,
+    tket_qsystem::QSystemRebasePassError,
+    PyQSystemRebasePassError,
     "Errors from the QSystem rebase pass."
+);
+
+create_py_exception!(
+    tket_qsystem::QSystemLLVMPassError,
+    PyQSystemLLVMPassError,
+    "Errors from the QSystem pre-LLVM pass."
 );
 
 /// Flatten the structure of a Guppy-generated program to enable additional optimisations.
@@ -215,27 +223,5 @@ fn resolve_modifiers(circ: &mut CompilationState, scope: Option<PyPassScope>) ->
     let py_scope = scope.unwrap_or_default();
     let pass = tket::passes::ModifierResolverPass::default_with_scope(py_scope.scope);
     pass.run(&mut circ.hugr).convert_pyerrs()?;
-    Ok(())
-}
-
-#[pyfunction]
-#[pyo3(signature=(circ, *, constant_fold = true, monomorphize = true, force_order = true, hide_funcs = true, scope = None))]
-fn qsystem_rebase_pass(
-    circ: &mut CompilationState,
-    constant_fold: bool,
-    monomorphize: bool,
-    force_order: bool,
-    hide_funcs: bool,
-    scope: Option<PyPassScope>,
-) -> PyResult<()> {
-    let py_scope = scope.unwrap_or_default();
-    let qsystem_pass = tket_qsystem::QSystemPass::defaults(tket_qsystem::QSystemPlatform::Helios)
-        .with_scope(py_scope.scope)
-        .with_constant_fold(constant_fold)
-        .with_monomorphize(monomorphize)
-        .with_force_order(force_order)
-        .with_hide_funcs(hide_funcs);
-
-    qsystem_pass.run(&mut circ.hugr).convert_pyerrs()?;
     Ok(())
 }

--- a/tket-py/src/passes/qsystem.rs
+++ b/tket-py/src/passes/qsystem.rs
@@ -1,0 +1,48 @@
+//! QSystem pass bindings
+use pyo3::prelude::*;
+use tket::passes::{ComposablePass, WithScope};
+
+use crate::passes::PyPassScope;
+use crate::state::CompilationState;
+use crate::utils::ConvertPyErr;
+
+#[pyfunction]
+#[pyo3(signature=(circ, *, resolve_modifiers = true, lower_drops = true, hide_funcs = true, scope = None))]
+pub(super) fn qsystem_rebase_pass(
+    circ: &mut CompilationState,
+    resolve_modifiers: bool,
+    lower_drops: bool,
+    hide_funcs: bool,
+    scope: Option<PyPassScope>,
+) -> PyResult<()> {
+    let py_scope = scope.unwrap_or_default();
+    let qsystem_pass =
+        tket_qsystem::QSystemRebasePass::defaults(tket_qsystem::QSystemPlatform::Helios)
+            .with_scope(py_scope.scope)
+            .with_resolve_modifiers(resolve_modifiers)
+            .with_lower_drops(lower_drops)
+            .with_hide_funcs(hide_funcs);
+
+    qsystem_pass.run(&mut circ.hugr).convert_pyerrs()?;
+    Ok(())
+}
+
+#[pyfunction]
+#[pyo3(signature=(circ, *, constant_fold = true, monomorphize = true, force_order = true, scope = None))]
+pub(super) fn qsystem_llvm_pass(
+    circ: &mut CompilationState,
+    constant_fold: bool,
+    monomorphize: bool,
+    force_order: bool,
+    scope: Option<PyPassScope>,
+) -> PyResult<()> {
+    let py_scope = scope.unwrap_or_default();
+    let qsystem_pass = tket_qsystem::QSystemLLVMPass::default()
+        .with_scope(py_scope.scope)
+        .with_constant_fold(constant_fold)
+        .with_monomorphize(monomorphize)
+        .with_force_order(force_order);
+
+    qsystem_pass.run(&mut circ.hugr).convert_pyerrs()?;
+    Ok(())
+}

--- a/tket-py/test/test_pass.py
+++ b/tket-py/test/test_pass.py
@@ -21,7 +21,7 @@ import hypothesis.strategies as st
 from hypothesis.strategies._internal import SearchStrategy
 from hypothesis import given, settings
 
-from tket.passes import PytketHugrPass, QSystemLLVMPass, QSystemRebasePass
+from tket.passes import PytketHugrPass, _QSystemLLVMPass, QSystemRebasePass
 from hugr.build.base import Hugr
 
 import numpy as np
@@ -372,7 +372,7 @@ def test_python_qsystem_pass() -> None:
     normalize = NormalizeGuppy()
     hugr = normalize(_hugr_from_path("test_files/guppy_examples/flat_quantum.hugr"))
     qsystem_rebase = QSystemRebasePass()
-    qsystem_llvm = QSystemLLVMPass()
+    qsystem_llvm = _QSystemLLVMPass()
     qsystem_hugr = qsystem_llvm(qsystem_rebase(hugr))
     assert _count_ops(qsystem_hugr, "ZZPhase") == 1
     assert _count_ops(qsystem_hugr, "Custom") == 0

--- a/tket-py/test/test_pass.py
+++ b/tket-py/test/test_pass.py
@@ -21,7 +21,7 @@ import hypothesis.strategies as st
 from hypothesis.strategies._internal import SearchStrategy
 from hypothesis import given, settings
 
-from tket.passes import PytketHugrPass, QSystemPass
+from tket.passes import PytketHugrPass, QSystemLLVMPass, QSystemRebasePass
 from hugr.build.base import Hugr
 
 import numpy as np
@@ -371,8 +371,9 @@ def test_issue_1516() -> None:
 def test_python_qsystem_pass() -> None:
     normalize = NormalizeGuppy()
     hugr = normalize(_hugr_from_path("test_files/guppy_examples/flat_quantum.hugr"))
-    qsystem_pass = QSystemPass()
-    qsystem_hugr = qsystem_pass(hugr)
+    qsystem_rebase = QSystemRebasePass()
+    qsystem_llvm = QSystemLLVMPass()
+    qsystem_hugr = qsystem_llvm(qsystem_rebase(hugr))
     assert _count_ops(qsystem_hugr, "ZZPhase") == 1
     assert _count_ops(qsystem_hugr, "Custom") == 0
     assert _count_ops(qsystem_hugr, "tket.quantum") == 0

--- a/tket-py/tket/_tket/passes.pyi
+++ b/tket-py/tket/_tket/passes.pyi
@@ -125,7 +125,7 @@ def qsystem_llvm_pass(
     force_order: bool = True,
     scope: PassScope | None = None,
 ) -> None:
-    """Runs a rust backed pass to convert qsystem ops to llvm ops.
+    """Runs a rust backed pass to prepare the HUGR for LLVM code generation.
 
     :param constant_fold: Whether to perform constant folding.
     :param monomorphize: Whether to monomorphize generic functions.

--- a/tket-py/tket/_tket/passes.pyi
+++ b/tket-py/tket/_tket/passes.pyi
@@ -104,16 +104,31 @@ def resolve_modifiers(
 
 def qsystem_rebase_pass(
     circ: CompilationState,
-    constant_fold: bool = True,
-    monomorphize: bool = True,
-    force_order: bool = True,
+    *,
+    resolve_modifiers: bool = True,
+    lower_drops: bool = True,
     hide_funcs: bool = True,
     scope: PassScope | None = None,
 ) -> None:
     """Runs a rust backed pass to convert quantum ops to qsystem ops.
 
+    :param resolve_modifiers: Whether to resolve modifier operations.
+    :param lower_drops: Whether to lower drop operations.
+    :param hide_funcs: Make all HUGR functions private.
+    """
+
+def qsystem_llvm_pass(
+    circ: CompilationState,
+    *,
+    constant_fold: bool = True,
+    monomorphize: bool = True,
+    force_order: bool = True,
+    scope: PassScope | None = None,
+) -> None:
+    """Runs a rust backed pass to convert qsystem ops to llvm ops.
+
     :param constant_fold: Whether to perform constant folding.
     :param monomorphize: Whether to monomorphize generic functions.
     :param force_order: Whether to enforce total ordering of all HUGR operations.
-    :param hide_funcs: Make all HUGR functions private.
+    :param scope: A scope to control how the pass is applied to HUGR regions.
     """

--- a/tket-py/tket/passes/__init__.py
+++ b/tket-py/tket/passes/__init__.py
@@ -33,7 +33,8 @@ __all__ = [
     "InlineFunctions",
     "NormalizeGuppy",
     "ModifierResolverPass",
-    "QSystemPass",
+    "QSystemRebasePass",
+    "QSystemLLVMPass",
     "Cliffordize",
 ]
 
@@ -379,19 +380,17 @@ class ModifierResolverPass(ComposablePass):
 
 
 @dataclass(kw_only=True)
-class QSystemPass(ComposablePass):
-    """A pass to convert quantum ops to qsystem ops.
+class QSystemRebasePass(ComposablePass):
+    """Convert quantum operations to QSystem operations.
 
-     Parameters:
-    - constant_fold: Whether to perform constant folding.
-    - monomorphize: Whether to monomorphize generic functions.
-    - force_order: Whether to enforce total ordering of all HUGR operations.
-    - hide_funcs: Whether to mark all functions as private.
+    Parameters:
+    - resolve_modifiers: Whether to resolve Guppy modifiers.
+    - lower_drops: Whether to lower qubit drops to QSystem operations.
+    - hide_funcs: Whether to mark generated helper functions as private.
     """
 
-    constant_fold: bool = True
-    monomorphize: bool = True
-    force_order: bool = True
+    resolve_modifiers: bool = True
+    lower_drops: bool = True
     hide_funcs: bool = True
     _scope: PassScope = GlobalScope.PRESERVE_PUBLIC
 
@@ -403,7 +402,7 @@ class QSystemPass(ComposablePass):
             copy_call=lambda h: self._qsystem_rebase(h, inplace),
         )
 
-    def with_scope(self, scope: PassScope) -> QSystemPass:
+    def with_scope(self, scope: PassScope) -> QSystemRebasePass:
         """Set the scope of this pass and return self."""
         self._scope = scope
         return self
@@ -422,10 +421,59 @@ class QSystemPass(ComposablePass):
         """Run the pass in the CompilationState"""
         _passes.qsystem_rebase_pass(
             program._inner,
+            resolve_modifiers=self.resolve_modifiers,
+            lower_drops=self.lower_drops,
+            hide_funcs=self.hide_funcs,
+            scope=self._scope,
+        )
+        return program
+
+
+@dataclass(kw_only=True)
+class QSystemLLVMPass(ComposablePass):
+    """Prepare a QSystem program for LLVM lowering.
+
+    Parameters:
+    - constant_fold: Whether to perform constant folding.
+    - monomorphize: Whether to monomorphize generic functions.
+    - force_order: Whether to enforce total ordering of all HUGR operations.
+    """
+
+    constant_fold: bool = True
+    monomorphize: bool = True
+    force_order: bool = True
+    _scope: PassScope = GlobalScope.PRESERVE_PUBLIC
+
+    def run(self, hugr: Hugr, *, inplace: bool = True) -> PassResult:
+        return implement_pass_run(
+            self,
+            hugr=hugr,
+            inplace=inplace,
+            copy_call=lambda h: self._qsystem_llvm(h, inplace),
+        )
+
+    def with_scope(self, scope: PassScope) -> QSystemLLVMPass:
+        """Set the scope of this pass and return self."""
+        self._scope = scope
+        return self
+
+    def _qsystem_llvm(self, hugr: Hugr, inplace: bool) -> PassResult:
+        tk_program = _state.CompilationState.from_python(hugr)
+
+        self._run_tk(tk_program)
+
+        package = tk_program.to_python()
+        return PassResult.for_pass(
+            self, hugr=package.modules[0], inplace=inplace, result=None
+        )
+
+    def _run_tk(self, program: _state.CompilationState) -> _state.CompilationState:
+        """Run the pass in the CompilationState"""
+        _passes.qsystem_llvm_pass(
+            program._inner,
             constant_fold=self.constant_fold,
             monomorphize=self.monomorphize,
             force_order=self.force_order,
-            hide_funcs=self.hide_funcs,
             scope=self._scope,
         )
         return program

--- a/tket-py/tket/passes/__init__.py
+++ b/tket-py/tket/passes/__init__.py
@@ -34,7 +34,7 @@ __all__ = [
     "NormalizeGuppy",
     "ModifierResolverPass",
     "QSystemRebasePass",
-    "QSystemLLVMPass",
+    "_QSystemLLVMPass",
     "Cliffordize",
 ]
 
@@ -430,8 +430,10 @@ class QSystemRebasePass(ComposablePass):
 
 
 @dataclass(kw_only=True)
-class QSystemLLVMPass(ComposablePass):
+class _QSystemLLVMPass(ComposablePass):
     """Prepare a QSystem program for LLVM lowering.
+
+    This is normally called automatically by the tools before LLVM lowering.
 
     Parameters:
     - constant_fold: Whether to perform constant folding.
@@ -452,7 +454,7 @@ class QSystemLLVMPass(ComposablePass):
             copy_call=lambda h: self._qsystem_llvm(h, inplace),
         )
 
-    def with_scope(self, scope: PassScope) -> QSystemLLVMPass:
+    def with_scope(self, scope: PassScope) -> _QSystemLLVMPass:
         """Set the scope of this pass and return self."""
         self._scope = scope
         return self

--- a/tket-qsystem/src/lib.rs
+++ b/tket-qsystem/src/lib.rs
@@ -8,307 +8,22 @@ pub(crate) mod helpers;
 #[cfg(feature = "llvm")]
 pub mod llvm;
 pub mod lower_drops;
+pub mod passes;
 pub mod pytket;
 
-use derive_more::{Display, Error, From};
-use hugr::hugr::{HugrError, hugrmut::HugrMut};
-use hugr::{HugrView, Node, core::Visibility, ops::OpType};
-use itertools::Itertools as _;
-use std::collections::HashSet;
-use tket::passes::ModifierResolverPass;
-use tket::passes::composable::WithScope;
-use tket::passes::const_fold::{ConstFoldError, ConstantFoldPass};
-use tket::passes::modifier_resolver::ModifierResolverErrors;
-use tket::passes::{
-    ComposablePass, MonomorphizePass, PassScope, RemoveDeadFuncsError, RemoveDeadFuncsPass,
-    force_order, replace_types::ReplaceTypesError,
-};
-
-use lower_drops::LowerDropsPass;
-use tket::TketOp;
-
 pub use extension::qsystem::QSystemPlatform;
-use extension::{
-    futures::FutureOpDef,
-    qsystem::{LowerTk2Error, LowerTketToQSystemPass, QSystemOp},
+pub use passes::{
+    QSystemLLVMPass, QSystemLLVMPassError, QSystemRebasePass, QSystemRebasePassError,
 };
-
-/// Modify a [hugr::Hugr] into a form that is acceptable for ingress into a
-/// Q-System. Returns an error if this cannot be done.
-///
-/// This pass should only be applied with [`PassScope::Global`] scopes on HUGRs
-/// with function entrypoints. An error will be returned if this is not the
-/// case.
-///
-/// To construct a `QSystemPass` use [Default::default].
-#[derive(Debug, Clone)]
-pub struct QSystemPass {
-    constant_fold: bool,
-    monomorphize: bool,
-    force_order: bool,
-    hide_funcs: bool,
-    /// Where to apply the pass.
-    ///
-    /// Configurable via [`WithScope::with_scope`].
-    scope: PassScope,
-    /// Target platform, which may affect how certain operations are lowered.
-    ///
-    /// Configurable via [`WithPlatform::with_platform`].
-    platform: QSystemPlatform,
-}
-
-impl QSystemPass {
-    /// Load default settings for `QSystemPass` given the target qsystem platform.
-    pub fn defaults(platform: QSystemPlatform) -> Self {
-        Self {
-            constant_fold: true,
-            monomorphize: true,
-            force_order: true,
-            hide_funcs: true,
-            scope: PassScope::default(),
-            platform,
-        }
-    }
-}
-
-#[derive(Error, Debug, Display, From)]
-#[non_exhaustive]
-/// An error reported from [QSystemPass].
-pub enum QSystemPassError {
-    /// An error from the component [force_order] pass.
-    ForceOrderError(HugrError),
-    /// An error from the component [LowerTketToQSystemPass] pass.
-    LowerTk2Error(LowerTk2Error),
-    /// An error from the component [ConstantFoldPass] pass.
-    ConstantFoldError(ConstFoldError),
-    /// An error from the component [LowerDropsPass] pass.
-    LinearizeArrayError(ReplaceTypesError),
-    /// An error when running [RemoveDeadFuncsPass] after the monomorphisation
-    /// pass.
-    ///
-    ///  [RemoveDeadFuncsPass]: tket::passes::RemoveDeadFuncsError
-    DCEError(RemoveDeadFuncsError),
-    /// Error while resolving modifier operations.
-    ModifierResolver(ModifierResolverErrors),
-    /// No [FuncDefn] named "main" in [Module].
-    ///
-    /// [FuncDefn]: hugr::ops::FuncDefn
-    /// [Module]: hugr::ops::Module
-    #[display("No function named 'main' in module.")]
-    NoMain,
-    /// QSystemPass was applied with a local scope.
-    #[display("QSystemPass was applied with a local scope {scope}")]
-    LocalScopeError {
-        /// The scope that was applied.
-        scope: PassScope,
-    },
-}
-
-impl QSystemPass {
-    /// Returns a new `QSystemPass` with constant folding enabled according to
-    /// `constant_fold`.
-    ///
-    /// On by default
-    pub fn with_constant_fold(mut self, constant_fold: bool) -> Self {
-        self.constant_fold = constant_fold;
-        self
-    }
-
-    /// Returns a new `QSystemPass` with monomorphization enabled according to
-    /// `monomorphize`.
-    ///
-    /// On by default.
-    pub fn with_monomorphize(mut self, monomorphize: bool) -> Self {
-        self.monomorphize = monomorphize;
-        self
-    }
-
-    /// Changes whether we force a total ordering on all ops in the Hugr.
-    ///
-    /// On by default.
-    ///
-    /// When enabled, we push quantum ops as early as possible, and we push
-    /// `tket.futures.read` ops as late as possible.
-    pub fn with_force_order(mut self, force_order: bool) -> Self {
-        self.force_order = force_order;
-        self
-    }
-
-    /// Makes all functions private.
-    ///
-    /// On by default
-    ///
-    /// When enabled all functions are marked as private. This enables LLVM to drop functions which are not called.
-    pub fn with_hide_funcs(mut self, hide_funcs: bool) -> Self {
-        self.hide_funcs = hide_funcs;
-        self
-    }
-
-    /// Add order edges in the HUGR regions to force qubit frees to be as early
-    /// as possible, quantum ops to be as early as possible, and Future::Reads
-    /// to be as late as possible.
-    fn force_order(&self, hugr: &mut impl HugrMut<Node = Node>) -> Result<(), QSystemPassError> {
-        let Some(root) = self.scope.root(hugr) else {
-            // Scope tells us not to modify any node.
-            return Ok(());
-        };
-
-        force_order::force_order(hugr, root, |hugr, node| {
-            let optype = hugr.get_optype(node);
-
-            let is_quantum =
-                optype.cast::<TketOp>().is_some() || optype.cast::<QSystemOp>().is_some();
-            let is_qalloc = matches!(
-                optype.cast(),
-                Some(TketOp::QAlloc) | Some(TketOp::TryQAlloc)
-            ) || optype.cast() == Some(QSystemOp::TryQAlloc);
-            let is_qfree =
-                optype.cast() == Some(TketOp::QFree) || optype.cast() == Some(QSystemOp::QFree);
-            let is_read = optype.cast() == Some(FutureOpDef::Read);
-
-            // HACK: for now qallocs and qfrees are not adequately ordered,
-            // see <https://github.com/quantinuum/guppylang/issues/778>. To
-            // mitigate this we push qfrees as early as possible and qallocs
-            // as late as possible
-            //
-            // To maximise laziness we push quantum ops (including
-            // LazyMeasure) as early as possible and Future::Read as late as
-            // possible.
-            if is_qfree {
-                -3
-            } else if is_quantum && !is_qalloc {
-                // non-qalloc quantum ops
-                -2
-            } else if is_qalloc {
-                -1
-            } else if !is_read {
-                // all other ops
-                0
-            } else {
-                // Future::Read ops
-                1
-            }
-        })?;
-        Ok(())
-    }
-
-    /// Find a function named "main" in the HUGR.
-    ///
-    /// This is used for backwards compatibility with HUGRs that have a module as
-    /// the entrypoint.
-    ///
-    /// Returns [`QSystemPassError::NoMain`] if there is no function named "main".
-    fn find_main(&self, hugr: &impl HugrView<Node = Node>) -> Result<Node, QSystemPassError> {
-        hugr.children(hugr.module_root())
-            .find(|&n| {
-                hugr.get_optype(n)
-                    .as_func_defn()
-                    .is_some_and(|fd| fd.func_name() == "main")
-            })
-            .ok_or(QSystemPassError::NoMain)
-    }
-
-    /// Collect the set of public function definitions in the HUGR, if `hide_funcs` is
-    /// enabled. These will be made private at the end of the pass to avoid
-    /// forcing LLVM to compile them as callable.
-    fn collect_pub_funcs(&self, hugr: &impl HugrView<Node = Node>) -> Option<HashSet<Node>> {
-        self.hide_funcs.then(|| {
-            hugr.children(hugr.module_root())
-                .filter(|n| {
-                    hugr.get_optype(*n)
-                        .as_func_defn()
-                        .is_some_and(|fd| fd.visibility() == &Visibility::Public)
-                })
-                .collect::<HashSet<_>>()
-        })
-    }
-
-    /// Mark non-whitelisted function definitions as private to avoid forcing LLVM to compile them as callable.
-    ///
-    /// Use [`Self::collect_pub_funcs`] to get the set of whitelisted public functions before running the main passes.
-    fn hide_non_pub_funcs(&self, hugr: &mut impl HugrMut<Node = Node>, pub_funcs: HashSet<Node>) {
-        for n in hugr.children(hugr.module_root()).collect_vec() {
-            if !pub_funcs.contains(&n)
-                && let OpType::FuncDefn(fd) = hugr.optype_mut(n)
-            {
-                *fd.visibility_mut() = Visibility::Private;
-            }
-        }
-    }
-}
-
-impl WithScope for QSystemPass {
-    fn with_scope(mut self, scope: impl Into<PassScope>) -> Self {
-        self.scope = scope.into();
-        self
-    }
-}
-
-impl<H: HugrMut<Node = Node> + 'static> ComposablePass<H> for QSystemPass {
-    type Error = QSystemPassError;
-    type Result = ();
-
-    /// Run `QSystemPass` on the given Hugr. `registry` is used for
-    /// validation, if enabled.
-    /// Expects the HUGR to have a function entrypoint.
-    fn run(&self, hugr: &mut H) -> Result<(), QSystemPassError> {
-        if !matches!(self.scope, PassScope::Global(_)) {
-            return Err(QSystemPassError::LocalScopeError {
-                scope: self.scope.clone(),
-            });
-        }
-
-        ModifierResolverPass::default()
-            .with_scope(self.scope.clone())
-            .run(hugr)?;
-
-        if self.monomorphize {
-            MonomorphizePass::default_with_scope(self.scope.clone())
-                .run(hugr)
-                .unwrap_or_else(|never| match never {});
-            RemoveDeadFuncsPass::default_with_scope(self.scope.clone()).run(hugr)?
-        }
-
-        // ReplaceTypes steps (there are several below) can introduce new helper
-        // functions that are public to enable linking/sharing. We'll make these private
-        // once we're done so that LLVM is not forced to compile them as callable.
-        let pub_funcs = self.collect_pub_funcs(hugr);
-
-        LowerTketToQSystemPass::new(self.platform)
-            .with_scope(self.scope.clone())
-            .run(hugr)?;
-
-        LowerDropsPass::default_with_scope(self.scope.clone()).run(hugr)?;
-
-        // Mark any new helper functions as private.
-        if let Some(pub_funcs) = pub_funcs {
-            self.hide_non_pub_funcs(hugr, pub_funcs);
-        }
-
-        if self.constant_fold {
-            ConstantFoldPass::default().run(hugr)?;
-        }
-        if self.force_order {
-            self.force_order(hugr)?;
-        }
-
-        // Backwards compatibility: If the entrypoint is a module, find a function named "main" and set that as
-        // entrypoint instead.
-        if hugr.entrypoint() == hugr.module_root() {
-            let main_n = self.find_main(hugr)?;
-            hugr.set_entrypoint(main_n);
-        }
-
-        Ok(())
-    }
-}
+#[expect(deprecated)]
+pub use passes::{QSystemPass, QSystemPassError};
 
 #[cfg(test)]
 mod test {
     use super::*;
 
     use hugr::{
-        Hugr,
+        Hugr, HugrView,
         builder::{
             Container, Dataflow, DataflowHugr, DataflowSubContainer, FunctionBuilder, HugrBuilder,
         },
@@ -316,7 +31,7 @@ mod test {
         extension::prelude::qb_t,
         extension::simple_op::MakeExtensionOp,
         hugr::hugrmut::HugrMut,
-        ops::{CallIndirect, ExtensionOp, handle::NodeHandle},
+        ops::{CallIndirect, ExtensionOp, OpType, handle::NodeHandle},
         std_extensions::{
             arithmetic::float_types::ConstF64,
             collections::array::{ArrayOpBuilder, array_type},
@@ -326,27 +41,24 @@ mod test {
     };
 
     use hugr::extension::prelude::bool_t;
+    use itertools::Itertools as _;
     use petgraph::visit::{Topo, Walker as _};
     use rstest::rstest;
     use tket::extension::guppy::{DROP_OP_NAME, GUPPY_EXTENSION};
     use tket::extension::measurement::measurement_type;
     use tket::extension::modifier::{CONTROL_OP_ID, MODIFIER_EXTENSION, Modifier};
-    use tket::metadata;
+    use tket::passes::ComposablePass;
+    use tket::{TketOp, metadata};
 
-    use crate::{
-        QSystemPass,
-        extension::{
-            futures::{FutureOpBuilder, FutureOpDef, future_type},
-            qsystem::{QSystemOp, QSystemPlatform},
-        },
+    use crate::extension::{
+        futures::{FutureOpBuilder, FutureOpDef, future_type},
+        qsystem::{QSystemOp, QSystemPlatform},
     };
 
     #[rstest]
-    #[case(QSystemPlatform::Helios, false)]
-    #[case(QSystemPlatform::Helios, true)]
-    #[case(QSystemPlatform::Sol, false)]
-    #[case(QSystemPlatform::Sol, true)]
-    fn qsystem_pass(#[case] platform: QSystemPlatform, #[case] set_entrypoint: bool) {
+    #[case(QSystemPlatform::Helios)]
+    #[case(QSystemPlatform::Sol)]
+    fn qsystem_passes(#[case] platform: QSystemPlatform) {
         let mut mb = hugr::builder::ModuleBuilder::new();
         let func = mb
             .define_function("func", Signature::new_endo(type_row![]))
@@ -400,12 +112,13 @@ mod test {
             let hugr = mb.finish_hugr().unwrap();
             (hugr, [call_node, h_node, f_node, rx_node, main_n])
         };
-        if set_entrypoint {
-            // set the entrypoint to the main function
-            // if this is not done the "backwards compatibility" code is triggered
-            hugr.set_entrypoint(main_node);
-        }
-        QSystemPass::defaults(platform).run(&mut hugr).unwrap();
+        // set the entrypoint to the main function
+        hugr.set_entrypoint(main_node);
+
+        QSystemRebasePass::defaults(platform)
+            .run(&mut hugr)
+            .unwrap();
+        QSystemLLVMPass::default().run(&mut hugr).unwrap();
 
         let sg = hugr.scheduling_graph(main_node);
         let topo_sorted = Topo::new(sg.petgraph()).iter(&sg.petgraph()).collect_vec();
@@ -427,6 +140,31 @@ mod test {
         {
             assert!(get_pos(call_node) < get_pos(n));
         }
+    }
+
+    #[rstest]
+    #[case(QSystemPlatform::Helios)]
+    #[case(QSystemPlatform::Sol)]
+    fn qsystem_split_passes(#[case] platform: QSystemPlatform) {
+        let mut builder =
+            FunctionBuilder::new("main", Signature::new(vec![qb_t()], vec![qb_t()])).unwrap();
+        let [qb] = builder.input_wires_arr();
+        let [qb] = builder
+            .add_dataflow_op(TketOp::H, [qb])
+            .unwrap()
+            .outputs_arr();
+        let mut hugr = builder.finish_hugr_with_outputs([qb]).unwrap();
+
+        QSystemRebasePass::defaults(platform)
+            .run(&mut hugr)
+            .unwrap();
+        assert!(
+            hugr.nodes()
+                .all(|node| hugr.get_optype(node).cast::<TketOp>().is_none())
+        );
+
+        QSystemLLVMPass::default().run(&mut hugr).unwrap();
+        hugr.validate().unwrap();
     }
 
     #[test]
@@ -458,19 +196,19 @@ mod test {
         // Check there are no public funcs (after hiding).
         let mut hugr = orig.clone();
         // TODO: add sol case?
-        QSystemPass::defaults(QSystemPlatform::Helios)
+        QSystemRebasePass::defaults(QSystemPlatform::Helios)
             .run(&mut hugr)
             .unwrap();
+        QSystemLLVMPass::default().run(&mut hugr).unwrap();
         assert_eq!(count_pub_funcs(&hugr), 0);
 
+        // Run the same passes without hiding public functions.
         let mut hugr_public = orig;
-        QSystemPass {
-            hide_funcs: false,
-            ..QSystemPass::defaults(QSystemPlatform::Helios) // TODO: add Sol case?
-        }
-        .with_hide_funcs(false)
-        .run(&mut hugr_public)
-        .unwrap();
+        QSystemRebasePass::defaults(QSystemPlatform::Helios)
+            .with_hide_funcs(false)
+            .run(&mut hugr_public)
+            .unwrap();
+        QSystemLLVMPass::default().run(&mut hugr_public).unwrap();
 
         assert_eq!(count_pub_funcs(&hugr_public), 4);
         assert_eq!(
@@ -493,9 +231,10 @@ mod test {
             dfb.finish_hugr_with_outputs([]).unwrap()
         };
 
-        QSystemPass::defaults(QSystemPlatform::Helios)
+        QSystemRebasePass::defaults(QSystemPlatform::Helios)
             .run(&mut hugr)
             .unwrap();
+        QSystemLLVMPass::default().run(&mut hugr).unwrap();
 
         // Check a function for discarding measurements has been introduced.
         let expected_sig = Signature::new(vec![future_type(bool_t())], vec![Type::UNIT]);
@@ -511,7 +250,7 @@ mod test {
     #[rstest]
     #[case(QSystemPlatform::Helios)]
     #[case(QSystemPlatform::Sol)]
-    fn qsystem_pass_resolves_modifiers(#[case] platform: QSystemPlatform) {
+    fn qsystem_native_pass_resolves_modifiers(#[case] platform: QSystemPlatform) {
         let mut module = hugr::builder::ModuleBuilder::new();
 
         let foo_sig = Signature::new_endo([qb_t()]);
@@ -563,12 +302,16 @@ mod test {
         }
 
         let mut hugr = module.finish_hugr().unwrap();
+        hugr.set_entrypoint(foo.node());
         assert!(
             hugr.nodes()
                 .any(|node| Modifier::from_optype(hugr.get_optype(node)).is_some())
         );
 
-        QSystemPass::defaults(platform).run(&mut hugr).unwrap();
+        QSystemRebasePass::defaults(platform)
+            .run(&mut hugr)
+            .unwrap();
+        QSystemLLVMPass::default().run(&mut hugr).unwrap();
 
         assert!(
             hugr.nodes()

--- a/tket-qsystem/src/passes.rs
+++ b/tket-qsystem/src/passes.rs
@@ -1,0 +1,10 @@
+//! Passes for optimizing and lowering HUGRs with native QSystem operations.
+
+mod compat;
+pub mod llvm;
+pub mod rebase;
+
+#[expect(deprecated)]
+pub use compat::{QSystemPass, QSystemPassError};
+pub use llvm::{QSystemLLVMPass, QSystemLLVMPassError};
+pub use rebase::{QSystemRebasePass, QSystemRebasePassError};

--- a/tket-qsystem/src/passes/compat.rs
+++ b/tket-qsystem/src/passes/compat.rs
@@ -1,0 +1,185 @@
+//! Compatibility pass that runs the full QSystem preparation pipeline.
+//!
+//! This module will be removed in a future release. New callers should use [`QSystemRebasePass`] and [`QSystemLLVMPass`] directly.
+#![expect(deprecated)]
+
+use derive_more::{Display, Error};
+use hugr::Node;
+use hugr::hugr::{HugrError, hugrmut::HugrMut};
+use tket::passes::composable::WithScope;
+use tket::passes::const_fold::ConstFoldError;
+use tket::passes::modifier_resolver::ModifierResolverErrors;
+use tket::passes::replace_types::ReplaceTypesError;
+use tket::passes::{ComposablePass, PassScope, RemoveDeadFuncsError};
+
+use crate::extension::qsystem::{LowerTk2Error, QSystemPlatform};
+
+use super::llvm::{QSystemLLVMPass, QSystemLLVMPassError};
+use super::rebase::{QSystemRebasePass, QSystemRebasePassError};
+
+/// Errors reported from [`QSystemPass`].
+#[derive(Error, Debug, Display)]
+#[non_exhaustive]
+#[deprecated(
+    since = "0.27.0",
+    note = "QSystemPass and its error type have been split into QSystemRebasePass and QSystemLLVMPass."
+)]
+pub enum QSystemPassError {
+    /// An error from the component [`tket::passes::force_order`] pass.
+    ForceOrderError(HugrError),
+    /// An error from the component
+    /// [`LowerTketToQSystemPass`][crate::extension::qsystem::LowerTketToQSystemPass]
+    /// pass.
+    LowerTk2Error(LowerTk2Error),
+    /// An error from the component [`ConstantFoldPass`] pass.
+    ///
+    /// [`ConstantFoldPass`]: tket::passes::ConstantFoldPass
+    ConstantFoldError(ConstFoldError),
+    /// An error from the component
+    /// [`LowerDropsPass`][crate::lower_drops::LowerDropsPass] pass.
+    LinearizeArrayError(ReplaceTypesError),
+    /// An error when running [`RemoveDeadFuncsPass`] after monomorphisation.
+    ///
+    /// [`RemoveDeadFuncsPass`]: tket::passes::RemoveDeadFuncsPass
+    DCEError(RemoveDeadFuncsError),
+    /// Error while resolving modifier operations.
+    ModifierResolver(ModifierResolverErrors),
+    /// No [FuncDefn] named "main" in [Module].
+    ///
+    /// [FuncDefn]: hugr::ops::FuncDefn
+    /// [Module]: hugr::ops::Module
+    #[display("No function named 'main' in module.")]
+    NoMain,
+    /// QSystemPass was applied with a local scope.
+    #[display("QSystemPass was applied with a local scope {scope}")]
+    LocalScopeError {
+        /// The scope that was applied.
+        scope: PassScope,
+    },
+}
+
+impl From<QSystemRebasePassError> for QSystemPassError {
+    fn from(error: QSystemRebasePassError) -> Self {
+        match error {
+            QSystemRebasePassError::ModifierResolver(error) => Self::ModifierResolver(error),
+            QSystemRebasePassError::LowerTk2Error(error) => Self::LowerTk2Error(error),
+            QSystemRebasePassError::LinearizeArrayError(error) => Self::LinearizeArrayError(error),
+        }
+    }
+}
+
+impl From<QSystemLLVMPassError> for QSystemPassError {
+    fn from(error: QSystemLLVMPassError) -> Self {
+        match error {
+            QSystemLLVMPassError::ForceOrderError(error) => Self::ForceOrderError(error),
+            QSystemLLVMPassError::ConstantFoldError(error) => Self::ConstantFoldError(error),
+            QSystemLLVMPassError::DCEError(error) => Self::DCEError(error),
+            QSystemLLVMPassError::InvalidEntrypoint { .. } => Self::NoMain,
+            QSystemLLVMPassError::LocalScopeError { scope } => Self::LocalScopeError { scope },
+        }
+    }
+}
+
+/// Modify a HUGR into a form that is acceptable for ingress into a Q-System.
+///
+/// This is a compatibility wrapper for the historical `QSystemPass` API. New
+/// callers that need a pass boundary for native-gate optimization should run
+/// [`QSystemRebasePass`], perform any native optimizations, and then run
+/// [`QSystemLLVMPass`].
+///
+/// This pass should only be applied with [`PassScope::Global`] scopes on HUGRs
+/// with function entrypoints. An error will be returned if this is not the case.
+#[derive(Debug, Clone)]
+#[deprecated(
+    since = "0.27.0",
+    note = "QSystemPass has been split into QSystemRebasePass and QSystemLLVMPass."
+)]
+pub struct QSystemPass {
+    native: QSystemRebasePass,
+    llvm: QSystemLLVMPass,
+}
+
+impl QSystemPass {
+    /// Load default settings for [`QSystemPass`] given the target QSystem
+    /// platform.
+    pub fn defaults(platform: QSystemPlatform) -> Self {
+        Self {
+            native: QSystemRebasePass::defaults(platform),
+            llvm: QSystemLLVMPass::default(),
+        }
+    }
+
+    /// Returns a new pass with constant folding enabled according to
+    /// `constant_fold`.
+    ///
+    /// On by default.
+    pub fn with_constant_fold(mut self, constant_fold: bool) -> Self {
+        self.llvm = self.llvm.with_constant_fold(constant_fold);
+        self
+    }
+
+    /// Returns a new pass with monomorphization enabled according to
+    /// `monomorphize`.
+    ///
+    /// On by default.
+    pub fn with_monomorphize(mut self, monomorphize: bool) -> Self {
+        self.llvm = self.llvm.with_monomorphize(monomorphize);
+        self
+    }
+
+    /// Changes whether we force a total ordering on all ops in the HUGR.
+    ///
+    /// On by default.
+    pub fn with_force_order(mut self, force_order: bool) -> Self {
+        self.llvm = self.llvm.with_force_order(force_order);
+        self
+    }
+
+    /// Changes whether helper functions introduced by QSystem lowering are
+    /// marked as private.
+    ///
+    /// On by default.
+    pub fn with_hide_funcs(mut self, hide_funcs: bool) -> Self {
+        self.native = self.native.with_hide_funcs(hide_funcs);
+        self
+    }
+
+    /// Returns a new pass with modifier resolution enabled according to
+    /// `resolve_modifiers`.
+    ///
+    /// On by default.
+    pub fn with_resolve_modifiers(mut self, resolve_modifiers: bool) -> Self {
+        self.native = self.native.with_resolve_modifiers(resolve_modifiers);
+        self
+    }
+
+    /// Returns a new pass with Guppy `drop` lowering enabled according to
+    /// `lower_drops`.
+    ///
+    /// On by default.
+    pub fn with_lower_drops(mut self, lower_drops: bool) -> Self {
+        self.native = self.native.with_lower_drops(lower_drops);
+        self
+    }
+}
+
+impl WithScope for QSystemPass {
+    fn with_scope(mut self, scope: impl Into<PassScope>) -> Self {
+        let scope = scope.into();
+        self.native = self.native.with_scope(scope.clone());
+        self.llvm = self.llvm.with_scope(scope);
+        self
+    }
+}
+
+impl<H: HugrMut<Node = Node> + 'static> ComposablePass<H> for QSystemPass {
+    type Error = QSystemPassError;
+    type Result = ();
+
+    fn run(&self, hugr: &mut H) -> Result<Self::Result, Self::Error> {
+        self.llvm.check_global_scope()?;
+        self.native.run(hugr)?;
+        self.llvm.run(hugr)?;
+        Ok(())
+    }
+}

--- a/tket-qsystem/src/passes/compat.rs
+++ b/tket-qsystem/src/passes/compat.rs
@@ -63,7 +63,7 @@ impl From<QSystemRebasePassError> for QSystemPassError {
         match error {
             QSystemRebasePassError::ModifierResolver(error) => Self::ModifierResolver(error),
             QSystemRebasePassError::LowerTk2Error(error) => Self::LowerTk2Error(error),
-            QSystemRebasePassError::LinearizeArrayError(error) => Self::LinearizeArrayError(error),
+            QSystemRebasePassError::LowerDropsError(error) => Self::LinearizeArrayError(error),
         }
     }
 }

--- a/tket-qsystem/src/passes/llvm.rs
+++ b/tket-qsystem/src/passes/llvm.rs
@@ -1,0 +1,199 @@
+//! Final preparation for lowering QSystem HUGRs to LLVM.
+
+use derive_more::{Display, Error, From};
+use hugr::hugr::{HugrError, hugrmut::HugrMut};
+use hugr::{HugrView, Node};
+use tket::TketOp;
+use tket::passes::composable::WithScope;
+use tket::passes::const_fold::{ConstFoldError, ConstantFoldPass};
+use tket::passes::{
+    ComposablePass, MonomorphizePass, PassScope, RemoveDeadFuncsError, RemoveDeadFuncsPass,
+    force_order,
+};
+
+use crate::extension::futures::FutureOpDef;
+use crate::extension::qsystem::{helios::HeliosOp, sol::SolOp};
+
+/// Errors reported while preparing a QSystem HUGR for LLVM lowering.
+#[derive(Error, Debug, Display, From)]
+#[non_exhaustive]
+pub enum QSystemLLVMPassError {
+    /// An error from the component [`force_order`] pass.
+    ForceOrderError(HugrError),
+    /// An error from the component [`ConstantFoldPass`] pass.
+    ConstantFoldError(ConstFoldError),
+    /// An error when running [`RemoveDeadFuncsPass`] after monomorphisation.
+    DCEError(RemoveDeadFuncsError),
+    /// The entrypoint of the HUGR is not a function.
+    #[display("Expected the HUGR entrypoint to be a function, but found {entrypoint_optype}.")]
+    InvalidEntrypoint {
+        /// The optype of the entrypoint node.
+        entrypoint_optype: String,
+    },
+    /// QSystemLLVMPass was applied with a local scope.
+    #[display("QSystemLLVMPass was applied with a local scope {scope}")]
+    LocalScopeError {
+        /// The scope that was applied.
+        scope: PassScope,
+    },
+}
+
+/// Prepare a QSystem-only HUGR for LLVM lowering.
+///
+/// This pass is intended to run after [`super::rebase::QSystemRebasePass`] and
+/// any native-gate optimizations. It performs the final global cleanups required
+/// by the LLVM lowering path. No further HUGR-level optimizations are expected
+/// to run after this pass.
+///
+/// The pass currently requires a global scope, matching the final preparation
+/// behavior of the old [`crate::QSystemPass`].
+#[derive(Debug, Clone)]
+pub struct QSystemLLVMPass {
+    constant_fold: bool,
+    monomorphize: bool,
+    force_order: bool,
+    /// Where to apply the pass.
+    ///
+    /// Configurable via [`WithScope::with_scope`].
+    scope: PassScope,
+}
+
+impl Default for QSystemLLVMPass {
+    fn default() -> Self {
+        Self {
+            constant_fold: true,
+            monomorphize: true,
+            force_order: true,
+            scope: PassScope::default(),
+        }
+    }
+}
+
+impl QSystemLLVMPass {
+    /// Returns a new pass with constant folding enabled according to
+    /// `constant_fold`.
+    ///
+    /// On by default.
+    pub fn with_constant_fold(mut self, constant_fold: bool) -> Self {
+        self.constant_fold = constant_fold;
+        self
+    }
+
+    /// Returns a new pass with monomorphization enabled according to
+    /// `monomorphize`.
+    ///
+    /// On by default.
+    pub fn with_monomorphize(mut self, monomorphize: bool) -> Self {
+        self.monomorphize = monomorphize;
+        self
+    }
+
+    /// Changes whether we force a total ordering on all ops in the HUGR.
+    ///
+    /// On by default.
+    ///
+    /// When enabled, we push quantum ops as early as possible, and we push
+    /// `tket.futures.read` ops as late as possible.
+    pub fn with_force_order(mut self, force_order: bool) -> Self {
+        self.force_order = force_order;
+        self
+    }
+
+    /// Check that this pass is configured with a global scope.
+    pub(crate) fn check_global_scope(&self) -> Result<(), QSystemLLVMPassError> {
+        if matches!(self.scope, PassScope::Global(_)) {
+            Ok(())
+        } else {
+            Err(QSystemLLVMPassError::LocalScopeError {
+                scope: self.scope.clone(),
+            })
+        }
+    }
+
+    /// Add order edges in the HUGR regions to force qubit frees to be as early
+    /// as possible, quantum ops to be as early as possible, and Future::Reads
+    /// to be as late as possible.
+    fn force_order(
+        &self,
+        hugr: &mut impl HugrMut<Node = Node>,
+    ) -> Result<(), QSystemLLVMPassError> {
+        let Some(root) = self.scope.root(hugr) else {
+            return Ok(());
+        };
+
+        force_order::force_order(hugr, root, |hugr, node| {
+            let optype = hugr.get_optype(node);
+
+            let is_quantum = optype.cast::<TketOp>().is_some()
+                || optype.cast::<HeliosOp>().is_some()
+                || optype.cast::<SolOp>().is_some();
+            let is_qalloc = matches!(
+                optype.cast(),
+                Some(TketOp::QAlloc) | Some(TketOp::TryQAlloc)
+            ) || optype.cast() == Some(HeliosOp::TryQAlloc)
+                || optype.cast() == Some(SolOp::TryQAlloc);
+            let is_qfree = optype.cast() == Some(TketOp::QFree)
+                || optype.cast() == Some(HeliosOp::QFree)
+                || optype.cast() == Some(SolOp::QFree);
+            let is_read = optype.cast() == Some(FutureOpDef::Read);
+
+            // For now qallocs and qfrees are not adequately ordered; see
+            // <https://github.com/quantinuum/guppylang/issues/778>. To
+            // mitigate this we push qfrees as early as possible and qallocs as
+            // late as possible. To maximise laziness we push quantum ops
+            // (including LazyMeasure) as early as possible and Future::Read as
+            // late as possible.
+            if is_qfree {
+                -3
+            } else if is_quantum && !is_qalloc {
+                -2
+            } else if is_qalloc {
+                -1
+            } else if !is_read {
+                0
+            } else {
+                1
+            }
+        })?;
+        Ok(())
+    }
+}
+
+impl WithScope for QSystemLLVMPass {
+    fn with_scope(mut self, scope: impl Into<PassScope>) -> Self {
+        self.scope = scope.into();
+        self
+    }
+}
+
+impl<H: HugrMut<Node = Node> + 'static> ComposablePass<H> for QSystemLLVMPass {
+    type Error = QSystemLLVMPassError;
+    type Result = ();
+
+    fn run(&self, hugr: &mut H) -> Result<Self::Result, Self::Error> {
+        // The entrypoint must be a function.
+        if !hugr.entrypoint_optype().is_func_defn() {
+            return Err(QSystemLLVMPassError::InvalidEntrypoint {
+                entrypoint_optype: hugr.entrypoint_optype().to_string(),
+            });
+        }
+
+        self.check_global_scope()?;
+
+        if self.monomorphize {
+            MonomorphizePass::default_with_scope(self.scope.clone())
+                .run(hugr)
+                .unwrap_or_else(|never| match never {});
+            RemoveDeadFuncsPass::default_with_scope(self.scope.clone()).run(hugr)?;
+        }
+
+        if self.constant_fold {
+            ConstantFoldPass::default().run(hugr)?;
+        }
+        if self.force_order {
+            self.force_order(hugr)?;
+        }
+
+        Ok(())
+    }
+}

--- a/tket-qsystem/src/passes/rebase.rs
+++ b/tket-qsystem/src/passes/rebase.rs
@@ -23,7 +23,7 @@ pub enum QSystemRebasePassError {
     /// An error from the component [`LowerTketToQSystemPass`] pass.
     LowerTk2Error(LowerTk2Error),
     /// An error from the component [`LowerDropsPass`] pass.
-    LinearizeArrayError(ReplaceTypesError),
+    LowerDropsError(ReplaceTypesError),
 }
 
 /// Lower a HUGR to operations supported by a concrete QSystem platform.

--- a/tket-qsystem/src/passes/rebase.rs
+++ b/tket-qsystem/src/passes/rebase.rs
@@ -1,0 +1,156 @@
+//! Lowering to native QSystem operations.
+
+use std::collections::HashSet;
+
+use derive_more::{Display, Error, From};
+use hugr::hugr::hugrmut::HugrMut;
+use hugr::{HugrView, Node, core::Visibility, ops::OpType};
+use itertools::Itertools as _;
+use tket::passes::composable::WithScope;
+use tket::passes::modifier_resolver::ModifierResolverErrors;
+use tket::passes::replace_types::ReplaceTypesError;
+use tket::passes::{ComposablePass, ModifierResolverPass, PassScope};
+
+use crate::extension::qsystem::{LowerTk2Error, LowerTketToQSystemPass, QSystemPlatform};
+use crate::lower_drops::LowerDropsPass;
+
+/// Errors reported while lowering a HUGR to native QSystem operations.
+#[derive(Error, Debug, Display, From)]
+#[non_exhaustive]
+pub enum QSystemRebasePassError {
+    /// Error while resolving modifier operations.
+    ModifierResolver(ModifierResolverErrors),
+    /// An error from the component [`LowerTketToQSystemPass`] pass.
+    LowerTk2Error(LowerTk2Error),
+    /// An error from the component [`LowerDropsPass`] pass.
+    LinearizeArrayError(ReplaceTypesError),
+}
+
+/// Lower a HUGR to operations supported by a concrete QSystem platform.
+///
+/// This pass performs the target-aware lowering part of the old
+/// [`crate::QSystemPass`] pipeline. By default it resolves modifier operations,
+/// lowers `tket.quantum` operations to platform-native QSystem operations, lowers
+/// Guppy `drop` operations, and marks helper functions introduced during
+/// lowering as private.
+///
+/// The pass supports both local and global scopes. Some lowerings require adding
+/// helper functions at module scope and are therefore only performed for global
+/// scopes by the underlying [`LowerTketToQSystemPass`].
+#[derive(Debug, Clone)]
+pub struct QSystemRebasePass {
+    resolve_modifiers: bool,
+    lower_drops: bool,
+    hide_funcs: bool,
+    /// Where to apply the pass.
+    ///
+    /// Configurable via [`WithScope::with_scope`].
+    scope: PassScope,
+    /// Target platform, which may affect how certain operations are lowered.
+    platform: QSystemPlatform,
+}
+
+impl QSystemRebasePass {
+    /// Load default settings for [`QSystemRebasePass`] given the target QSystem
+    /// platform.
+    pub fn defaults(platform: QSystemPlatform) -> Self {
+        Self {
+            resolve_modifiers: true,
+            lower_drops: true,
+            hide_funcs: true,
+            scope: PassScope::default(),
+            platform,
+        }
+    }
+
+    /// Returns a new pass with modifier resolution enabled according to
+    /// `resolve_modifiers`.
+    ///
+    /// On by default.
+    pub fn with_resolve_modifiers(mut self, resolve_modifiers: bool) -> Self {
+        self.resolve_modifiers = resolve_modifiers;
+        self
+    }
+
+    /// Returns a new pass with Guppy `drop` lowering enabled according to
+    /// `lower_drops`.
+    ///
+    /// On by default.
+    pub fn with_lower_drops(mut self, lower_drops: bool) -> Self {
+        self.lower_drops = lower_drops;
+        self
+    }
+
+    /// Changes whether helper functions introduced by lowering are marked as
+    /// private.
+    ///
+    /// On by default.
+    pub fn with_hide_funcs(mut self, hide_funcs: bool) -> Self {
+        self.hide_funcs = hide_funcs;
+        self
+    }
+
+    /// Collect the public function definitions present before lowering.
+    ///
+    /// Lowering can introduce reusable helper functions with public visibility.
+    /// The collected set lets us keep pre-existing public functions public while
+    /// hiding newly introduced helpers before LLVM sees the HUGR.
+    fn collect_pub_funcs(&self, hugr: &impl HugrView<Node = Node>) -> Option<HashSet<Node>> {
+        self.hide_funcs.then(|| {
+            hugr.children(hugr.module_root())
+                .filter(|n| {
+                    hugr.get_optype(*n)
+                        .as_func_defn()
+                        .is_some_and(|fd| fd.visibility() == &Visibility::Public)
+                })
+                .collect::<HashSet<_>>()
+        })
+    }
+
+    /// Mark non-whitelisted function definitions as private.
+    fn hide_non_pub_funcs(&self, hugr: &mut impl HugrMut<Node = Node>, pub_funcs: HashSet<Node>) {
+        for n in hugr.children(hugr.module_root()).collect_vec() {
+            if !pub_funcs.contains(&n)
+                && let OpType::FuncDefn(fd) = hugr.optype_mut(n)
+            {
+                *fd.visibility_mut() = Visibility::Private;
+            }
+        }
+    }
+}
+
+impl WithScope for QSystemRebasePass {
+    fn with_scope(mut self, scope: impl Into<PassScope>) -> Self {
+        self.scope = scope.into();
+        self
+    }
+}
+
+impl<H: HugrMut<Node = Node> + 'static> ComposablePass<H> for QSystemRebasePass {
+    type Error = QSystemRebasePassError;
+    type Result = ();
+
+    fn run(&self, hugr: &mut H) -> Result<Self::Result, Self::Error> {
+        if self.resolve_modifiers {
+            ModifierResolverPass::default()
+                .with_scope(self.scope.clone())
+                .run(hugr)?;
+        }
+
+        let pub_funcs = self.collect_pub_funcs(hugr);
+
+        LowerTketToQSystemPass::new(self.platform)
+            .with_scope(self.scope.clone())
+            .run(hugr)?;
+
+        if self.lower_drops {
+            LowerDropsPass::default_with_scope(self.scope.clone()).run(hugr)?;
+        }
+
+        if let Some(pub_funcs) = pub_funcs {
+            self.hide_non_pub_funcs(hugr, pub_funcs);
+        }
+
+        Ok(())
+    }
+}

--- a/tket-qsystem/tests/guppy_opt.rs
+++ b/tket-qsystem/tests/guppy_opt.rs
@@ -15,7 +15,7 @@ use tket::passes::NormalizeGuppy;
 use tket::serialize::pytket::{EncodeOptions, EncodedCircuit};
 
 use tket_qsystem::pytket::{qsystem_decoder_config, qsystem_encoder_config};
-use tket_qsystem::{QSystemPass, QSystemPlatform};
+use tket_qsystem::{QSystemLLVMPass, QSystemPlatform, QSystemRebasePass};
 use tket1_passes::{Tket1Circuit, Tket1Pass};
 
 const GUPPY_EXAMPLES_DIR: &str = "../test_files/guppy_optimization";
@@ -191,9 +191,10 @@ fn optimize_guppy(#[case] name: &str) {
 
     // Lower to QSystem. This may blow up the HUGR size.
     //TODO: add Sol case
-    QSystemPass::defaults(QSystemPlatform::Helios)
+    QSystemRebasePass::defaults(QSystemPlatform::Helios)
         .run(&mut hugr)
         .unwrap();
+    QSystemLLVMPass::default().run(&mut hugr).unwrap();
 
     hugr.validate().unwrap_or_else(|e| panic!("{e}"));
 }


### PR DESCRIPTION
Splits `QSystemPass` into two steps:

- A `QSystemRebasePass` that lowers the generic quantum operations into native operations.
- A `QSystemLLVMPass` that prepares the HUGR to be lowered to LLVMIR.

Native-aware optimizations can be run in between the two.

See https://github.com/Quantinuum/tket2/issues/1750 for a longer writeup.

Closes #1627. Closes #1727. Closes #1467.

BREAKING CHANGE: `QSystemPass` was split into `QSystemRebasePass` and `QSystemLLVMPass`.