### PR TITLE
ci: remove --no-project flag to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,9 @@ jobs:
       - name: Type check with mypy
         run: uv run mypy .
       - name: Check formatting with ruff
-        run: uv run --no-project ruff format --check
+        run: uv run ruff format --check
       - name: Lint with ruff
-        run: uv run --no-project ruff check
+        run: uv run ruff check
 
   benches:
     name: Continuous benchmarking 🏋️
@@ -306,18 +306,8 @@ jobs:
       - name: Setup dependencies
         # avoid building qis-compiler
         run: uv sync --package=tket --exact --all-extras --python ${{ env.PYTHON_LOWEST }}
-      - name: pytest version
-        run: uv run pytest --version
-      - name: which pytest
-        run: uv run which pytest
-      - name: pytest version w/ --no-project
-        run: uv run --no-project pytest --version
-      - name: which pytest w/ --no-project
-        run: uv run --no-project which pytest
-      - name: which pytest inside bash
-        run: uv run --no-project bash -c 'which pytest'
       - name: Run python tests with coverage instrumentation
-        run: uv run --no-project pytest --cov=./ --cov-report=xml ${{ env.PKGS }}
+        run: uv run pytest --cov=./ --cov-report=xml ${{ env.PKGS }}
       - name: Upload python coverage to codecov.io
         if: github.event_name != 'merge_group'
         uses: codecov/codecov-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,8 +308,14 @@ jobs:
         run: uv sync --package=tket --exact --all-extras --python ${{ env.PYTHON_LOWEST }}
       - name: pytest version
         run: uv run pytest --version
+      - name: which pytest
+        run: uv run which pytest
       - name: pytest version w/ --no-project
         run: uv run --no-project pytest --version
+      - name: which pytest w/ --no-project
+        run: uv run --no-project which pytest
+      - name: which pytest inside bash
+        run: uv run --no-project bash -c 'which pytest'
       - name: Run python tests with coverage instrumentation
         run: uv run --no-project pytest --cov=./ --cov-report=xml ${{ env.PKGS }}
       - name: Upload python coverage to codecov.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,10 @@ jobs:
       - name: Setup dependencies
         # avoid building qis-compiler
         run: uv sync --package=tket --exact --all-extras --python ${{ env.PYTHON_LOWEST }}
+      - name: pytest version
+        run: uv run pytest --version
+      - name: pytest version w/ --no-project
+        run: uv run --no-project pytest --version
       - name: Run python tests with coverage instrumentation
         run: uv run --no-project pytest --cov=./ --cov-report=xml ${{ env.PKGS }}
       - name: Upload python coverage to codecov.io


### PR DESCRIPTION
It's not clear the --no-project flag is doing anything - this is from a CI run:
```
Run uv run --no-project which pytest
warning: `--frozen` has no effect when used alongside `--no-project`
/home/runner/work/tket2/tket2/.venv/bin/pytest
```

but on my local machine, `--no-project` avoids using the .venv and instead looks for a system-installed pytest, thus `uv run --no-project pytest` typically fails with:
```
error: Failed to spawn: `pytest`
  Caused by: No such file or directory (os error 2)
```

Thus, if there's any reason that we need the `--no-project`, then at the least we should understand why it behaves differently in CI, and comment.

But this PR takes the viewpoint that there is no need for `--no-project`, hence removing it to avoid confusion.