### PR TITLE
feat: Target platform option in PytketHugrPass

### DIFF
--- a/tket-py/src/passes/tket1.rs
+++ b/tket-py/src/passes/tket1.rs
@@ -1,14 +1,16 @@
 //! Passes that call to tket1-passes using the tket-c-api.
 
+use std::str::FromStr;
+
 use rayon::iter::ParallelIterator;
 use std::sync::Arc;
 use tket::passes::composable::PassScope;
-use tket_qsystem::QSystemPlatform;
+use tket_qsystem::PlatformTarget;
 
 use crate::passes::PyPassScope;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use tket::serialize::pytket::{EncodeOptions, EncodedCircuit};
-use tket_qsystem::pytket::{qsystem_decoder_config, qsystem_encoder_config};
 
 use crate::state::CompilationState;
 use crate::utils::{ConvertPyErr, create_py_exception};
@@ -16,23 +18,49 @@ use crate::utils::{ConvertPyErr, create_py_exception};
 /// Runs a pytket pass on all circuit-like regions under the entrypoint of the
 /// HUGR.
 ///
+/// The `target` string selects which set of encoder/decoder extensions is used
+/// when translating between the HUGR and pytket circuits:
+///
+/// - `"tket"` (default): Only base `tket` operations are encoded. When decoding,
+///   pytket commands are translated into base `tket.quantum` operations, falling
+///   back to Helios qsystem operations for commands without a base counterpart
+///   (e.g. `ZZPhase`).
+/// - `"sol"`: Base `tket` and native Sol operations are encoded. When decoding,
+///   commands are translated into native Sol qsystem operations where possible,
+///   falling back to base `tket.quantum` operations.
+/// - `"helios"`: Base `tket` and native Helios operations are encoded. When
+///   decoding, commands are translated into native Helios qsystem operations
+///   where possible, falling back to base `tket.quantum` operations.
+///
+/// Operations without a valid encoder are kept as-is on a pytket roundtrip.
+/// Pytket commands without a valid decoder produce an unsupported `TKET1.tk1op`
+/// operation in the decoded HUGR.
+///
 /// Parameters:
 /// - program: The CompilationState to run the pass on.
 /// - pass_json: The JSON string of the pytket pass to run. See [pytket
 ///   documentation](https://docs.quantinuum.com/tket/api-docs/passes.html#pytket.passes.BasePass.to_dict)
 ///   for more details.
+/// - target: The platform target identifier selecting which encoder/decoder
+///   extension set to use. Defaults to the platform-agnostic `"tket"` target.
 #[pyfunction]
