### PR TITLE
feat: Improve InlineFuncs size heuristic

### DIFF
--- a/tket-py/src/passes/inline_funcs.rs
+++ b/tket-py/src/passes/inline_funcs.rs
@@ -14,7 +14,7 @@ use crate::utils::ConvertPyErr;
 ///
 /// Parameters:
 /// - heuristic: Heuristic used to choose which non-recursive functions to
-///   inline. Defaults to `tket.passes.MaxSize(64)`.
+///   inline. Defaults to `tket.passes.MaxSize(128)`.
 /// - follow_inline_hints: Whether to follow compiler hints for inlining
 ///   functions.
 #[pyfunction]

--- a/tket-py/tket/_tket/passes.pyi
+++ b/tket-py/tket/_tket/passes.pyi
@@ -27,7 +27,7 @@ def normalize_guppy(
     constant_folding: bool = True,
     remove_dead_funcs: bool = True,
     inline_dfgs: bool = True,
-    inline_funcs: inline_funcs.InlineFuncsHeuristic | None = inline_funcs.MaxSize(64),
+    inline_funcs: inline_funcs.InlineFuncsHeuristic | None = inline_funcs.MaxSize(128),
     remove_redundant_order_edges: bool = True,
     squash_borrows: bool = True,
     scope: PassScope = GlobalScope.PRESERVE_PUBLIC,
@@ -51,7 +51,7 @@ def normalize_guppy(
 def inline_functions(
     circ: CompilationState,
     *,
-    heuristic: inline_funcs.InlineFuncsHeuristic = inline_funcs.MaxSize(64),
+    heuristic: inline_funcs.InlineFuncsHeuristic = inline_funcs.MaxSize(128),
     scope: PassScope = GlobalScope.PRESERVE_PUBLIC,
 ) -> None:
     """Inline acyclic function calls below the selected scope."""

--- a/tket-py/tket/passes/__init__.py
+++ b/tket-py/tket/passes/__init__.py
@@ -148,7 +148,7 @@ class NormalizeGuppy(ComposablePass):
         inline_funcs_heuristic: inline_funcs.InlineFuncsHeuristic | None
         match self.inline_funcs:
             case True:
-                inline_funcs_heuristic = inline_funcs.MaxSize(64)
+                inline_funcs_heuristic = inline_funcs.MaxSize(128)
             case False:
                 inline_funcs_heuristic = None
             case _:
@@ -247,10 +247,10 @@ class InlineFunctions(ComposablePass):
 
     Parameters:
     - heuristic: Heuristic used to choose which non-recursive functions to
-      inline. Defaults to `MaxSize(64)`.
+      inline. Defaults to `MaxSize(128)`.
     """
 
-    heuristic: inline_funcs.InlineFuncsHeuristic = inline_funcs.MaxSize(64)
+    heuristic: inline_funcs.InlineFuncsHeuristic = inline_funcs.MaxSize(128)
     _scope: PassScope = GlobalScope.PRESERVE_PUBLIC
 
     def run(self, hugr: Hugr, *, inplace: bool = True) -> PassResult:

--- a/tket/src/passes/inline_funcs.rs
+++ b/tket/src/passes/inline_funcs.rs
@@ -62,6 +62,14 @@ fn estimated_inline_size<H: HugrView>(
     estimated_inline_size_inner(func, hugr, cache, &mut HashSet::new(), limit)
 }
 
+/// Recursive worker for [`estimated_inline_size`].
+///
+/// Arguments:
+/// - `cache` memoizes completed function estimates across calls in the pass,
+/// - `visiting` tracks the current recursion stack so cyclic call graphs are
+///   treated as over budget.
+/// - `limit` is only used to cut the estimation early if we already exceeded
+///   the max size.
 fn estimated_inline_size_inner<H: HugrView>(
     func: H::Node,
     hugr: &H,

--- a/tket/src/passes/inline_funcs.rs
+++ b/tket/src/passes/inline_funcs.rs
@@ -32,17 +32,72 @@ pub enum InlineFuncsHeuristic {
 
 impl InlineFuncsHeuristic {
     /// Returns `True` if the function definition should be inlined.
-    fn should_inline<H: HugrView>(&self, func: H::Node, hugr: &H) -> bool {
+    fn should_inline<H: HugrView>(
+        &self,
+        func: H::Node,
+        hugr: &H,
+        size_cache: &mut HashMap<H::Node, usize>,
+    ) -> bool {
         match self {
-            InlineFuncsHeuristic::MaxSize(size) => hugr.descendants(func).count() <= *size,
+            InlineFuncsHeuristic::MaxSize(size) => {
+                estimated_inline_size(func, hugr, size_cache, *size) <= *size
+            }
             InlineFuncsHeuristic::All => true,
         }
     }
 }
 
+/// Estimate the expanded size of inlining a function under a max-size heuristic.
+///
+/// The direct descendant count alone can underestimate wrappers that call other
+/// inlineable helpers. Counting reachable static callees keeps those wrappers
+/// from repeatedly expanding medium-sized helper graphs before later cleanup
+/// passes get a chance to simplify them.
+fn estimated_inline_size<H: HugrView>(
+    func: H::Node,
+    hugr: &H,
+    cache: &mut HashMap<H::Node, usize>,
+    limit: usize,
+) -> usize {
+    estimated_inline_size_inner(func, hugr, cache, &mut HashSet::new(), limit)
+}
+
+fn estimated_inline_size_inner<H: HugrView>(
+    func: H::Node,
+    hugr: &H,
+    cache: &mut HashMap<H::Node, usize>,
+    visiting: &mut HashSet<H::Node>,
+    limit: usize,
+) -> usize {
+    if let Some(size) = cache.get(&func) {
+        return *size;
+    }
+    if !visiting.insert(func) {
+        return limit.saturating_add(1);
+    }
+
+    let mut size = hugr.descendants(func).count();
+    for call in hugr
+        .descendants(func)
+        .filter(|node| hugr.get_optype(*node).is_call())
+    {
+        if let Some(callee) = hugr.static_source(call) {
+            size = size.saturating_add(estimated_inline_size_inner(
+                callee, hugr, cache, visiting, limit,
+            ));
+            if size > limit {
+                break;
+            }
+        }
+    }
+    visiting.remove(&func);
+    cache.insert(func, size);
+    size
+}
+
 impl Default for InlineFuncsHeuristic {
     fn default() -> Self {
-        Self::MaxSize(64)
+        Self::MaxSize(128)
     }
 }
 
@@ -73,6 +128,7 @@ impl<H: HugrMut> ComposablePass<H> for InlineFunctionsPass {
 
     fn run(&self, h: &mut H) -> Result<(), Self::Error> {
         let mut should_inline_cache: HashMap<H::Node, bool> = HashMap::new();
+        let mut size_cache: HashMap<H::Node, usize> = HashMap::new();
         inline_acyclic_scoped(h, self.scope.clone(), |h, call| {
             let Some(func) = h.static_source(call) else {
                 return false;
@@ -81,7 +137,7 @@ impl<H: HugrMut> ComposablePass<H> for InlineFunctionsPass {
                 match h.get_metadata::<InlineAnnotation>(func) {
                     Some(InlineAnnotation::Never) => false,
                     Some(InlineAnnotation::BestEffort) => true,
-                    None => self.heuristic.should_inline(func, h),
+                    None => self.heuristic.should_inline(func, h, &mut size_cache),
                 }
             })
         })
@@ -157,7 +213,7 @@ pub fn inline_acyclic_scoped<H: HugrMut>(
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use itertools::Itertools;
     use rstest::rstest;
@@ -170,7 +226,7 @@ mod test {
     use hugr_core::ops::OpType;
     use hugr_core::{Hugr, extension::prelude::qb_t, types::Signature};
 
-    use super::{InlineFunctionsPass, inline_acyclic_scoped};
+    use super::{InlineFunctionsPass, estimated_inline_size, inline_acyclic_scoped};
     use crate::metadata::InlineAnnotation;
     use crate::passes::composable::test::run_validating;
     use crate::passes::inline_funcs::InlineFuncsHeuristic;
@@ -350,6 +406,21 @@ mod test {
                 .collect::<HashSet<_>>(),
             HashSet::from_iter(g_targets),
         );
+    }
+
+    #[test]
+    fn max_size_heuristic_counts_transitive_callees() {
+        let h = make_test_hugr();
+        let b = find_func(&h, "b");
+        let direct_size = h.descendants(b).count();
+        let expanded_size = estimated_inline_size(b, &h, &mut HashMap::new(), usize::MAX);
+
+        assert!(expanded_size > direct_size);
+        assert!(!InlineFuncsHeuristic::MaxSize(direct_size).should_inline(
+            b,
+            &h,
+            &mut HashMap::new()
+        ));
     }
 
     #[rstest]


### PR DESCRIPTION
Improves the `MaxSize` heuristic for function inlining by checking transitive caller's sizes.
That prevents us from exponential size grow when multiple small functions call each other.

The check counts an estimate size for the descendants if they were to be inlined, and adds it to the size of the caller function. This prevents a panic in the `tests.integration.std.test_random-test_pcg32_compile.hugr` where we ended up generating too many calls to a function declaration, due to the callers being copied lots of times.

```
pyo3_runtime.PanicException: Outgoing port count exceeds maximum.
portgraph-0.16.1/src/portgraph.rs:548:9
```

Bumps the default MaxSize from 64 to 128 to account for these added counts.