### PR TITLE
feat: Decode global phases from pytket circuits

### DIFF
--- a/tket-py/src/metadata.rs
+++ b/tket-py/src/metadata.rs
@@ -2,9 +2,11 @@
 
 use hugr::metadata::Metadata;
 use pyo3::prelude::*;
+#[expect(deprecated)]
+use tket::metadata::PytketPhaseExpr;
 use tket::metadata::{
     CircuitRewriteTraces, ExpectedQubitsHint, InlineAnnotation, PytketBitRegisterNames,
-    PytketInputParameters, PytketOpGroup, PytketPhaseExpr, PytketQubitRegisterNames, UnitaryFlags,
+    PytketInputParameters, PytketOpGroup, PytketQubitRegisterNames, UnitaryFlags,
 };
 
 /// The module definition.
@@ -20,6 +22,7 @@ pub fn module(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
     m.add("PYTKET_OP_GROUP", PytketOpGroup::KEY)?;
     m.add("PYTKET_BIT_REGISTER_NAMES", PytketBitRegisterNames::KEY)?;
     m.add("PYTKET_QUBIT_REGISTER_NAMES", PytketQubitRegisterNames::KEY)?;
+    #[expect(deprecated)]
     m.add("PYTKET_PHASE_EXPR", PytketPhaseExpr::KEY)?;
     Ok(m)
 }

--- a/tket-py/tket/metadata.py
+++ b/tket-py/tket/metadata.py
@@ -5,7 +5,6 @@ Examples:
     >>> from tket.metadata import (
     ...     MaxQubitsHint,
     ...     PytketInputParameters,
-    ...     PytketPhaseExpr,
     ...     PytketQubitRegisterNames,
     ... )
     >>>
@@ -15,7 +14,6 @@ Examples:
     >>> node.metadata[MaxQubitsHint] = 3
     >>> node.metadata[PytketInputParameters] = ["theta", "phi"]
     >>> node.metadata[PytketQubitRegisterNames] = [("q", [0]), ("ancilla", [1])]
-    >>> node.metadata[PytketPhaseExpr] = "1/2"
     >>> node.metadata[MaxQubitsHint]
     3
     >>> node.metadata.get(PytketQubitRegisterNames)
@@ -26,6 +24,7 @@ Examples:
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, TypeAlias, TypedDict
+from typing_extensions import deprecated
 
 from hugr.metadata import Metadata
 
@@ -158,8 +157,13 @@ class PytketQubitRegisterNames(Metadata[list[PytketQubit]]):
         return _read_pytket_register(cls.KEY, value)
 
 
+@deprecated("Call `used_extensions` on the hugr instead.")
 class PytketPhaseExpr(Metadata[str]):
-    """Metadata key for the serialized pytket global phase expression."""
+    """Metadata key for the serialized pytket global phase expression.
+
+    Deprecated:
+        Use explicit ``tket.global_phase`` operations instead.
+    """
 
     KEY = _metadata.PYTKET_PHASE_EXPR
 

--- a/tket/src/metadata.rs
+++ b/tket/src/metadata.rs
@@ -116,9 +116,18 @@ impl Metadata for PytketQubitRegisterNames {
     type Type<'hugr> = Vec<Qubit>;
 }
 
