### PR TITLE
fix: Add missing `argument` extension reexport

### DIFF
--- a/tket-py/tket/extensions/__init__.py
+++ b/tket-py/tket/extensions/__init__.py
@@ -1,4 +1,5 @@
 from tket_exts import (
+    argument,
     debug,
     futures,
     global_phase,
@@ -19,6 +20,7 @@ from tket_exts import (
 
 
 __all__ = [
+    "argument",
     "debug",
     "futures",
     "global_phase",


### PR DESCRIPTION
`tket-py` is missing a reexport from `tket_exts` for the new `tket.argument` extension