### PR TITLE
fix: RedundantOrderEdges pass finding loops when there are none

### DIFF
--- a/tket/src/passes/redundant_order_edges.rs
+++ b/tket/src/passes/redundant_order_edges.rs
@@ -87,7 +87,6 @@ impl RedundantOrderEdgesPass {
                     for (&other_pred, &other_pred_port) in order_preds.iter() {
                         if reaching_pred.contains(&(other_pred, other_pred_port)) {
                             // `other_pred` reaches predecessor `order_pred` of child, and has a direct edge to child.
-                            assert!(!to_remove.contains_key(&(*order_pred, child))); // this would mean a cycle
                             to_remove.insert((other_pred, child), (other_pred_port, ord_in));
                         }
                     }
@@ -177,6 +176,8 @@ mod tests {
     #[case([("input", "noop1"), ("noop1", "noop5"), ("input", "noop4"), ("noop4", "noop5"), ("noop5", "output"),
             ("input", "noop5"), ("noop1", "output"), ("noop4", "output")],
            [("input", "noop1"), ("noop1", "noop5"), ("input", "noop4"), ("noop4", "noop5"), ("noop5", "output")])]
+    #[case([("noop1", "noop4"), ("noop4", "noop2"), ("noop2", "noop5"), ("noop4", "noop5"), ("noop1", "noop5")],
+           [("noop1", "noop4"), ("noop4", "noop2"), ("noop2", "noop5")])]
     fn test_redundant_order_edges(
         #[case] start_edges: impl IntoIterator<Item = (&'static str, &'static str)>,
         #[case] end_edges: impl IntoIterator<Item = (&'static str, &'static str)>,

--- a/tket/src/passes/redundant_order_edges.rs
+++ b/tket/src/passes/redundant_order_edges.rs
@@ -177,7 +177,7 @@ mod tests {
             ("input", "noop5"), ("noop1", "output"), ("noop4", "output")],
            [("input", "noop1"), ("noop1", "noop5"), ("input", "noop4"), ("noop4", "noop5"), ("noop5", "output")])]
     #[case([("noop1", "noop4"), ("noop4", "noop2"), ("noop2", "noop5"), ("noop4", "noop5"), ("noop1", "noop5")],
-           [("noop1", "noop4"), ("noop4", "noop2"), ("noop2", "noop5")])]
+           [("noop1", "noop4"), ("noop4", "noop2"), ("noop2", "noop5"), ("noop1", "noop4")])]
     fn test_redundant_order_edges(
         #[case] start_edges: impl IntoIterator<Item = (&'static str, &'static str)>,
         #[case] end_edges: impl IntoIterator<Item = (&'static str, &'static str)>,


### PR DESCRIPTION
The pass had an `assert` to fail when an edge is reached multiple times, claiming that would be a cycle.

This PR removes the assert, and adds a test showing a case where the same order edge is reached from multiple paths (it should not affect the rest of the pass, since edges are just added to a map).