### PR TITLE
chore: Fix lint warnings in rust 1.97

### DIFF
--- a/tket-qsystem/src/llvm/debug.rs
+++ b/tket-qsystem/src/llvm/debug.rs
@@ -80,7 +80,7 @@ impl<AL: ArrayLowering> DebugCodegenExtension<AL> {
         let [qubits] = args
             .inputs
             .try_into()
-            .map_err(|_| anyhow!(format!("StateResult expects a qubit array argument")))?;
+            .map_err(|_| anyhow!("StateResult expects a qubit array argument".to_string()))?;
         let qubits_array = self.array_lowering.array_to_ptr(
             builder,
             qubits,

--- a/tket-qsystem/src/pytket/tests.rs
+++ b/tket-qsystem/src/pytket/tests.rs
@@ -324,12 +324,12 @@ fn circuit_standalone_roundtrip(#[case] hugr: Hugr) {
     assert_eq!(
         &circ_signature.input, &deser_sig.input,
         "Input signature mismatch\n  Expected: {}\n  Actual:   {}",
-        &circ_signature, &deser_sig
+        circ_signature, deser_sig
     );
     assert_eq!(
         &circ_signature.output, &deser_sig.output,
         "Output signature mismatch\n  Expected: {}\n  Actual:   {}",
-        &circ_signature, &deser_sig
+        circ_signature, deser_sig
     );
 
     let reser = SerialCircuit::encode(
@@ -376,12 +376,12 @@ fn encoded_circuit_roundtrip(#[case] hugr: Hugr, #[case] num_circuits: usize) {
     assert_eq!(
         &circ_signature.input, &deser_sig.input,
         "Input signature mismatch\n  Expected: {}\n  Actual:   {}",
-        &circ_signature, &deser_sig
+        circ_signature, deser_sig
     );
     assert_eq!(
         &circ_signature.output, &deser_sig.output,
         "Output signature mismatch\n  Expected: {}\n  Actual:   {}",
-        &circ_signature, &deser_sig
+        circ_signature, deser_sig
     );
 }
 

--- a/tket/src/portmatching/matcher.rs
+++ b/tket/src/portmatching/matcher.rs
@@ -466,7 +466,7 @@ pub(super) fn validate_circuit_edge(
 /// Returns a predicate checking that `node` satisfies `prop` in `circ`.
 pub(crate) fn validate_circuit_node(
     circ: &Circuit<impl HugrView<Node = Node>>,
-) -> impl for<'a> Fn(NodeID, &PNode) -> bool + '_ {
+) -> impl Fn(NodeID, &PNode) -> bool + '_ {
     move |node, prop| {
         let NodeID::HugrNode(node) = node else {
             return false;

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -1186,12 +1186,12 @@ fn circuit_standalone_roundtrip(#[case] hugr: Hugr, #[case] config: CircuitRound
     assert_eq!(
         &circ_signature.input, &deser_sig.input,
         "Input signature mismatch\n  Expected: {}\n  Actual:   {}",
-        &circ_signature, &deser_sig
+        circ_signature, deser_sig
     );
     assert_eq!(
         &circ_signature.output, &deser_sig.output,
         "Output signature mismatch\n  Expected: {}\n  Actual:   {}",
-        &circ_signature, &deser_sig
+        circ_signature, deser_sig
     );
 
     let reser = SerialCircuit::encode(&deser, encode_options).unwrap();
@@ -1306,12 +1306,12 @@ fn encoded_circuit_roundtrip(
     assert_eq!(
         &circ_signature.input, &deser_sig.input,
         "Input signature mismatch\n  Expected: {}\n  Actual:   {}",
-        &circ_signature, &deser_sig
+        circ_signature, deser_sig
     );
     assert_eq!(
         &circ_signature.output, &deser_sig.output,
         "Output signature mismatch\n  Expected: {}\n  Actual:   {}",
-        &circ_signature, &deser_sig
+        circ_signature, deser_sig
     );
 }
 


### PR DESCRIPTION
Rust 1.97 is coming out today.

This PR fixes some new lints before they cause problems in our CI.