-#[pyo3(signature = (program, pass_json, *, scope = None))]
+#[pyo3(signature = (program, pass_json, *, scope = None, target = None))]
 pub(crate) fn tket1_pass(
     program: &mut CompilationState,
     pass_json: &str,
     scope: Option<PyPassScope>,
+    target: Option<&str>,
 ) -> PyResult<()> {
     // TODO: Implement a Tket1Pass: ComposablePass, use it here with the right scope.
     // <https://github.com/Quantinuum/tket2/issues/1494>
     let scope: PassScope = scope.unwrap_or_default().scope;
+    let target = match target {
+        None => PlatformTarget::default(),
+        Some(s) => PlatformTarget::from_str(s)
+            .map_err(|_| PyValueError::new_err(format!("Unknown platform target: {s:?}")))?,
+    };
     let encode_options = EncodeOptions::new()
-        .with_config(qsystem_encoder_config(QSystemPlatform::Helios))
+        .with_config(target.encoder_config())
         .with_subcircuits(scope.recursive());
 
     let Some(root) = scope.root(&program.hugr) else {
@@ -53,12 +81,7 @@ pub(crate) fn tket1_pass(
         .convert_pyerrs()?;
 
     encoded_circ
-        .reassemble_inplace(
-            &mut program.hugr,
-            // TODO: Make the decoder set configurable.
-            // <https://github.com/Quantinuum/tket2/issues/1619>
-            Some(Arc::new(qsystem_decoder_config(QSystemPlatform::Helios))),
-        )
+        .reassemble_inplace(&mut program.hugr, Some(Arc::new(target.decoder_config())))
         .convert_pyerrs()?;
 
     Ok(())

--- a/tket-py/src/state/base.rs
+++ b/tket-py/src/state/base.rs
@@ -1,6 +1,7 @@
 //! Rust-backed representation of circuits
 
 use std::num::NonZeroU8;
+use std::str::FromStr;
 
 use anyhow::Context;
 use hugr::envelope::{EnvelopeConfig, EnvelopeFormat, ZstdConfig};
@@ -15,9 +16,9 @@ use tket::serialize::TKETDecode;
 use tket::serialize::pytket::{DecodeOptions, EncodeOptions};
 use tket::{Circuit, TketOp};
 use tket_json_rs::circuit_json::SerialCircuit;
-use tket_qsystem::QSystemPlatform;
 use tket_qsystem::extension::REGISTRY;
-use tket_qsystem::pytket::{qsystem_decoder_config, qsystem_encoder_config};
+use tket_qsystem::pytket::qsystem_encoder_config;
+use tket_qsystem::{PlatformTarget, QSystemPlatform};
 
 use crate::ops::PyTketOp;
 use crate::rewrite::PyCircuitRewrite;
@@ -45,12 +46,21 @@ impl CompilationState {
     }
 
     /// Load a program from a legacy `pytket.Circuit`.
+    ///
+    /// The `target` string selects which decoder extension set is used when
+    /// translating pytket commands into HUGR operations. It defaults to the
+    /// platform-agnostic `"tket"` target. See [`PlatformTarget`] for the
+    /// available targets and their behaviour.
     #[staticmethod]
-    pub fn from_tket1(circ: &Bound<PyAny>) -> anyhow::Result<Self> {
+    #[pyo3(signature = (circ, *, target = None))]
+    pub fn from_tket1(circ: &Bound<PyAny>, target: Option<&str>) -> anyhow::Result<Self> {
+        let target = match target {
+            None => PlatformTarget::default(),
+            Some(s) => PlatformTarget::from_str(s)
+                .with_context(|| format!("Unknown platform target: {s:?}"))?,
+        };
         let hugr = SerialCircuit::from_tket1(circ)?
-            .decode(
-                DecodeOptions::new().with_config(qsystem_decoder_config(QSystemPlatform::Helios)),
-            )
+            .decode(DecodeOptions::new().with_config(target.decoder_config()))
             .context("Could not decode a CompilationState from a pytket circuit")?;
         Ok(CompilationState { hugr })
     }

--- a/tket-py/test/test_pass.py
+++ b/tket-py/test/test_pass.py
@@ -21,7 +21,12 @@ import hypothesis.strategies as st
 from hypothesis.strategies._internal import SearchStrategy
 from hypothesis import given, settings
 
-from tket.passes import PytketHugrPass, _QSystemLLVMPass, QSystemRebasePass
+from tket.passes import (
+    PytketHugrPass,
+    _QSystemLLVMPass,
+    QSystemRebasePass,
+    PlatformTarget,
+)
 from hugr.build.base import Hugr
 from hugr.package import Package
 
@@ -229,7 +234,7 @@ def test_squash_phasedx_rz():
         Circuit(1).Rz(0.25, 0).Rz(0.75, 0).Rz(0.25, 0).Rz(-1.25, 0)
     )
     hugr = Hugr.from_str(c.to_str(), tket_registry())
-    squash_pass = PytketHugrPass(SquashRzPhasedX())
+    squash_pass = PytketHugrPass(SquashRzPhasedX(), target=PlatformTarget.Tket)
     opt_hugr = squash_pass(hugr)
     opt_circ = CompilationState.from_bytes(opt_hugr.to_bytes())
     # TODO: We cannot use circuit_cost due to a panic on non-tket ops and there
@@ -248,6 +253,25 @@ def test_sequence_pass():
     opt_circ = CompilationState.from_bytes(res_hugr.to_bytes())
     assert opt_circ.num_operations() == 1
     assert opt_circ.circuit_cost(lambda op: int(op == TketOp.CX)) == 1
+
+
+@pytest.mark.parametrize(
+    ("target", "expected_rz"),
+    [
+        (PlatformTarget.Tket, "tket.quantum.Rz"),
+        (PlatformTarget.Sol, "tket.qsystem.sol.Rz"),
+        (PlatformTarget.Helios, "tket.qsystem.helios.Rz"),
+    ],
+)
+def test_platform_target_decoding(target: PlatformTarget, expected_rz: str):
+    """The platform target controls which extension the ambiguous `Rz`
+    operation is decoded into."""
+    c = CompilationState.from_tket1(Circuit(1).Rz(0.25, 0).Rz(0.25, 0))
+    hugr = Hugr.from_str(c.to_str(), tket_registry())
+
+    res = PytketHugrPass(RemoveRedundancies(), target=target).run(hugr)
+
+    assert _count_ops(res.hugr, expected_rz) == 1
 
 
 def test_normalize_guppy():

--- a/tket-py/tket/_state/__init__.py
+++ b/tket-py/tket/_state/__init__.py
@@ -27,6 +27,7 @@ TK1EncodeError = _state.TK1EncodeError
 if TYPE_CHECKING:
     from tket._rewrite import CircuitRewrite
     from tket.util import PytketCircuitProto
+    from tket.passes import PlatformTarget
 
 
 __all__ = [
@@ -65,9 +66,21 @@ class CompilationState:
     _py_extensions: ExtensionRegistry | None = None
 
     @staticmethod
-    def from_tket1(circ: PytketCircuitProto) -> CompilationState:
-        """Create a CompilationState from a legacy pytket Circuit."""
-        return CompilationState(_inner=_state.CompilationState.from_tket1(circ))
+    def from_tket1(
+        circ: PytketCircuitProto, *, target: PlatformTarget | None = None
+    ) -> CompilationState:
+        """Create a CompilationState from a legacy pytket Circuit.
+
+        Parameters:
+        - circ: The legacy pytket circuit to load.
+        - target: The platform target selecting which decoder extension set is
+          used when translating pytket commands into HUGR operations. Defaults
+          to the platform-agnostic ``PlatformTarget.Tket``.
+        """
+        target_str = target.value if target is not None else None
+        return CompilationState(
+            _inner=_state.CompilationState.from_tket1(circ, target=target_str)  # type: ignore[arg-type]
+        )
 
     @staticmethod
     def from_python(hugr: Hugr | Package) -> CompilationState:

--- a/tket-py/tket/_tket/passes.pyi
+++ b/tket-py/tket/_tket/passes.pyi
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pathlib import Path
 
 from .optimiser import BadgerOptimiser
@@ -81,6 +83,7 @@ def tket1_pass(
     pass_json: str,
     *,
     scope: PassScope | None = None,
+    target: Literal["tket", "sol", "helios"] | None = None,
 ) -> None:
     """Runs a pytket pass on all circuit-like regions under the entrypoint of the
     HUGR.
@@ -92,6 +95,9 @@ def tket1_pass(
     - traverse_subcircuits: Whether to recurse into the children of the
       circuit-like regions, and optimise them too.
       nested inside other subregions of the circuit.
+    - target: The platform target identifier selecting which encoder/decoder
+      extension set to use. One of ``"tket"``, ``"sol"``, or ``"helios"``.
+      Defaults to the platform-agnostic ``"tket"`` target.
     """
 
 def resolve_modifiers(

--- a/tket-py/tket/_tket/state.pyi
+++ b/tket-py/tket/_tket/state.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 
 from tket._tket.ops import TketOp
 from tket.util import PytketCircuitProto as Tk1Circuit
@@ -23,8 +23,18 @@ class CompilationState:
         """Create a new empty program."""
 
     @staticmethod
-    def from_tket1(circ: Tk1Circuit) -> CompilationState:
-        """Load a program from a legacy pytket Circuit."""
+    def from_tket1(
+        circ: Tk1Circuit, *, target: Literal["tket", "sol", "helios"] | None = None
+    ) -> CompilationState:
+        """Load a program from a legacy pytket Circuit.
+
+        Parameters:
+        - circ: The legacy pytket circuit to load.
+        - target: The platform target identifier selecting which decoder
+          extension set to use when translating pytket commands into HUGR
+          operations. One of ``"tket"``, ``"sol"``, or ``"helios"``. Defaults to
+          the platform-agnostic ``"tket"`` target.
+        """
 
     def apply_rewrite(self, rw) -> None:
         """Apply a rewrite on the circuit."""

--- a/tket-py/tket/passes/__init__.py
+++ b/tket-py/tket/passes/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from functools import cache
 import json
 from pathlib import Path
@@ -28,6 +29,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "PytketHugrPass",
+    "PlatformTarget",
     "PassResult",
     "InlineFuncsHeuristic",
     "InlineFunctions",
@@ -39,20 +41,69 @@ __all__ = [
 ]
 
 
+class PlatformTarget(Enum):
+    """A hardware platform that passes can target.
+
+    Passes use this to decide which platform-specific gate sets and extensions
+    to produce or accept. See the individual passes (e.g.
+    :py:class:`PytketHugrPass`) for the behaviour associated with each target.
+    """
+
+    Tket = "tket"  # Platform-agnostic target using only the base `tket` extensions.
+    Sol = "sol"  # Quantinuum Sol platform (base tket + Sol operations).
+    Helios = "helios"  # Quantinuum Helios platform (base tket + Helios operations).
+
+
 @dataclass
 class PytketHugrPass(ComposablePass):
     pytket_passes: list[PytketPass]
+    target: PlatformTarget = PlatformTarget.Tket
     _scope: PassScope = GlobalScope.PRESERVE_PUBLIC
 
     """
     A class which provides an interface to apply pytket passes to Hugr programs.
 
-    The user can create a :py:class:`PytketHugrPass` object from any serializable member of `pytket.passes`.
+    The user can create a :py:class:`PytketHugrPass` object from any
+    serializable member of `pytket.passes`.
+
+    The ``target`` selects which set of encoder/decoder extensions is used when
+    translating between HUGRs and pytket circuits, controlling which operations
+    get encoded as pytket commands and which pytket commands get decoded back
+    into HUGR operations:
+
+    - :py:attr:`PlatformTarget.Tket` (default):
+        Only base ``tket`` operations are encoded.
+        When decoding, pytket commands are translated into base ``tket.quantum``
+        operations, falling back to Helios qsystem operations for
+        commands without a base counterpart (e.g. ``ZZPhase``).
+    - :py:attr:`PlatformTarget.Sol`:
+        Base ``tket`` and native Sol operations are encoded.
+        When decoding, commands are translated into native Sol qsystem operations
+        where possible, falling back to base ``tket.quantum`` operations.
+    - :py:attr:`PlatformTarget.Helios`:
+        Base ``tket`` and native Helios operations are encoded.
+        When decoding, commands are translated into native Helios qsystem operations
+        where possible, falling back to base ``tket.quantum`` operations.
+
+    Operations without a valid encoder are kept as-is on a pytket roundtrip.
+    Pytket commands without a valid decoder produce an unsupported
+    ``TKET1.tk1op`` operation in the decoded HUGR.
+
+    Parameters:
+    - pytket_passes: The pytket passes to run.
+    - target: The platform target selecting which encoder/decoder extension set
+      to use when translating between HUGRs and pytket circuits. Defaults to the
+      platform-agnostic :py:attr:`PlatformTarget.Tket`.
     """
 
-    def __init__(self, *pytket_passes: PytketPass) -> None:
+    def __init__(
+        self,
+        *pytket_passes: PytketPass,
+        target: PlatformTarget = PlatformTarget.Tket,
+    ) -> None:
         """Initialize a PytketHugrPass from a :py:class:`~pytket.passes.BasePass` instance."""
         self.pytket_passes = list(pytket_passes)
+        self.target = target
 
     def with_scope(self, scope: PassScope) -> PytketHugrPass:
         """Set the scope configuration for the composed pass."""
@@ -70,10 +121,11 @@ class PytketHugrPass(ComposablePass):
 
     def then(self, other: ComposablePass) -> ComposablePass:
         """Perform another composable pass after this pass."""
-        if isinstance(other, PytketHugrPass):
-            return PytketHugrPass(*self.pytket_passes, *other.pytket_passes).with_scope(
-                self._scope
+        if isinstance(other, PytketHugrPass) and self.target == other.target:
+            combined = PytketHugrPass(
+                *self.pytket_passes, *other.pytket_passes, target=self.target
             )
+            return combined.with_scope(self._scope)
         else:
             return ComposedPass(self, other)
 
@@ -81,7 +133,12 @@ class PytketHugrPass(ComposablePass):
         tk_program = _state.CompilationState.from_python(hugr)
         for py_pass in self.pytket_passes:
             pass_json = json.dumps(py_pass.to_dict())
-            _passes.tket1_pass(tk_program._inner, pass_json, scope=self._scope)
+            _passes.tket1_pass(
+                tk_program._inner,
+                pass_json,
+                scope=self._scope,
+                target=self.target.value,
+            )
 
         package = tk_program.to_python()
         new_hugr = package.modules[0]

--- a/tket-qsystem/src/lib.rs
+++ b/tket-qsystem/src/lib.rs
@@ -10,6 +10,7 @@ pub mod llvm;
 pub mod lower_drops;
 pub mod passes;
 pub mod pytket;
+mod target;
 
 pub use extension::qsystem::QSystemPlatform;
 pub use passes::{
@@ -17,6 +18,7 @@ pub use passes::{
 };
 #[expect(deprecated)]
 pub use passes::{QSystemPass, QSystemPassError};
+pub use target::PlatformTarget;
 
 #[cfg(test)]
 mod test {

--- a/tket-qsystem/src/pytket.rs
+++ b/tket-qsystem/src/pytket.rs
@@ -7,7 +7,7 @@ pub use futures::FutureEmitter;
 use hugr::HugrView;
 pub use qsystem::QSystemEmitter;
 use tket::serialize::pytket::{
-    PytketDecoderConfig, PytketEncoderConfig, default_decoder_config, default_encoder_config,
+    PytketDecoderConfig, PytketEncoderConfig, add_default_decoders, default_encoder_config,
 };
 
 use crate::extension::qsystem::QSystemPlatform;
@@ -18,10 +18,26 @@ use crate::extension::qsystem::QSystemPlatform;
 /// Contains a list of custom decoders that define translations of legacy tket
 /// primitives into HUGR operations.
 pub fn qsystem_decoder_config(platform: QSystemPlatform) -> PytketDecoderConfig {
-    let mut config = default_decoder_config();
+    let mut config = PytketDecoderConfig::new();
+
+    // Platform-specific decoders take priority over the base quantum ones.
+    add_qsystem_decoders(&mut config, platform);
+    add_default_decoders(&mut config);
+
+    config
+}
+
+/// Add the platform-specific HUGR decoders and type translators to an existing config.
+///
+/// This registers the base `qsystem` operation decoders together with the future type translators.
+///
+/// Decoders are tried in registration order, so this is useful when building
+/// custom decoder configs that register additional decoders *before* the qsystem
+/// ones to give them higher priority, while still keeping the qsystem decoders as
+/// a fallback.
+pub fn add_qsystem_decoders(config: &mut PytketDecoderConfig, platform: QSystemPlatform) {
     config.add_decoder(QSystemEmitter(platform));
     config.add_type_translator(FutureEmitter);
-    config
 }
 
 /// Default pytket encoder configuration for [`Circuit`][tket::Circuit]s with

--- a/tket-qsystem/src/target.rs
+++ b/tket-qsystem/src/target.rs
@@ -1,0 +1,83 @@
+//! Target platform selection for translating between HUGRs and pytket circuits.
+
+use hugr::HugrView;
+use strum::{EnumIter, EnumString, IntoStaticStr};
+use tket::serialize::pytket::{
+    PytketDecoderConfig, PytketEncoderConfig, default_decoder_config, default_encoder_config,
+};
+
+use crate::extension::qsystem::QSystemPlatform;
+use crate::pytket::{add_qsystem_decoders, qsystem_decoder_config, qsystem_encoder_config};
+
+/// Selects which set of encoder/decoder extensions is used when translating
+/// between HUGRs and pytket circuits.
+///
+/// This is a superset of [`QSystemPlatform`]: in addition to the native
+/// Quantinuum platforms it includes a platform-agnostic [`PlatformTarget::Tket`]
+/// variant that only uses the base `tket` extensions. The
+/// [`qsystem_platform`][PlatformTarget::qsystem_platform] conversion maps each
+/// target onto its [`QSystemPlatform`], returning `None` for the non-native
+/// `Tket` target.
+///
+/// The string representation of each variant (used by the python bindings) is
+/// the lowercase variant name, e.g. `"tket"`, `"sol"`, or `"helios"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, EnumIter, EnumString, IntoStaticStr)]
+#[strum(serialize_all = "lowercase")]
+#[non_exhaustive]
+pub enum PlatformTarget {
+    /// Platform-agnostic target using only the base `tket` extensions.
+    #[default]
+    Tket,
+    /// Quantinuum Sol platform.
+    Sol,
+    /// Quantinuum Helios platform.
+    Helios,
+}
+
+impl PlatformTarget {
+    /// The string identifier for this target, as used by the python bindings.
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// The native [`QSystemPlatform`] for this target, if any.
+    ///
+    /// A qsystem platform is only relevant when a native target is selected;
+    /// the platform-agnostic [`PlatformTarget::Tket`] returns `None`.
+    pub fn qsystem_platform(self) -> Option<QSystemPlatform> {
+        match self {
+            PlatformTarget::Tket => None,
+            PlatformTarget::Sol => Some(QSystemPlatform::Sol),
+            PlatformTarget::Helios => Some(QSystemPlatform::Helios),
+        }
+    }
+
+    /// Pytket encoder configuration for this target.
+    ///
+    /// Only the extensions supported by the target are registered, so that a
+    /// HUGR is not implicitly rebased into a different gate set when encoded.
+    pub fn encoder_config<H: HugrView>(self) -> PytketEncoderConfig<H> {
+        match self.qsystem_platform() {
+            None => default_encoder_config(),
+            Some(platform) => qsystem_encoder_config(platform),
+        }
+    }
+
+    /// Pytket decoder configuration for this target.
+    ///
+    /// Native targets decode into their platform-specific operations. The
+    /// platform-agnostic [`PlatformTarget::Tket`] decodes into base
+    /// `tket.quantum` operations, with the Helios decoders registered as a
+    /// fallback for pytket commands without a base counterpart (e.g. `ZZPhase`
+    /// or `PhasedX`).
+    pub fn decoder_config(self) -> PytketDecoderConfig {
+        match self.qsystem_platform() {
+            None => {
+                let mut config = default_decoder_config();
+                add_qsystem_decoders(&mut config, QSystemPlatform::Helios);
+                config
+            }
+            Some(platform) => qsystem_decoder_config(platform),
+        }
+    }
+}

--- a/tket/src/serialize/pytket.rs
+++ b/tket/src/serialize/pytket.rs
@@ -11,8 +11,8 @@ mod options;
 
 pub use circuit::EncodedCircuit;
 pub use config::{
-    PytketDecoderConfig, PytketEncoderConfig, TypeTranslatorSet, default_decoder_config,
-    default_encoder_config,
+    PytketDecoderConfig, PytketEncoderConfig, TypeTranslatorSet, add_default_decoders,
+    default_decoder_config, default_encoder_config,
 };
 pub use encoder::PytketEncoderContext;
 pub use error::{

--- a/tket/src/serialize/pytket/config.rs
+++ b/tket/src/serialize/pytket/config.rs
@@ -20,6 +20,20 @@ use hugr::HugrView;
 /// primitives into HUGR operations.
 pub fn default_decoder_config() -> PytketDecoderConfig {
     let mut config = PytketDecoderConfig::new();
+    add_default_decoders(&mut config);
+    config
+}
+
+/// Add the default HUGR decoders and type translators to an existing config.
+///
+/// This registers the base `tket` decoders ([`CoreDecoder`], [`PreludeEmitter`],
+/// and [`TketOpEmitter`]) together with the default type translators.
+///
+/// Decoders are tried in registration order, so this is useful when building
+/// custom decoder configs that register additional decoders *before* the base
+/// ones to give them higher priority, while still keeping the base decoders as
+/// a fallback.
+pub fn add_default_decoders(config: &mut PytketDecoderConfig) {
     config.add_decoder(CoreDecoder);
     config.add_decoder(PreludeEmitter);
     config.add_decoder(TketOpEmitter);
@@ -27,8 +41,6 @@ pub fn default_decoder_config() -> PytketDecoderConfig {
     config.add_type_translator(PreludeEmitter);
     config.add_type_translator(FloatEmitter);
     config.add_type_translator(RotationEmitter);
-
-    config
 }
 
 /// Default encoder configuration for Hugrs.


### PR DESCRIPTION
Closes #1619

Adds a `target` option to `PytketHugrPass` and to `CompilationState.from_tket1` so calling a pass doesn't unexpectedly rebase quantum operations between `tket.quantum` and the native `qsystem` ones.