-/// Metadata key for the global phase
+/// Metadata key for the serialized pytket global phase expression.
+///
+/// Deprecated: global phases are now represented as explicit
+/// `tket.global_phase` operations. This definition is left for
+/// compatibility with older Hugrs.
+#[deprecated(
+    since = "0.21.1",
+    note = "use explicit tket.global_phase operations instead"
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PytketPhaseExpr;
+#[expect(deprecated, reason = "the impl is retained for legacy HUGR metadata")]
 impl Metadata for PytketPhaseExpr {
     const KEY: &'static str = "TKET1.phase";
     type Type<'hugr> = &'hugr str;

--- a/tket/src/serialize/pytket/config.rs
+++ b/tket/src/serialize/pytket/config.rs
@@ -9,8 +9,8 @@ pub use encoder_config::PytketEncoderConfig;
 pub use type_translators::TypeTranslatorSet;
 
 use crate::serialize::pytket::extension::{
-    CoreDecoder, FloatEmitter, MeasurementEmitter, PreludeEmitter, RotationEmitter, Tk1Emitter,
-    TketOpEmitter,
+    CoreDecoder, FloatEmitter, GlobalPhaseDecoder, MeasurementEmitter, PreludeEmitter,
+    RotationEmitter, Tk1Emitter, TketOpEmitter,
 };
 use hugr::HugrView;
 
@@ -27,7 +27,8 @@ pub fn default_decoder_config() -> PytketDecoderConfig {
 /// Add the default HUGR decoders and type translators to an existing config.
 ///
 /// This registers the base `tket` decoders ([`CoreDecoder`], [`PreludeEmitter`],
-/// and [`TketOpEmitter`]) together with the default type translators.
+/// [`GlobalPhaseDecoder`], and [`TketOpEmitter`]) together with the default
+/// type translators.
 ///
 /// Decoders are tried in registration order, so this is useful when building
 /// custom decoder configs that register additional decoders *before* the base
@@ -36,6 +37,7 @@ pub fn default_decoder_config() -> PytketDecoderConfig {
 pub fn add_default_decoders(config: &mut PytketDecoderConfig) {
     config.add_decoder(CoreDecoder);
     config.add_decoder(PreludeEmitter);
+    config.add_decoder(GlobalPhaseDecoder);
     config.add_decoder(TketOpEmitter);
 
     config.add_type_translator(PreludeEmitter);

--- a/tket/src/serialize/pytket/config.rs
+++ b/tket/src/serialize/pytket/config.rs
@@ -9,7 +9,7 @@ pub use encoder_config::PytketEncoderConfig;
 pub use type_translators::TypeTranslatorSet;
 
 use crate::serialize::pytket::extension::{
-    CoreDecoder, FloatEmitter, GlobalPhaseDecoder, MeasurementEmitter, PreludeEmitter,
+    CoreDecoder, FloatEmitter, GlobalPhaseEmitter, MeasurementEmitter, PreludeEmitter,
     RotationEmitter, Tk1Emitter, TketOpEmitter,
 };
 use hugr::HugrView;
@@ -37,7 +37,7 @@ pub fn default_decoder_config() -> PytketDecoderConfig {
 pub fn add_default_decoders(config: &mut PytketDecoderConfig) {
     config.add_decoder(CoreDecoder);
     config.add_decoder(PreludeEmitter);
-    config.add_decoder(GlobalPhaseDecoder);
+    config.add_decoder(GlobalPhaseEmitter);
     config.add_decoder(TketOpEmitter);
 
     config.add_type_translator(PreludeEmitter);
@@ -54,6 +54,7 @@ pub fn default_encoder_config<H: HugrView>() -> PytketEncoderConfig<H> {
     config.add_emitter(FloatEmitter);
     config.add_emitter(MeasurementEmitter);
     config.add_emitter(RotationEmitter);
+    config.add_emitter(GlobalPhaseEmitter);
     config.add_emitter(Tk1Emitter);
     config.add_emitter(TketOpEmitter);
 

--- a/tket/src/serialize/pytket/config.rs
+++ b/tket/src/serialize/pytket/config.rs
@@ -27,7 +27,7 @@ pub fn default_decoder_config() -> PytketDecoderConfig {
 /// Add the default HUGR decoders and type translators to an existing config.
 ///
 /// This registers the base `tket` decoders ([`CoreDecoder`], [`PreludeEmitter`],
-/// [`GlobalPhaseDecoder`], and [`TketOpEmitter`]) together with the default
+/// [`GlobalPhaseEmitter`], and [`TketOpEmitter`]) together with the default
 /// type translators.
 ///
 /// Decoders are tried in registration order, so this is useful when building

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -13,6 +13,7 @@ pub use param::{LoadedParameter, ParameterType};
 pub use tracked_elem::{TrackedBit, TrackedQubit};
 pub use wires::TrackedWires;
 
+pub(super) use param::parser::PytketParam;
 pub(super) use wires::FoundWire;
 
 use std::sync::Arc;
@@ -38,7 +39,6 @@ use crate::serialize::pytket::circuit::{
     AdditionalNodesAndWires, EncodedCircuitInfo, StraightThroughWire,
 };
 use crate::serialize::pytket::config::PytketDecoderConfig;
-use crate::serialize::pytket::decoder::param::parser::PytketParam;
 use crate::serialize::pytket::decoder::wires::WireTracker;
 use crate::serialize::pytket::extension::{RegisterCount, build_opaque_tket_op};
 use crate::serialize::pytket::opaque::{EncodedEdgeID, OpaqueSubgraphs};

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -31,12 +31,14 @@ use tket_json_rs::circuit_json::SerialCircuit;
 
 use super::PytketDecodeError;
 use crate::TketOp;
+use crate::extension::global_phase::GlobalPhase;
 use crate::extension::rotation::rotation_type;
 use crate::metadata;
 use crate::serialize::pytket::circuit::{
     AdditionalNodesAndWires, EncodedCircuitInfo, StraightThroughWire,
 };
 use crate::serialize::pytket::config::PytketDecoderConfig;
+use crate::serialize::pytket::decoder::param::parser::PytketParam;
 use crate::serialize::pytket::decoder::wires::WireTracker;
 use crate::serialize::pytket::extension::{RegisterCount, build_opaque_tket_op};
 use crate::serialize::pytket::opaque::{EncodedEdgeID, OpaqueSubgraphs};
@@ -154,20 +156,20 @@ impl<'h> PytketDecoderContext<'h> {
             &config,
         )?;
 
-        if !serialcirc.phase.is_empty() {
-            // TODO - add a phase gate
-            // <https://github.com/quantinuum/tket2/issues/598>
-            // let phase = Param::new(serialcirc.phase);
-            // decoder.add_phase(phase);
-        }
-
-        Ok(PytketDecoderContext {
+        let mut decoder = PytketDecoderContext {
             builder: dfg,
             wire_tracker: Box::new(wire_tracker),
             config,
             extensions: options.extensions,
             opaque_subgraphs,
-        })
+        };
+
+        if !serialcirc.phase.is_empty() && !PytketParam::parse(&serialcirc.phase).is_zero() {
+            let phase = decoder.load_half_turns(&serialcirc.phase);
+            decoder.add_global_phase(phase)?;
+        }
+
+        Ok(decoder)
     }
 
     /// Store the serialised circuit information as HUGR metadata,
@@ -177,8 +179,6 @@ impl<'h> PytketDecoderContext<'h> {
         // should pass through the serialization roundtrip.
 
         let node = dfg.container_node();
-        dfg.hugr_mut()
-            .set_metadata::<metadata::PytketPhaseExpr>(node, &serialcirc.phase);
         dfg.hugr_mut()
             .set_metadata::<metadata::PytketQubitRegisterNames>(node, serialcirc.qubits.clone());
         dfg.hugr_mut()
@@ -976,6 +976,19 @@ impl<'h> PytketDecoderContext<'h> {
         self.wire_tracker
             .load_half_turns_parameter(&mut self.builder, param, Some(typ))
             .with_type(typ, &mut self.builder)
+    }
+
+    /// Add an explicit global phase operation for a pytket half-turns expression.
+    ///
+    /// Pytket may represent global phase either as the circuit-level `phase`
+    /// property or as a zero-qubit `Phase` command. Both forms are normalized
+    /// through this helper so later HUGR passes see the same explicit operation.
+    pub fn add_global_phase(
+        &mut self,
+        phase: LoadedParameter,
+    ) -> Result<BuildHandle<DataflowOpID>, PytketDecodeError> {
+        let phase = phase.as_rotation(&mut self.builder);
+        self.add_node_with_wires(GlobalPhase, &[], &[], &[], &[], &[phase])
     }
 
     /// Returns the configuration used by the decoder.

--- a/tket/src/serialize/pytket/decoder/param/parser.rs
+++ b/tket/src/serialize/pytket/decoder/param/parser.rs
@@ -18,8 +18,6 @@ use crate::serialize::pytket::decoder::ParameterType;
 ///
 /// The leafs of the AST are either a constant value, a variable name, or an
 /// unrecognized sympy expression.
-///
-/// Return type of [`parse_pytket_param`].
 #[derive(Debug, Display, Clone, PartialEq)]
 pub enum PytketParam<'a> {
     /// A constant value that can be loaded directly.
@@ -47,18 +45,25 @@ pub enum PytketParam<'a> {
     },
 }
 
-/// Parse a TKET1 operation parameter, and return an AST representing the expression.
-#[inline]
-pub fn parse_pytket_param(param: &str) -> PytketParam<'_> {
-    let Ok(mut parsed) = ParamParser::parse(Rule::parameter, param) else {
-        // The parameter could not be parsed, so we just return it as an opaque sympy expression.
-        return PytketParam::Sympy(param);
-    };
-    let parsed = parsed
-        .next()
-        .expect("The `parameter` rule can only be matched once.");
+impl<'a> PytketParam<'a> {
+    /// Parse a TKET1 operation parameter, and return an AST representing the expression.
+    #[inline]
+    pub fn parse(param: &'a str) -> Self {
+        let Ok(mut parsed) = ParamParser::parse(Rule::parameter, param) else {
+            // The parameter could not be parsed, so we just return it as an opaque sympy expression.
+            return PytketParam::Sympy(param);
+        };
+        let parsed = parsed
+            .next()
+            .expect("The `parameter` rule can only be matched once.");
 
-    parse_infix_ops(parsed.into_inner())
+        parse_infix_ops(parsed.into_inner())
+    }
+
+    /// Returns `true` if the parameter is zero.
+    pub fn is_zero(&self) -> bool {
+        matches!(self, PytketParam::Constant(value) if *value == 0.0)
+    }
 }
 
 #[derive(Parser)]
@@ -284,7 +289,7 @@ mod test {
         param_ty: ParameterType::Rotation,
     })]
     fn parse_param(#[case] param: &str, #[case] expected: PytketParam) {
-        let parsed = parse_pytket_param(param);
+        let parsed = PytketParam::parse(param);
         if parsed != expected {
             panic!(
                 "Incorrect parameter parsing\n\texpression: \"{param}\"\n\tparsed: {parsed}\n\texpected: {expected}"

--- a/tket/src/serialize/pytket/decoder/param/parser.rs
+++ b/tket/src/serialize/pytket/decoder/param/parser.rs
@@ -2,6 +2,7 @@
 //!
 //! This is based on the `pest` grammar defined in `param.pest`.
 
+use cgmath::RelativeEq;
 use derive_more::Display;
 use hugr::ops::OpType;
 use hugr::std_extensions::arithmetic::float_ops::FloatOps;
@@ -18,7 +19,7 @@ use crate::serialize::pytket::decoder::ParameterType;
 ///
 /// The leafs of the AST are either a constant value, a variable name, or an
 /// unrecognized sympy expression.
-#[derive(Debug, Display, Clone, PartialEq)]
+#[derive(Debug, Display, Clone)]
 pub enum PytketParam<'a> {
     /// A constant value that can be loaded directly.
     #[display("{_0}")]
@@ -63,6 +64,45 @@ impl<'a> PytketParam<'a> {
     /// Returns `true` if the parameter is zero.
     pub fn is_zero(&self) -> bool {
         matches!(self, PytketParam::Constant(value) if *value == 0.0)
+    }
+}
+
+impl<'a> PartialEq for PytketParam<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Constant(l0), Self::Constant(r0)) => {
+                l0.relative_eq(r0, f64::EPSILON, f64::EPSILON)
+            }
+            (Self::InputVariable { name: l_name }, Self::InputVariable { name: r_name }) => {
+                l_name == r_name
+            }
+            (Self::Sympy(l0), Self::Sympy(r0)) => l0 == r0,
+            (
+                Self::Operation {
+                    op: l_op,
+                    args: l_args,
+                    param_ty: l_param_ty,
+                },
+                Self::Operation {
+                    op: r_op,
+                    args: r_args,
+                    param_ty: r_param_ty,
+                },
+            ) => l_op == r_op && l_args == r_args && l_param_ty == r_param_ty,
+            _ => false,
+        }
+    }
+}
+
+impl<'a> Eq for PytketParam<'a> {}
+
+impl<'a> std::hash::Hash for PytketParam<'a> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::InputVariable { name } => name.hash(state),
+            Self::Sympy(expr) => expr.hash(state),
+            _ => self.to_string().hash(state),
+        }
     }
 }
 

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -18,7 +18,7 @@ use tket_json_rs::circuit_json::ImplicitPermutation;
 use tket_json_rs::register::ElementId as PytketRegister;
 
 use crate::extension::rotation::{ConstRotation, rotation_type};
