### PR TITLE
chore: Ignore snapshot files in pre-commit fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
         exclude: |
           (?x)^(
             test_files/.*|
+            .*/snapshots/.*|
             .*.snap|
             .*.snap.new|
             .release-please-manifest.json|
@@ -23,6 +24,7 @@ repos:
         exclude: |
           (?x)^(
             test_files/.*|
+            .*/snapshots/.*|
             .*.snap|
             .*.snap.new|
             .*.lock


### PR DESCRIPTION
`just check` has been adding newlines to the end of snapshot files due to this rule.