### PR TITLE
refactor!: remove `ModifierFlags` logic from modifier and `dfg_modify` modules

### DIFF
--- a/tket/src/modifier.rs
+++ b/tket/src/modifier.rs
@@ -9,18 +9,13 @@
 //! Global phase is an operation that applies some global phase to a circuit.
 //! It is implemented as a side-effect that takes a rotation angle as an input.
 
-use hugr::{
-    HugrView, core::HugrNode, extension::simple_op::MakeExtensionOp, hugr::hugrmut::HugrMut,
-    ops::ExtensionOp,
-};
+use hugr::{extension::simple_op::MakeExtensionOp, ops::ExtensionOp};
 
 use crate::extension::modifier::Modifier;
 pub mod control;
 pub mod dagger;
 pub mod modifier_resolver;
 pub mod power;
-
-use crate::metadata;
 
 /// An accumulated modifier that combines control, dagger, and power modifiers.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
@@ -56,50 +51,5 @@ impl CombinedModifier {
             Err(_) => {}
         }
         Ok(())
-    }
-}
-
-/// Flags for each modifier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct ModifierFlags {
-    control: bool,
-    dagger: bool,
-}
-
-impl ModifierFlags {
-    fn from_metadata<N: HugrNode>(h: &impl HugrView<Node = N>, n: N) -> Option<Self> {
-        h.get_metadata::<metadata::UnitaryFlags>(n)
-            .map(|num| ModifierFlags {
-                control: (num & 1) != 0,
-                dagger: (num & 2) != 0,
-            })
-    }
-
-    fn set_metadata<N: HugrNode>(&self, h: &mut impl HugrMut<Node = N>, n: N) {
-        let mut num = 0;
-        if self.dagger {
-            num |= 1;
-        }
-        if self.control {
-            num |= 2;
-        }
-        h.set_metadata::<metadata::UnitaryFlags>(n, num);
-    }
-
-    fn from_combined(combined: &CombinedModifier) -> Self {
-        ModifierFlags {
-            control: combined.control > 0,
-            dagger: combined.dagger,
-        }
-    }
-
-    fn or(self, other: &Option<Self>) -> Self {
-        match other {
-            None => self,
-            Some(other) => ModifierFlags {
-                control: self.control || other.control,
-                dagger: self.dagger || other.dagger,
-            },
-        }
     }
 }

--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -116,7 +116,7 @@ pub mod dfg_modify;
 pub mod global_phase_modify;
 pub mod tket_op_modify;
 
-use super::{CombinedModifier, ModifierFlags};
+use super::CombinedModifier;
 use crate::passes::utils::unpack_container::TypeUnpacker;
 use crate::passes::{InScope, PassScope};
 use crate::{TketOp, extension::global_phase::GlobalPhase, modifier::Modifier};

--- a/tket/src/modifier/modifier_resolver/dfg_modify.rs
+++ b/tket/src/modifier/modifier_resolver/dfg_modify.rs
@@ -22,7 +22,7 @@ use petgraph::visit::{Topo, Walker};
 
 use crate::{TketOp, extension::global_phase::GlobalPhase};
 
-use super::{DirWire, ModifierFlags, ModifierResolver, ModifierResolverErrors, PortExt};
+use super::{DirWire, ModifierResolver, ModifierResolverErrors, PortExt};
 
 impl<N: HugrNode> ModifierResolver<N> {
     /// Modifies the body of a dataflow graph.
@@ -408,18 +408,6 @@ impl<N: HugrNode> ModifierResolver<N> {
             self.function_input_modifiers
                 .insert(new_function_node, input_modifiers);
         }
-        // Set unitarity metadata
-        // TODO: ModifierFlags indicate whether a function satisfies the controllable or daggerable
-        // constraints after Guppy type checking.
-        //
-        // These flags previously determined whether modifier resolution should modify a function.
-        // This is no longer the case; see [`Self::modify_fn_if_needed`]. They may therefore be removed
-        // in the future.
-        //
-        // See: https://github.com/Quantinuum/tket2/issues/1790
-        ModifierFlags::from_combined(self.modifiers())
-            .or(&ModifierFlags::from_metadata(h, func))
-            .set_metadata(h, new_function_node);
         self.modified_functions.insert(func);
 
         Ok(new_function_node)

--- a/tket/src/modifier/modifier_resolver/tket_op_modify.rs
+++ b/tket/src/modifier/modifier_resolver/tket_op_modify.rs
@@ -571,17 +571,14 @@ mod test {
     };
     use strum::IntoEnumIterator;
 
+    use crate::extension::{
+        modifier::{CONTROL_OP_ID, DAGGER_OP_ID, MODIFIER_EXTENSION},
+        rotation::rotation_type,
+    };
     use crate::{
         extension::rotation::ConstRotation,
         modifier::modifier_resolver::tests::{SetUnitary, test_modifier_resolver},
         modifier::modifier_resolver::*,
-    };
-    use crate::{
-        extension::{
-            modifier::{CONTROL_OP_ID, DAGGER_OP_ID, MODIFIER_EXTENSION},
-            rotation::rotation_type,
-        },
-        modifier::*,
     };
 
     fn size(op: TketOp) -> Option<(usize, bool)> {


### PR DESCRIPTION
After https://github.com/Quantinuum/tket2/pull/1784 Unitary flag metadata are no more used by the pass

BREAKING CHANGE: remove the public structure `ModifierFlags` from `tket/src/modifier.rs`