-use crate::serialize::pytket::decoder::param::parser::{PytketParam, parse_pytket_param};
+use crate::serialize::pytket::decoder::param::parser::PytketParam;
 use crate::serialize::pytket::decoder::{
     LoadedParameter, ParameterType, PytketDecoderContext, TrackedBit, TrackedBitId, TrackedQubit,
     TrackedQubitId,
@@ -1083,7 +1083,7 @@ impl WireTracker {
             &mut self.parameters,
             &mut self.parameter_vars,
             &mut self.unused_parameter_inputs,
-            parse_pytket_param(param),
+            PytketParam::parse(param),
             param,
             type_hint,
         )

--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -171,7 +171,7 @@ impl<H: HugrView> PytketEncoderContext<H> {
         .cloned();
 
         // Backwards compatibility only: The global phase parameter
-        // of pytket circuits is now encoded as  explicit `tket.global_phase` operations instead.
+        // of pytket circuits is now encoded as explicit `tket.global_phase` operations instead.
         #[expect(deprecated)]
         let phase = match hugr.get_metadata::<metadata::PytketPhaseExpr>(region) {
             Some(p) => p.to_string(),

--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -170,7 +170,9 @@ impl<H: HugrView> PytketEncoderContext<H> {
         .filter(|name| !name.is_empty())
         .cloned();
 
-        // Recover other parameters stored in the metadata
+        // Backwards compatibility only: The global phase parameter
+        // of pytket circuits is now encoded as  explicit `tket.global_phase` operations instead.
+        #[expect(deprecated)]
         let phase = match hugr.get_metadata::<metadata::PytketPhaseExpr>(region) {
             Some(p) => p.to_string(),
             None => "0".to_string(),

--- a/tket/src/serialize/pytket/extension.rs
+++ b/tket/src/serialize/pytket/extension.rs
@@ -24,7 +24,7 @@ mod tket;
 
 pub use core::CoreDecoder;
 pub use float::FloatEmitter;
-pub use global_phase::GlobalPhaseDecoder;
+pub use global_phase::GlobalPhaseEmitter;
 pub use measurement::MeasurementEmitter;
 pub use prelude::PreludeEmitter;
 pub use rotation::RotationEmitter;

--- a/tket/src/serialize/pytket/extension.rs
+++ b/tket/src/serialize/pytket/extension.rs
@@ -15,6 +15,7 @@
 
 mod core;
 mod float;
+mod global_phase;
 mod measurement;
 mod prelude;
 mod rotation;
@@ -23,6 +24,7 @@ mod tket;
 
 pub use core::CoreDecoder;
 pub use float::FloatEmitter;
+pub use global_phase::GlobalPhaseDecoder;
 pub use measurement::MeasurementEmitter;
 pub use prelude::PreludeEmitter;
 pub use rotation::RotationEmitter;

--- a/tket/src/serialize/pytket/extension/global_phase.rs
+++ b/tket/src/serialize/pytket/extension/global_phase.rs
@@ -1,18 +1,24 @@
-//! Decoder for pytket global phase operations.
+//! Encoder and decoder for pytket global phase operations.
 
-use super::PytketDecoder;
+use super::{PytketDecoder, PytketEmitter};
+use crate::extension::global_phase::{GLOBAL_PHASE_EXTENSION_ID, GlobalPhase};
 use crate::serialize::pytket::decoder::{
     DecodeStatus, LoadedParameter, PytketDecoderContext, TrackedBit, TrackedQubit,
 };
+use crate::serialize::pytket::encoder::{EmitCommandOptions, EncodeStatus, PytketEncoderContext};
 use crate::serialize::pytket::extension::RegisterCount;
-use crate::serialize::pytket::{PytketDecodeError, PytketDecodeErrorInner};
+use crate::serialize::pytket::{PytketDecodeError, PytketDecodeErrorInner, PytketEncodeError};
+use hugr::HugrView;
+use hugr::extension::ExtensionId;
+use hugr::extension::simple_op::MakeExtensionOp;
+use hugr::ops::ExtensionOp;
 use tket_json_rs::optype::OpType as PytketOptype;
 
 /// Decoder for pytket global phase operations.
 #[derive(Debug, Clone, Default)]
-pub struct GlobalPhaseDecoder;
+pub struct GlobalPhaseEmitter;
 
-impl PytketDecoder for GlobalPhaseDecoder {
+impl PytketDecoder for GlobalPhaseEmitter {
     fn op_types(&self) -> Vec<PytketOptype> {
         vec![PytketOptype::Phase]
     }
@@ -38,5 +44,26 @@ impl PytketDecoder for GlobalPhaseDecoder {
 
         decoder.add_global_phase(params[0])?;
         Ok(DecodeStatus::Success)
+    }
+}
+
+impl<H: HugrView> PytketEmitter<H> for GlobalPhaseEmitter {
+    fn extensions(&self) -> Option<Vec<ExtensionId>> {
+        Some(vec![GLOBAL_PHASE_EXTENSION_ID])
+    }
+
+    fn op_to_pytket(
+        &self,
+        node: H::Node,
+        op: &ExtensionOp,
+        hugr: &H,
+        encoder: &mut PytketEncoderContext<H>,
+    ) -> Result<EncodeStatus, PytketEncodeError<H::Node>> {
+        let Ok(GlobalPhase) = GlobalPhase::from_extension_op(op) else {
+            return Ok(EncodeStatus::Unsupported);
+        };
+
+        encoder.emit_node(PytketOptype::Phase, node, hugr, EmitCommandOptions::new())?;
+        Ok(EncodeStatus::Success)
     }
 }

--- a/tket/src/serialize/pytket/extension/global_phase.rs
+++ b/tket/src/serialize/pytket/extension/global_phase.rs
@@ -1,0 +1,42 @@
+//! Decoder for pytket global phase operations.
+
+use super::PytketDecoder;
+use crate::serialize::pytket::decoder::{
+    DecodeStatus, LoadedParameter, PytketDecoderContext, TrackedBit, TrackedQubit,
+};
+use crate::serialize::pytket::extension::RegisterCount;
+use crate::serialize::pytket::{PytketDecodeError, PytketDecodeErrorInner};
+use tket_json_rs::optype::OpType as PytketOptype;
+
+/// Decoder for pytket global phase operations.
+#[derive(Debug, Clone, Default)]
+pub struct GlobalPhaseDecoder;
+
+impl PytketDecoder for GlobalPhaseDecoder {
+    fn op_types(&self) -> Vec<PytketOptype> {
+        vec![PytketOptype::Phase]
+    }
+
+    fn op_to_hugr<'h>(
+        &self,
+        _op: &tket_json_rs::circuit_json::Operation,
+        qubits: &[TrackedQubit],
+        bits: &[TrackedBit],
+        params: &[LoadedParameter],
+        _opgroup: Option<&str>,
+        decoder: &mut PytketDecoderContext<'h>,
+    ) -> Result<DecodeStatus, PytketDecodeError> {
+        let count = RegisterCount::new(qubits.len(), bits.len(), params.len());
+        if count != RegisterCount::only_params(1) {
+            return Err(PytketDecodeErrorInner::NotEnoughInputRegisters {
+                expected_types: vec!["rotation".to_string()],
+                expected_count: RegisterCount::only_params(1),
+                actual_count: count,
+            }
+            .wrap());
+        }
+
+        decoder.add_global_phase(params[0])?;
+        Ok(DecodeStatus::Success)
+    }
+}

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -1140,10 +1140,9 @@ fn decode_global_phase_attribute_and_command() {
         .collect_vec();
 
     assert_eq!(global_phase_nodes.len(), 2);
-    assert_eq!(
-        hugr.get_metadata::<metadata::PytketPhaseExpr>(hugr.entrypoint()),
-        None
-    );
+    #[expect(deprecated)]
+    let phase_metadata = hugr.get_metadata::<metadata::PytketPhaseExpr>(hugr.entrypoint());
+    assert_eq!(phase_metadata, None);
 
     let reser: SerialCircuit = SerialCircuit::encode(&hugr, EncodeOptions::new()).unwrap();
     assert_eq!(reser.phase, "0");

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -9,6 +9,7 @@ use hugr::builder::{
     ModuleBuilder, SubContainer,
 };
 use hugr::extension::prelude::{ConstExternalSymbol, UnwrapBuilder, bool_t, option_type, qb_t};
+use hugr::extension::simple_op::MakeExtensionOp;
 use hugr::std_extensions::arithmetic::float_types::{ConstF64, float64_type};
 use hugr::std_extensions::logic::LogicOp;
 use std::sync::Arc;
@@ -16,6 +17,7 @@ use std::sync::Arc;
 use super::TKETDecode;
 use crate::TketOp;
 use crate::extension::TKET1_EXTENSION_ID;
+use crate::extension::global_phase::GlobalPhase;
 use crate::extension::measurement::MeasurementOp;
 use crate::extension::rotation::{ConstRotation, RotationOp, rotation_type};
 use crate::extension::sympy::SympyOpDef;
@@ -202,9 +204,12 @@ fn validate_serial_circ(circ: &SerialCircuit) {
 )]
 fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
     assert_eq!(a.name, b.name);
-    assert_eq!(a.phase, b.phase);
     assert_eq!(&a.qubits, &b.qubits);
     assert_eq!(a.commands.len(), b.commands.len());
+
+    // pytket phase parameters do not roundtrip exactly.
+    // Phases are decoded as Hugr ops, but the encoder does not re-encoded them into the pytket circuit.
+    // TODO: Update this comment if a GlobalPhase encoder is added.
 
     // Allow additional bit ids after a roundtrip, as the encoder may freely
     // allocate new IDs instead of reusing old ones.
@@ -1086,6 +1091,38 @@ fn decode_tuple_output_from_permuted_barrier_args() {
         .unwrap();
 
     hugr.validate().unwrap();
+}
+
+#[test]
+fn decode_global_phase_attribute_and_command() {
+    // A circuit with both a phase parameter and a phase op.
+    // The decoded Hugr should contain two phase nodes.
+    let ser: circuit_json::SerialCircuit = serde_json::from_str(
+        r#"{
+        "phase": "1/2",
+        "bits": [],
+        "qubits": [],
+        "commands": [
+            {"args": [], "op": {"type": "Phase", "params": ["alpha"]}}
+        ],
+        "implicit_permutation": []
+    }"#,
+    )
+    .unwrap();
+
+    let hugr = ser.decode(DecodeOptions::new()).unwrap();
+    hugr.validate().unwrap();
+
+    let global_phase_nodes = hugr
+        .nodes()
+        .filter(|node| GlobalPhase::from_optype(hugr.get_optype(*node)).is_some())
+        .collect_vec();
+
+    assert_eq!(global_phase_nodes.len(), 2);
+    assert_eq!(
+        hugr.get_metadata::<metadata::PytketPhaseExpr>(hugr.entrypoint()),
+        None
+    );
 }
 
 /// Test parameter to select which decoders/encoders to enable.

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -1,6 +1,7 @@
 //! General tests.
 
 use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::io::BufReader;
 
 use cool_asserts::assert_matches;
@@ -23,6 +24,7 @@ use crate::extension::rotation::{ConstRotation, RotationOp, rotation_type};
 use crate::extension::sympy::SympyOpDef;
 use crate::metadata;
 use crate::serialize::pytket::PytketEncodeError;
+use crate::serialize::pytket::decoder::PytketParam;
 use crate::serialize::pytket::extension::{CoreDecoder, OpaqueTk1Op, PreludeEmitter};
 use crate::serialize::pytket::{
     DecodeInsertionTarget, DecodeOptions, EncodeOptions, EncodedCircuit, PytketDecodeError,
@@ -205,11 +207,6 @@ fn validate_serial_circ(circ: &SerialCircuit) {
 fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
     assert_eq!(a.name, b.name);
     assert_eq!(&a.qubits, &b.qubits);
-    assert_eq!(a.commands.len(), b.commands.len());
-
-    // pytket phase parameters do not roundtrip exactly.
-    // Phases are decoded as Hugr ops, but the encoder does not re-encoded them into the pytket circuit.
-    // TODO: Update this comment if a GlobalPhase encoder is added.
 
     // Allow additional bit ids after a roundtrip, as the encoder may freely
     // allocate new IDs instead of reusing old ones.
@@ -239,24 +236,34 @@ fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
     // TODO: Do a proper comparison independent of the toposort ordering, and
     // track register reordering.
     #[derive(PartialEq, Eq, Hash, Debug)]
-    struct CommandInfo {
+    struct CommandInfo<'p> {
         op_type: tket_json_rs::OpType,
-        params: Vec<String>,
+        params: Vec<PytketParam<'p>>,
         n_args: usize,
     }
 
-    impl From<&tket_json_rs::circuit_json::Command> for CommandInfo {
-        fn from(command: &tket_json_rs::circuit_json::Command) -> Self {
+    impl<'a> From<&'a tket_json_rs::circuit_json::Command> for CommandInfo<'a> {
+        fn from(command: &'a tket_json_rs::circuit_json::Command) -> Self {
+            let params = command
+                .op
+                .params
+                .iter()
+                .flatten()
+                .map(|p| PytketParam::parse(p))
+                .collect();
             CommandInfo {
                 op_type: command.op.op_type,
-                params: command.op.params.clone().unwrap_or_default(),
+                params,
                 n_args: command.args.len(),
             }
         }
     }
 
-    let a_command_count: HashMap<CommandInfo, usize> = a.commands.iter().map_into().counts();
-    let b_command_count: HashMap<CommandInfo, usize> = b.commands.iter().map_into().counts();
+    #[expect(clippy::mutable_key_type)]
+    let mut a_command_count: HashMap<CommandInfo<'_>, usize> =
+        a.commands.iter().map_into().counts();
+    #[expect(clippy::mutable_key_type)]
+    let b_command_count: HashMap<CommandInfo<'_>, usize> = b.commands.iter().map_into().counts();
     for (a, &count_a) in &a_command_count {
         let count_b = b_command_count.get(a).copied().unwrap_or_default();
         assert_eq!(
@@ -264,6 +271,19 @@ fn compare_serial_circs(a: &SerialCircuit, b: &SerialCircuit) {
             "command {a:?} appears {count_a} times in rhs and {count_b} times in lhs.\ncounts for a: {a_command_count:#?}\ncounts for b: {b_command_count:#?}"
         );
     }
+
+    // Phase parameters in the original circuit `a` get translated into a global phase operation after a roundtrip.
+    // So we add that virtual command to `a` here.
+    let a_phase = PytketParam::parse(&a.phase);
+    if !a_phase.is_zero() {
+        let global_phase_command = CommandInfo {
+            op_type: tket_json_rs::OpType::Phase,
+            params: vec![a_phase],
+            n_args: 0,
+        };
+        *a_command_count.entry(global_phase_command).or_default() += 1;
+    }
+
     assert_eq!(a_command_count.len(), b_command_count.len());
 }
 
@@ -1096,7 +1116,8 @@ fn decode_tuple_output_from_permuted_barrier_args() {
 #[test]
 fn decode_global_phase_attribute_and_command() {
     // A circuit with both a phase parameter and a phase op.
-    // The decoded Hugr should contain two phase nodes.
+    // The decoded Hugr should contain two phase nodes, and the re-encoded
+    // circuit should make both phases explicit as commands.
     let ser: circuit_json::SerialCircuit = serde_json::from_str(
         r#"{
         "phase": "1/2",
@@ -1122,6 +1143,27 @@ fn decode_global_phase_attribute_and_command() {
     assert_eq!(
         hugr.get_metadata::<metadata::PytketPhaseExpr>(hugr.entrypoint()),
         None
+    );
+
+    let reser: SerialCircuit = SerialCircuit::encode(&hugr, EncodeOptions::new()).unwrap();
+    assert_eq!(reser.phase, "0");
+
+    let phase_commands = reser
+        .commands
+        .iter()
+        .filter(|command| command.op.op_type == tket_json_rs::OpType::Phase)
+        .collect_vec();
+    assert_eq!(phase_commands.len(), 2);
+    assert!(phase_commands.iter().all(|command| command.args.is_empty()));
+
+    let phase_params = phase_commands
+        .iter()
+        .map(|command| command.op.params.clone().unwrap_or_default())
+        .collect_vec();
+    assert!(
+        phase_params
+            .iter()
+            .any(|params| params.len() == 1 && params[0] == "alpha")
     );
 }
 


### PR DESCRIPTION
Fixes https://github.com/Quantinuum/guppylang/issues/2001.

Now pytket circuit phase parameters and `Phase` commands are decoded as `tket.global_phase` ops.

Also added an encoder from `tket.global_phase` ops into pytket phase commands. This is not a clean roundtrip if the original circuit had a phase parameter, but it should be semantically equivalent.

The `PytketPhaseExpr` metadata is now deprecated, since we no longer encode the pytket phase there.
We still read its value when producing pytket circuits, for backwards compat with older hugrs.