### PR TITLE
refactor: Remove leftover todos in `ModifierResolverPass`

### DIFF
--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -1055,6 +1055,7 @@ impl<N: HugrNode> ModifierResolver<N> {
             // Some other Hugr extension operation.
             // Here, we do not know what is the modified version.
             // We try to place the original operation.
+            // TODO: Determine when we should raise an error
             // (see https://github.com/Quantinuum/tket2/issues/1828)
             self.modify_dataflow_op(h, op_node, optype, new_dfg)
         }
@@ -1350,6 +1351,11 @@ pub fn resolve_modifier_with_entrypoints_and_scope(
     // (e.g. intermediate nodes in a chain whose last modifier was the one rewritten).
     // Walk the same reachable set again and delete any surviving modifier nodes,
     // together with every downstream node that consumes their output.
+    //
+    // NOTE:
+    // This might be insufficient as a cleanup since the resolution procedure might
+    // generate nodes that are not reachable from the entry points.
+    // If more thorough cleanup is needed, we should run dead code elimination.
     let mut deletelist = entry_points.clone();
     let mut visited = FxHashSet::default();
     while let Some(node) = deletelist.pop_front() {

--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -637,7 +637,7 @@ impl<N: HugrNode> ModifierResolver<N> {
         node
     }
 
-    /// connects all the wires in the builder.
+    /// Connects all the wires in the builder.
     fn connect_all(
         &mut self,
         h: &impl HugrView<Node = N>,
@@ -647,7 +647,8 @@ impl<N: HugrNode> ModifierResolver<N> {
         for out_node in h.children(parent) {
             for out_port in h.node_outputs(out_node) {
                 if let Some(EdgeKind::StateOrder) = h.get_optype(out_node).port_kind(out_port) {
-                    // TODO: Currently, we just ignore StateOrder edges.
+                    // NICOLA TODO: Open an issue, discuss with Alan
+                    // Currently, we just ignore StateOrder edges.
                     // This might be OK when the dagger is applied since StateOrder is not managable then.
                     // However, if not, we should preserve the StateOrder edges.
                     // This could be done in two ways:
@@ -670,11 +671,7 @@ impl<N: HugrNode> ModifierResolver<N> {
 }
 
 impl<N: HugrNode> ModifierResolver<N> {
-    // FIXME: Shouldn't we check that there is a caller of the modified function?
-    // We don't want to modify a function that is loaded and modified but never called.
-    // When more than one modifier is chained, after the last modifier is resolved,
-    // we delete the last modifier node, but the previous modifiers are not deleted.
-    // If the second last modifier was only called by the last modifier, that will not be called anymore.
+    // NICOLA: I would like not to do deadcode elimination here
     fn verify(&self, h: &impl HugrView<Node = N>, n: N) -> Result<(), ModifierError<N>> {
         // Check if the node is a modifier, modifying an operation.
         let optype = h.get_optype(n);
@@ -870,7 +867,7 @@ impl<N: HugrNode> ModifierResolver<N> {
     /// - input: [out0:qubit, in1:int, out1:array[qubit, _], in4:int]
     /// - output: [in0:qubit, in2:qubit, in3:qubit]
     ///
-    /// FIXME: This reverses everything that can contain qubits, which might not be intended in general.
+    /// This reverses everything that can contain qubits.
     /// TODO: Handle state order edges.
     fn wire_node_inout<'a>(
         &mut self,

--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -647,7 +647,7 @@ impl<N: HugrNode> ModifierResolver<N> {
         for out_node in h.children(parent) {
             for out_port in h.node_outputs(out_node) {
                 if let Some(EdgeKind::StateOrder) = h.get_optype(out_node).port_kind(out_port) {
-                    // NICOLA TODO: Open an issue, discuss with Alan
+                    // TODO: see https://github.com/Quantinuum/tket2/issues/1836
                     // Currently, we just ignore StateOrder edges.
                     // This might be OK when the dagger is applied since StateOrder is not managable then.
                     // However, if not, we should preserve the StateOrder edges.
@@ -666,6 +666,7 @@ impl<N: HugrNode> ModifierResolver<N> {
             }
         }
         // FIXME: StateOrder is not preserved here.
+        // see: https://github.com/Quantinuum/tket2/issues/1836
         Ok(())
     }
 }

--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -35,8 +35,6 @@
 //! and a builder `new_dfg` to construct the new graph.
 //! The correspondence map (`corresp_map`) keeps the correspondence
 //! from wires in `h` to wires in `new_dfg`.
-//! The `call_map` keeps track of the calls to the modified function, so that we can connect
-//! the modified function to its callers after the resolution.
 //! See `modify_op`, which is the main function that modifies each node.
 //!
 //! During the resolution, when a node with some data flow included (such as a function) is encountered,

--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -1008,23 +1008,6 @@ impl<N: HugrNode> ModifierResolver<N> {
         self.map_insert(Wire::new(n, 0).into(), Wire::new(output, 0).into())
     }
 
-    /// Copy the dataflow operation to the new function.
-    /// These are the operations that are not modified by the modifier.
-    fn modify_dataflow_op(
-        &mut self,
-        h: &impl HugrMut<Node = N>,
-        n: N,
-        optype: &OpType,
-        new_dfg: &mut impl Container,
-    ) -> Result<(), ModifierResolverErrors<N>> {
-        let node = new_dfg.add_child_node(optype.clone());
-        let signature = h.signature(n).unwrap();
-        let inputs = signature.input.iter();
-        let outputs = signature.output.iter();
-        self.wire_node_inout(n, node, (inputs, outputs), (0, 0, 0))?;
-        Ok(())
-    }
-
     fn modify_extension_op(
         &mut self,
         h: &impl HugrMut<Node = N>,
@@ -1058,9 +1041,11 @@ impl<N: HugrNode> ModifierResolver<N> {
         } else {
             // Some other Hugr extension operation.
             // Here, we do not know what is the modified version.
-            // We try to place the original operation.
-            // TODO: raise an error
-            self.modify_dataflow_op(h, op_node, optype, new_dfg)
+            Err(ModifierResolverErrors::unresolvable(
+                op_node,
+                "unknown extension operation.",
+                optype.clone(),
+            ))
         }
     }
 
@@ -2183,6 +2168,101 @@ mod tests {
         assert_matches!(
             result,
             Err(ModifierResolverErrors::PowerModifierNotSupported { node: _ })
+        );
+    }
+
+    #[test]
+    /// Test that a function containing an unknown extension op returns an
+    /// [`ModifierResolverErrors::UnResolvable`] error.
+    fn unknown_extension_op_in_modified_function_returns_error() {
+        use hugr::extension::{ExtensionId, Version};
+        use hugr_core::Extension;
+        use std::sync::Arc;
+
+        // Build a minimal custom extension.
+        let unknown_ext: Arc<Extension> = Extension::new_arc(
+            ExtensionId::new_unchecked("test.unknown_modifier_ext"),
+            Version::new(0, 0, 1),
+            |ext, ext_ref| {
+                ext.add_op(
+                    "UnknownQubitOp".into(),
+                    String::new(),
+                    Signature::new_endo(vec![qb_t()]),
+                    ext_ref,
+                )
+                .unwrap();
+            },
+        );
+        let unknown_op = unknown_ext
+            .instantiate_extension_op("UnknownQubitOp", [])
+            .unwrap();
+
+        let mut module = ModuleBuilder::new();
+
+        let foo = {
+            let mut func = module
+                .define_function("foo", Signature::new_endo(vec![qb_t()]))
+                .unwrap();
+            let inputs: Vec<Wire> = func.input_wires().collect();
+            let qubit = func
+                .add_dataflow_op(unknown_op, inputs)
+                .unwrap()
+                .out_wire(0);
+            func.finish_with_outputs([qubit]).unwrap()
+        };
+
+        let ctrl_num = 1u64;
+        let controlled_sig = Signature::new_endo(vec![array_type(ctrl_num, qb_t()), qb_t()]);
+        let main_sig = Signature::new(type_row![], vec![array_type(ctrl_num, qb_t()), qb_t()]);
+        let control_op: ExtensionOp = MODIFIER_EXTENSION
+            .instantiate_extension_op(
+                &CONTROL_OP_ID,
+                [
+                    Term::BoundedNat(ctrl_num),
+                    vec![qb_t().into()].into(),
+                    vec![].into(),
+                ],
+            )
+            .unwrap();
+
+        {
+            let mut func = module.define_function("main", main_sig).unwrap();
+            let loaded = func.load_func(foo.handle(), &[]).unwrap();
+            let modified_fn = func
+                .add_dataflow_op(control_op, vec![loaded])
+                .unwrap()
+                .out_wire(0);
+            let control = func
+                .add_dataflow_op(TketOp::QAlloc, vec![])
+                .unwrap()
+                .out_wire(0);
+            let target = func
+                .add_dataflow_op(TketOp::QAlloc, vec![])
+                .unwrap()
+                .out_wire(0);
+            let control_arr = func.add_new_array(qb_t(), [control]).unwrap();
+            let outputs = func
+                .add_dataflow_op(
+                    CallIndirect {
+                        signature: controlled_sig,
+                    },
+                    [modified_fn, control_arr, target],
+                )
+                .unwrap()
+                .outputs();
+            func.finish_with_outputs(outputs).unwrap();
+        }
+
+        let mut h = module.finish_hugr().unwrap();
+        assert_matches!(h.validate(), Ok(()));
+
+        let entrypoint = h.entrypoint();
+        let result = resolve_modifier_with_entrypoints(&mut h, [entrypoint]);
+        assert_matches!(
+            result,
+            Err(ModifierResolverErrors::UnResolvable { node: _, msg, optype: _ }) => {
+                assert_eq!(msg, "unknown extension operation.");
+            }
         );
     }
 }

--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -1,7 +1,7 @@
 //! Try to delete modifier by applying the modifier to each component.
 //!
 //! The entry point of this module is [`resolve_modifier_with_entrypoints`]
-//! which takes a hugraph and a list of entry points.
+//! which takes a hugr and a list of entry points.
 //! Modifier resolver visits all the nodes reachable from the entry points.
 //!
 //! The main struct [`ModifierResolver`] holds the state during the process,
@@ -11,7 +11,7 @@
 //!
 //! A modifier is assumed to be applied to a loaded function
 //! and called directly exactly once by another modifier or
-//! an `IndirectedCall` node.
+//! an `IndirectCall` node.
 //! That is, the following structure is assumed:
 //! ```text
 //! LoadFunction -> Modifier* -> IndirectedCall
@@ -35,6 +35,8 @@
 //! and a builder `new_dfg` to construct the new graph.
 //! The correspondence map (`corresp_map`) keeps the correspondence
 //! from wires in `h` to wires in `new_dfg`.
+//! The `call_map` keeps track of the calls to the modified function, so that we can connect
+//! the modified function to its callers after the resolution.
 //! See `modify_op`, which is the main function that modifies each node.
 //!
 //! During the resolution, when a node with some data flow included (such as a function) is encountered,
@@ -91,18 +93,17 @@
 //!
 //! ## Not supported/TODO cases
 //! - Power: Power modifier is not supported at this point.
-//! - Non-trivial CFGs: We cannot support dagger for complicated CFGs
+//! - Dagger of non-trivial CFGs: We cannot support dagger for complicated CFGs
 //!   since it is not clear at all whether we should reverse the control flow or not.
 //!   Currently, when any non-trivial cfg with more than one block is encountered during
-//!   the resolution, an error is returned.
+//!   the resolution under a daggered context, an error is returned.
 //! - Branching in modifier chain: As noted above, we assume that a modifier is
 //!   chained linearly.
 //! - StateOrder edge: Currently, the modified function does not contain StateOrder edges
 //!   in any case.
 //!   This won't be manageable if dagger is applied, but if not, it should be handled in the future.
 //! - User defined extension ops: There is no way to infer modified unknown extension ops.
-//!   We currently try to insert the original optype without any modification,
-//!   but this could result in an unexpected error.
+//!   We currently raise an error if an unkown extension is found.
 use fxhash::FxHashSet;
 use itertools::{Either, Itertools};
 use std::{
@@ -133,7 +134,7 @@ use hugr::{
     types::{EdgeKind, FuncTypeBase, Signature, Type},
 };
 
-/// A wire of eigher direction.
+/// A wire of either direction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct DirWire<N = Node>(N, Port);
 
@@ -1058,8 +1059,7 @@ impl<N: HugrNode> ModifierResolver<N> {
             // Some other Hugr extension operation.
             // Here, we do not know what is the modified version.
             // We try to place the original operation.
-            // TODO: Revisit whether unknown extension operations should return
-            // an explicit error instead of falling back to the original operation.
+            // TODO: raise an error
             self.modify_dataflow_op(h, op_node, optype, new_dfg)
         }
     }

--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -1,7 +1,7 @@
 //! Try to delete modifier by applying the modifier to each component.
 //!
 //! The entry point of this module is [`resolve_modifier_with_entrypoints`]
-//! which takes a hugr and a list of entry points.
+//! which takes a hugraph and a list of entry points.
 //! Modifier resolver visits all the nodes reachable from the entry points.
 //!
 //! The main struct [`ModifierResolver`] holds the state during the process,
@@ -11,7 +11,7 @@
 //!
 //! A modifier is assumed to be applied to a loaded function
 //! and called directly exactly once by another modifier or
-//! an `IndirectCall` node.
+//! an `IndirectedCall` node.
 //! That is, the following structure is assumed:
 //! ```text
 //! LoadFunction -> Modifier* -> IndirectedCall
@@ -91,19 +91,20 @@
 //! We also should not forget to connect `fneg` to `Rx` in the new graph, whose edge/wires has
 //! no correspondence in the original graph.
 //!
-//! ## Not supported:
+//! ## Not supported/TODO cases
 //! - Power: Power modifier is not supported at this point.
-//! - Dagger of non-trivial CFGs: We cannot support dagger for complicated CFGs
+//! - Non-trivial CFGs: We cannot support dagger for complicated CFGs
 //!   since it is not clear at all whether we should reverse the control flow or not.
 //!   Currently, when any non-trivial cfg with more than one block is encountered during
-//!   the resolution under a daggered context, an error is returned.
+//!   the resolution, an error is returned.
 //! - Branching in modifier chain: As noted above, we assume that a modifier is
 //!   chained linearly.
 //! - StateOrder edge: Currently, the modified function does not contain StateOrder edges
 //!   in any case.
 //!   This won't be manageable if dagger is applied, but if not, it should be handled in the future.
 //! - User defined extension ops: There is no way to infer modified unknown extension ops.
-//!   We currently raise an error if an unknown extension is found.
+//!   We currently try to insert the original optype without any modification,
+//!   but this could result in an unexpected error.
 use fxhash::FxHashSet;
 use itertools::{Either, Itertools};
 use std::{
@@ -672,7 +673,6 @@ impl<N: HugrNode> ModifierResolver<N> {
 }
 
 impl<N: HugrNode> ModifierResolver<N> {
-    // NICOLA: I would like not to do deadcode elimination here
     fn verify(&self, h: &impl HugrView<Node = N>, n: N) -> Result<(), ModifierError<N>> {
         // Check if the node is a modifier, modifying an operation.
         let optype = h.get_optype(n);
@@ -869,7 +869,8 @@ impl<N: HugrNode> ModifierResolver<N> {
     /// - output: [in0:qubit, in2:qubit, in3:qubit]
     ///
     /// This reverses everything that can contain qubits.
-    /// TODO: Handle state order edges.
+    // TODO: Handle state order edges.
+    // (see https://github.com/Quantinuum/tket2/issues/1836)
     fn wire_node_inout<'a>(
         &mut self,
         old_node: N,
@@ -1006,6 +1007,23 @@ impl<N: HugrNode> ModifierResolver<N> {
         self.map_insert(Wire::new(n, 0).into(), Wire::new(output, 0).into())
     }
 
+    /// Copy the dataflow operation to the new function.
+    /// These are the operations that are not modified by the modifier.
+    fn modify_dataflow_op(
+        &mut self,
+        h: &impl HugrMut<Node = N>,
+        n: N,
+        optype: &OpType,
+        new_dfg: &mut impl Container,
+    ) -> Result<(), ModifierResolverErrors<N>> {
+        let node = new_dfg.add_child_node(optype.clone());
+        let signature = h.signature(n).unwrap();
+        let inputs = signature.input.iter();
+        let outputs = signature.output.iter();
+        self.wire_node_inout(n, node, (inputs, outputs), (0, 0, 0))?;
+        Ok(())
+    }
+
     fn modify_extension_op(
         &mut self,
         h: &impl HugrMut<Node = N>,
@@ -1038,11 +1056,9 @@ impl<N: HugrNode> ModifierResolver<N> {
         } else {
             // Some other Hugr extension operation.
             // Here, we do not know what is the modified version.
-            Err(ModifierResolverErrors::unresolvable(
-                op_node,
-                "unknown extension operation.",
-                optype.clone(),
-            ))
+            // We try to place the original operation.
+            // (see https://github.com/Quantinuum/tket2/issues/1828)
+            self.modify_dataflow_op(h, op_node, optype, new_dfg)
         }
     }
 
@@ -2142,101 +2158,6 @@ mod tests {
         assert_matches!(
             result,
             Err(ModifierResolverErrors::PowerModifierNotSupported { node: _ })
-        );
-    }
-
-    #[test]
-    /// Test that a function containing an unknown extension op returns an
-    /// [`ModifierResolverErrors::UnResolvable`] error.
-    fn unknown_extension_op_in_modified_function_returns_error() {
-        use hugr::extension::{ExtensionId, Version};
-        use hugr_core::Extension;
-        use std::sync::Arc;
-
-        // Build a minimal custom extension.
-        let unknown_ext: Arc<Extension> = Extension::new_arc(
-            ExtensionId::new_unchecked("test.unknown_modifier_ext"),
-            Version::new(0, 0, 1),
-            |ext, ext_ref| {
-                ext.add_op(
-                    "UnknownQubitOp".into(),
-                    String::new(),
-                    Signature::new_endo(vec![qb_t()]),
-                    ext_ref,
-                )
-                .unwrap();
-            },
-        );
-        let unknown_op = unknown_ext
-            .instantiate_extension_op("UnknownQubitOp", [])
-            .unwrap();
-
-        let mut module = ModuleBuilder::new();
-
-        let foo = {
-            let mut func = module
-                .define_function("foo", Signature::new_endo(vec![qb_t()]))
-                .unwrap();
-            let inputs: Vec<Wire> = func.input_wires().collect();
-            let qubit = func
-                .add_dataflow_op(unknown_op, inputs)
-                .unwrap()
-                .out_wire(0);
-            func.finish_with_outputs([qubit]).unwrap()
-        };
-
-        let ctrl_num = 1u64;
-        let controlled_sig = Signature::new_endo(vec![array_type(ctrl_num, qb_t()), qb_t()]);
-        let main_sig = Signature::new(type_row![], vec![array_type(ctrl_num, qb_t()), qb_t()]);
-        let control_op: ExtensionOp = MODIFIER_EXTENSION
-            .instantiate_extension_op(
-                &CONTROL_OP_ID,
-                [
-                    Term::BoundedNat(ctrl_num),
-                    vec![qb_t().into()].into(),
-                    vec![].into(),
-                ],
-            )
-            .unwrap();
-
-        {
-            let mut func = module.define_function("main", main_sig).unwrap();
-            let loaded = func.load_func(foo.handle(), &[]).unwrap();
-            let modified_fn = func
-                .add_dataflow_op(control_op, vec![loaded])
-                .unwrap()
-                .out_wire(0);
-            let control = func
-                .add_dataflow_op(TketOp::QAlloc, vec![])
-                .unwrap()
-                .out_wire(0);
-            let target = func
-                .add_dataflow_op(TketOp::QAlloc, vec![])
-                .unwrap()
-                .out_wire(0);
-            let control_arr = func.add_new_array(qb_t(), [control]).unwrap();
-            let outputs = func
-                .add_dataflow_op(
-                    CallIndirect {
-                        signature: controlled_sig,
-                    },
-                    [modified_fn, control_arr, target],
-                )
-                .unwrap()
-                .outputs();
-            func.finish_with_outputs(outputs).unwrap();
-        }
-
-        let mut h = module.finish_hugr().unwrap();
-        assert_matches!(h.validate(), Ok(()));
-
-        let entrypoint = h.entrypoint();
-        let result = resolve_modifier_with_entrypoints(&mut h, [entrypoint]);
-        assert_matches!(
-            result,
-            Err(ModifierResolverErrors::UnResolvable { node: _, msg, optype: _ }) => {
-                assert_eq!(msg, "unknown extension operation.");
-            }
         );
     }
 }

--- a/tket/src/modifier/modifier_resolver.rs
+++ b/tket/src/modifier/modifier_resolver.rs
@@ -91,7 +91,7 @@
 //! We also should not forget to connect `fneg` to `Rx` in the new graph, whose edge/wires has
 //! no correspondence in the original graph.
 //!
-//! ## Not supported/TODO cases
+//! ## Not supported:
 //! - Power: Power modifier is not supported at this point.
 //! - Dagger of non-trivial CFGs: We cannot support dagger for complicated CFGs
 //!   since it is not clear at all whether we should reverse the control flow or not.
@@ -103,7 +103,7 @@
 //!   in any case.
 //!   This won't be manageable if dagger is applied, but if not, it should be handled in the future.
 //! - User defined extension ops: There is no way to infer modified unknown extension ops.
-//!   We currently raise an error if an unkown extension is found.
+//!   We currently raise an error if an unknown extension is found.
 use fxhash::FxHashSet;
 use itertools::{Either, Itertools};
 use std::{
@@ -1032,7 +1032,6 @@ impl<N: HugrNode> ModifierResolver<N> {
             );
             Ok(())
         } else if Modifier::from_optype(optype).is_some() {
-            // TODO: check if this is ok.
             self.forget_node(h, op_node)
         } else if self.modify_array_op(h, op_node, optype, new_dfg)?
             || self.try_array_convert(h, op_node, optype, new_dfg)?
@@ -1339,10 +1338,6 @@ pub fn resolve_modifier_with_entrypoints_and_scope(
     // (e.g. intermediate nodes in a chain whose last modifier was the one rewritten).
     // Walk the same reachable set again and delete any surviving modifier nodes,
     // together with every downstream node that consumes their output.
-    // TODO:
-    // This might be insufficient as a cleanup since the resolution procedure might
-    // generate nodes that are not reachable from the entry points.
-    // If more thorough cleanup is needed, we should run dead code elimination.
     let mut deletelist = entry_points.clone();
     let mut visited = FxHashSet::default();
     while let Some(node) = deletelist.pop_front() {
@@ -1372,26 +1367,7 @@ pub fn resolve_modifier_with_entrypoints_and_scope(
             }
         }
     }
-    // Alternatively, we can just remove all the modifiers in the graph.
-    // let entry_points = vec![h.module_root()];
-    // for entry_point in entry_points.clone() {
-    //     let descendants = h.descendants(entry_point).collect::<Vec<_>>();
-    //     for node in descendants {
-    //         if !h.contains_node(node) {
-    //             continue;
-    //         }
-    //         let optype = h.get_optype(node);
-    //         if Modifier::from_optype(optype).is_some() {
-    //             let mut l = vec![node];
-    //             while let Some(n) = l.pop() {
-    //                 l.extend(h.output_neighbours(n));
-    //                 h.remove_node(n);
-    //             }
-    //         }
-    //     }
-    // }
 
-    // TODO: This as well.
     // Ad hoc cleanup procedure: remove any dangling global-phase nodes that
     // were produced or left behind by the resolution passes above.
     delete_phase(h, entry_points)?;

--- a/tket/src/modifier/modifier_resolver/call_modify.rs
+++ b/tket/src/modifier/modifier_resolver/call_modify.rs
@@ -31,9 +31,7 @@ impl<N: HugrNode> ModifierResolver<N> {
             .single_linked_output(call_node, call.called_function_port())
             .unwrap();
 
-        let Some(new_callee) =
-            self.modify_fn_if_needed(h, callee.0, Some(&old_signature), false)?
-        else {
+        let Some(new_callee) = self.modify_fn_if_needed(h, callee.0, Some(&old_signature))? else {
             // If the function need not be modified, just copy the Call node as is.
             let new = self.add_node_no_modification(h, call_node, call.clone(), new_dfg)?;
             self.call_map_insert(callee.0, (new, call.called_function_port()));

--- a/tket/src/modifier/modifier_resolver/call_modify.rs
+++ b/tket/src/modifier/modifier_resolver/call_modify.rs
@@ -245,9 +245,9 @@ impl<N: HugrNode> ModifierResolver<N> {
         new_dfg.hugr_mut().connect(new_load, 0, new_call_node, 0);
         self.map_insert_none((n, IncomingPort::from(0)).into())?;
 
-        // FIXME: Forgetting all the nodes in the chain so that we don't have to worry about mapping the edges.
+        // Forgetting all the nodes in the chain so that we don't have to worry about mapping the edges.
         // Otherwise, there would be edges in the original graph that have no corresponding edges in the new graph.
-        // However, this could remove wires referenced by other nodes that are not in the chain.
+        // NOTE: this could remove wires referenced by other nodes that are not in the chain.
         for node in trace {
             self.forget_node(h, node)?
         }

--- a/tket/src/modifier/modifier_resolver/call_modify.rs
+++ b/tket/src/modifier/modifier_resolver/call_modify.rs
@@ -31,7 +31,9 @@ impl<N: HugrNode> ModifierResolver<N> {
             .single_linked_output(call_node, call.called_function_port())
             .unwrap();
 
-        let Some(new_callee) = self.modify_fn_if_needed(h, callee.0, Some(&old_signature))? else {
+        let Some(new_callee) =
+            self.modify_fn_if_needed(h, callee.0, Some(&old_signature), false)?
+        else {
             // If the function need not be modified, just copy the Call node as is.
             let new = self.add_node_no_modification(h, call_node, call.clone(), new_dfg)?;
             self.call_map_insert(callee.0, (new, call.called_function_port()));

--- a/tket/src/modifier/modifier_resolver/dfg_modify.rs
+++ b/tket/src/modifier/modifier_resolver/dfg_modify.rs
@@ -301,8 +301,6 @@ impl<N: HugrNode> ModifierResolver<N> {
     /// When the function definition or a concrete call instantiation contains qubits,
     /// the function needs to be modified. The concrete signature matters for polymorphic
     /// functions whose uninstantiated definition may not reveal quantum data.
-    /// force is used to indicate that the function is being called after a modifiers chain,
-    /// so it must be modified even if the concrete signature does not contain qubits.
     ///
     /// NOTE: When a polymorphic function has a polymorphic input, the function is considered
     /// to have classical data (there are no quantum generic types or generic quantum operations).
@@ -311,7 +309,6 @@ impl<N: HugrNode> ModifierResolver<N> {
         h: &mut impl HugrMut<Node = N>,
         func: N,
         concrete_signature: Option<&Signature>,
-        force: bool,
     ) -> Result<Option<N>, ModifierResolverErrors<N>> {
         let OpType::FuncDefn(fn_defn) = h.get_optype(func) else {
             return Err(ModifierResolverErrors::unreachable(format!(
@@ -321,8 +318,7 @@ impl<N: HugrNode> ModifierResolver<N> {
         };
         let concrete_signature_has_quantum_data =
             concrete_signature.is_some_and(|signature| self.signature_has_quantum_data(signature));
-        if !force
-            && !concrete_signature_has_quantum_data
+        if !concrete_signature_has_quantum_data
             && !self.signature_has_quantum_data(fn_defn.signature().body())
         {
             return Ok(None);

--- a/tket/src/modifier/modifier_resolver/dfg_modify.rs
+++ b/tket/src/modifier/modifier_resolver/dfg_modify.rs
@@ -301,6 +301,8 @@ impl<N: HugrNode> ModifierResolver<N> {
     /// When the function definition or a concrete call instantiation contains qubits,
     /// the function needs to be modified. The concrete signature matters for polymorphic
     /// functions whose uninstantiated definition may not reveal quantum data.
+    /// force is used to indicate that the function is being called after a modifiers chain,
+    /// so it must be modified even if the concrete signature does not contain qubits.
     ///
     /// NOTE: When a polymorphic function has a polymorphic input, the function is considered
     /// to have classical data (there are no quantum generic types or generic quantum operations).
@@ -309,6 +311,7 @@ impl<N: HugrNode> ModifierResolver<N> {
         h: &mut impl HugrMut<Node = N>,
         func: N,
         concrete_signature: Option<&Signature>,
+        force: bool,
     ) -> Result<Option<N>, ModifierResolverErrors<N>> {
         let OpType::FuncDefn(fn_defn) = h.get_optype(func) else {
             return Err(ModifierResolverErrors::unreachable(format!(
@@ -318,7 +321,8 @@ impl<N: HugrNode> ModifierResolver<N> {
         };
         let concrete_signature_has_quantum_data =
             concrete_signature.is_some_and(|signature| self.signature_has_quantum_data(signature));
-        if !concrete_signature_has_quantum_data
+        if !force
+            && !concrete_signature_has_quantum_data
             && !self.signature_has_quantum_data(fn_defn.signature().body())
         {
             return Ok(None);

--- a/tket/src/modifier/modifier_resolver/tket_op_modify.rs
+++ b/tket/src/modifier/modifier_resolver/tket_op_modify.rs
@@ -92,7 +92,6 @@ impl<N: HugrNode> ModifierResolver<N> {
                             } else if i == qubits + control {
                                 Some((halfturn, IncomingPort::from(0)).into())
                             } else {
-                                // FIXME: forget state order
                                 None
                             }
                         })
@@ -348,7 +347,6 @@ impl<N: HugrNode> ModifierResolver<N> {
                     mem::swap(&mut incoming, &mut outgoing)
                 }
                 incoming.push((halfturns, IncomingPort::from(0)).into());
-                // FIXME: Ignoring StateOrder
                 Ok(PortVector { incoming, outgoing })
             }
             Rz | Y | Z => {
@@ -463,7 +461,6 @@ impl<N: HugrNode> ModifierResolver<N> {
                 assert_eq!(control, self.control_num());
                 self.modifiers.dagger = dagger;
 
-                // TODO: This does not handle invisible wires
                 if !dagger {
                     Ok(PortVector { incoming, outgoing })
                 } else {

--- a/tket/src/modifier/modifier_resolver/tket_op_modify.rs
+++ b/tket/src/modifier/modifier_resolver/tket_op_modify.rs
@@ -92,6 +92,8 @@ impl<N: HugrNode> ModifierResolver<N> {
                             } else if i == qubits + control {
                                 Some((halfturn, IncomingPort::from(0)).into())
                             } else {
+                                // TODO: forget state order
+                                // see (https://github.com/Quantinuum/tket2/issues/1828)
                                 None
                             }
                         })
@@ -347,6 +349,8 @@ impl<N: HugrNode> ModifierResolver<N> {
                     mem::swap(&mut incoming, &mut outgoing)
                 }
                 incoming.push((halfturns, IncomingPort::from(0)).into());
+                // TODO: Ignoring StateOrder
+                // see https://github.com/Quantinuum/tket2/issues/1828
                 Ok(PortVector { incoming, outgoing })
             }
             Rz | Y | Z => {
@@ -461,6 +465,8 @@ impl<N: HugrNode> ModifierResolver<N> {
                 assert_eq!(control, self.control_num());
                 self.modifiers.dagger = dagger;
 
+                // TODO: This does not handle StateOrder wires
+                // (see https://github.com/Quantinuum/tket2/issues/1828)
                 if !dagger {
                     Ok(PortVector { incoming, outgoing })
                 } else {

--- a/tket/src/modifier/modifier_resolver/tket_op_modify.rs
+++ b/tket/src/modifier/modifier_resolver/tket_op_modify.rs
@@ -92,8 +92,8 @@ impl<N: HugrNode> ModifierResolver<N> {
                             } else if i == qubits + control {
                                 Some((halfturn, IncomingPort::from(0)).into())
                             } else {
-                                // TODO: forget state order
-                                // see (https://github.com/Quantinuum/tket2/issues/1828)
+                                // TODO: Here we forget state order, we should handle them properly
+                                // see (https://github.com/Quantinuum/tket2/issues/1836)
                                 None
                             }
                         })
@@ -349,8 +349,8 @@ impl<N: HugrNode> ModifierResolver<N> {
                     mem::swap(&mut incoming, &mut outgoing)
                 }
                 incoming.push((halfturns, IncomingPort::from(0)).into());
-                // TODO: Ignoring StateOrder
-                // see https://github.com/Quantinuum/tket2/issues/1828
+                // TODO: Here we forget StateOrder wires, we should handle them properly
+                // (see https://github.com/Quantinuum/tket2/issues/1836)
                 Ok(PortVector { incoming, outgoing })
             }
             Rz | Y | Z => {
@@ -465,8 +465,8 @@ impl<N: HugrNode> ModifierResolver<N> {
                 assert_eq!(control, self.control_num());
                 self.modifiers.dagger = dagger;
 
-                // TODO: This does not handle StateOrder wires
-                // (see https://github.com/Quantinuum/tket2/issues/1828)
+                // TODO: This does not handle StateOrder wires, we should handle them properly
+                // (see https://github.com/Quantinuum/tket2/issues/1836)
                 if !dagger {
                     Ok(PortVector { incoming, outgoing })
                 } else {


### PR DESCRIPTION
closes https://github.com/Quantinuum/tket2/issues/1551

This PR removes leftover TODOS. The still valid TODO has been converted into an issue.