### PR TITLE
feat: Disable pytket encoding for tuple wires

### DIFF
--- a/tket/src/serialize/pytket/config/decoder_config.rs
+++ b/tket/src/serialize/pytket/config/decoder_config.rs
@@ -104,7 +104,7 @@ impl PytketDecoderConfig {
     /// Translate a HUGR type into a count of qubits, bits, and parameters,
     /// using the registered custom translator.
     ///
-    /// Only tuple sums, bools, and custom types are supported.
+    /// Only bools, parameter types, and registered custom types are supported.
     /// Other types will return `None`.
     pub fn type_to_pytket(&self, typ: &Type) -> Option<RegisterCount> {
         self.type_translators.type_to_pytket(typ)

--- a/tket/src/serialize/pytket/config/encoder_config.rs
+++ b/tket/src/serialize/pytket/config/encoder_config.rs
@@ -172,7 +172,7 @@ impl<H: HugrView> PytketEncoderConfig<H> {
     /// Translate a HUGR type into a count of qubits, bits, and parameters,
     /// using the registered custom translator.
     ///
-    /// Only tuple sums, bools, and custom types are supported.
+    /// Only bools, parameter types, and registered custom types are supported.
     /// Other types will return `None`.
     pub fn type_to_pytket(&self, typ: &Type) -> Option<RegisterCount> {
         self.type_translators.type_to_pytket(typ)

--- a/tket/src/serialize/pytket/config/type_translators.rs
+++ b/tket/src/serialize/pytket/config/type_translators.rs
@@ -12,7 +12,7 @@ use hugr::extension::prelude::bool_t;
 use hugr::std_extensions::arithmetic::float_types;
 use hugr::types::Type;
 use hugr::{Hugr, Wire};
-use hugr_core::types::{Term, TypeRow};
+use hugr_core::types::Term;
 use itertools::Itertools;
 
 use crate::extension::rotation;
@@ -64,15 +64,16 @@ impl TypeTranslatorSet {
     /// Translate a HUGR type into a count of qubits, bits, and parameters,
     /// using the registered custom translator.
     ///
-    /// Only tuple sums, bools, and custom types are supported.
+    /// Only bools, parameter types, and registered custom types are supported.
     /// Other types will return `None`.
     pub fn type_to_pytket(&self, typ: &Type) -> Option<RegisterCount> {
         self.type_to_pytket_internal(typ).filter(|c| !c.is_empty())
     }
 
-    /// Recursive call for [`Self::type_to_pytket`].
+    /// Cached implementation for [`Self::type_to_pytket`].
     ///
-    /// This allows returning empty register counts, for types that may be included inside other types.
+    /// This permits translators to return an empty register count, which the
+    /// public method treats as unsupported.
     fn type_to_pytket_internal(&self, typ: &Type) -> Option<RegisterCount> {
         let cache = self.type_cache.read().ok();
         if let Some(count) = cache.and_then(|c| c.get(typ).cloned()) {
@@ -88,24 +89,8 @@ impl TypeTranslatorSet {
         }
 
         let res = match &**typ {
-            Term::SumType(sum) => {
-                if sum.num_variants() == 0 {
-                    return Some(RegisterCount::default());
-                }
-                if typ == &bool_t() {
-                    return Some(RegisterCount::only_bits(1));
-                }
-                if let Some(tuple) = sum.as_tuple() {
-                    TypeRow::try_from(tuple.clone()).ok().and_then(|t| {
-                        let count: Option<RegisterCount> =
-                            t.iter().map(|ty| self.type_to_pytket_internal(ty)).sum();
-                        // Don't allow parameters nested inside other types
-                        count.filter(|c| c.params == 0)
-                    })
-                } else {
-                    None
-                }
-            }
+            Term::SumType(_) if typ == &bool_t() => Some(RegisterCount::only_bits(1)),
+            Term::SumType(_) => None,
             Term::ExtensionType(custom) => 'outer: {
                 let type_ext = custom.extension();
                 for encoder in self.translators_for_extension(type_ext) {
@@ -214,7 +199,7 @@ mod tests {
     #[case::empty(SumType::new_unary(0).into(), None)]
     #[case::native_bool(SumType::new_unary(2).into(), Some(RegisterCount::only_bits(1)))]
     #[case::simple(bool_t(), Some(RegisterCount::only_bits(1)))]
-    #[case::tuple(SumType::new_tuple(vec![bool_t(), qb_t(), bool_t(), SumType::new_unary(1).into()]).into(), Some(RegisterCount::new(1, 2, 0)))]
+    #[case::tuple(SumType::new_tuple(vec![bool_t(), qb_t()]).into(), None)]
     #[case::unsupported(SumType::new([vec![bool_t(), qb_t()], vec![bool_t()]]).into(), None)]
     fn test_translations(
         translator_set: TypeTranslatorSet,

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -1,7 +1,6 @@
 //! Structures to keep track of pytket [`ElementId`][tket_json_rs::register::ElementId]s and
 //! their correspondence to wires in the hugr being defined.
 use std::collections::{BTreeMap, VecDeque};
-use std::ops::Deref;
 use std::sync::Arc;
 
 use hugr::builder::{DFGBuilder, Dataflow as _};
@@ -11,7 +10,6 @@ use hugr::ops::Value;
 use hugr::std_extensions::arithmetic::float_types::{ConstF64, float64_type};
 use hugr::types::Type;
 use hugr::{Hugr, IncomingPort, Node, Wire};
-use hugr_core::types::{Term, TypeRow};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use tket_json_rs::circuit_json::ImplicitPermutation;
@@ -724,9 +722,6 @@ impl WireTracker {
             _ if ty == &bool_t() && !bit_args.is_empty() => {
                 self.initialize_bit_wire(builder, bit_args[0].clone())?
             }
-            _ if matches!(ty.deref(), Term::SumType(sum) if sum.as_tuple().is_some()) => {
-                return self.find_tuple_wire(config, builder, ty, qubit_args, bit_args, params);
-            }
             _ => {
                 return Err(PytketDecodeErrorInner::NoMatchingWire {
                     ty: ty.to_string(),
@@ -780,95 +775,6 @@ impl WireTracker {
             self.mark_wire_outdated(wire);
             Ok(FoundWire::Register(self.wires[&new_wire].clone()))
         }
-    }
-
-    /// Build a tuple wire from its tracked element wires when no matching
-    /// aggregate wire exists.
-    ///
-    /// Pytket passes may preserve an opaque barrier while presenting its qubit
-    /// arguments in an order that does not match any aggregate tuple wire
-    /// already tracked from the original HUGR. In that case, we can rebuild the
-    /// tuple explicitly from the individual decoded wires.
-    fn find_tuple_wire(
-        &mut self,
-        config: &PytketDecoderConfig,
-        builder: &mut DFGBuilder<&mut Hugr>,
-        ty: &Type,
-        qubit_args: &mut &[TrackedQubit],
-        bit_args: &mut &[TrackedBit],
-        params: &mut &[LoadedParameter],
-    ) -> Result<FoundWire, PytketDecodeError> {
-        let Term::SumType(sum) = ty.deref() else {
-            unreachable!("find_tuple_wire called with non-sum type");
-        };
-        let Some(tuple) = sum.as_tuple() else {
-            unreachable!("find_tuple_wire called with non-tuple sum type");
-        };
-        let tuple = TypeRow::try_from(tuple.clone()).map_err(|_| {
-            PytketDecodeErrorInner::NoMatchingWire {
-                ty: ty.to_string(),
-                qubit_args: qubit_args
-                    .iter()
-                    .map(|q| q.pytket_register().to_string())
-                    .collect(),
-                bit_args: bit_args
-                    .iter()
-                    .map(|bit| bit.pytket_register().to_string())
-                    .collect(),
-            }
-            .wrap()
-        })?;
-
-        let mut tuple_qubits = *qubit_args;
-        let mut tuple_bits = *bit_args;
-        let mut tuple_params = *params;
-        let mut element_wires = Vec::with_capacity(tuple.len());
-        for elem_ty in tuple.iter() {
-            let FoundWire::Register(wire) = self.find_typed_wire(
-                config,
-                builder,
-                elem_ty,
-                &mut tuple_qubits,
-                &mut tuple_bits,
-                &mut tuple_params,
-                None,
-            )?
-            else {
-                return Err(PytketDecodeErrorInner::NoMatchingWire {
-                    ty: ty.to_string(),
-                    qubit_args: qubit_args
-                        .iter()
-                        .map(|q| q.pytket_register().to_string())
-                        .collect(),
-                    bit_args: bit_args
-                        .iter()
-                        .map(|bit| bit.pytket_register().to_string())
-                        .collect(),
-                }
-                .wrap());
-            };
-            element_wires.push(wire.wire());
-        }
-
-        let reg_count = config
-            .type_to_pytket(ty)
-            .expect("tuple fallback requires a pytket-representable type");
-        let wire_qubits = qubit_args
-            .iter()
-            .take(reg_count.qubits)
-            .cloned()
-            .collect_vec();
-        let wire_bits = bit_args.iter().take(reg_count.bits).cloned().collect_vec();
-        let tuple_wire = builder
-            .make_tuple(element_wires)
-            .map_err(PytketDecodeError::custom)?;
-        self.track_wire(tuple_wire, Arc::new(ty.clone()), wire_qubits, wire_bits)?;
-
-        *qubit_args = tuple_qubits;
-        *bit_args = tuple_bits;
-        *params = tuple_params;
-
-        Ok(FoundWire::Register(self.wires[&tuple_wire].clone()))
     }
 
     /// Returns a new [TrackedWires] set for a list of [`TrackedQubit`]s,

--- a/tket/src/serialize/pytket/extension/prelude.rs
+++ b/tket/src/serialize/pytket/extension/prelude.rs
@@ -11,10 +11,9 @@ use crate::serialize::pytket::opaque::OpaqueSubgraphPayload;
 use crate::serialize::pytket::{PytketDecodeError, PytketEncodeError};
 use hugr::HugrView;
 use hugr::extension::ExtensionId;
-use hugr::extension::prelude::{BarrierDef, Noop, PRELUDE_ID, TupleOpDef, bool_t, qb_t};
+use hugr::extension::prelude::{BarrierDef, Noop, PRELUDE_ID, bool_t, qb_t};
 use hugr::extension::simple_op::MakeExtensionOp;
 use hugr::ops::{ExtensionOp, OpType};
-use hugr::types::TypeArg;
 use tket_json_rs::optype::OpType as PytketOptype;
 
 /// Encoder for [prelude](hugr::extension::prelude) operations.
@@ -33,9 +32,6 @@ impl<H: HugrView> PytketEmitter<H> for PreludeEmitter {
         hugr: &H,
         encoder: &mut PytketEncoderContext<H>,
     ) -> Result<EncodeStatus, PytketEncodeError<H::Node>> {
-        if let Ok(tuple_op) = TupleOpDef::from_extension_op(op) {
-            return self.tuple_op_to_pytket(node, op, &tuple_op, hugr, encoder);
-        };
         if let Ok(_barrier) = BarrierDef::from_extension_op(op) {
             // Check if the barrier has encodable types in its signature.
             // If not, fallback to marking it as unsupported.
@@ -76,56 +72,6 @@ impl PytketTypeTranslator for PreludeEmitter {
             // that use them are translated to pytket.
             _ => None,
         }
-    }
-}
-
-impl PreludeEmitter {
-    /// Encode a prelude tuple operation.
-    ///
-    /// These just bundle/unbundle the values of the inputs/outputs. Since
-    /// pytket types are already flattened, the translation of these is just a
-    /// no-op.
-    fn tuple_op_to_pytket<H: HugrView>(
-        &self,
-        node: H::Node,
-        op: &ExtensionOp,
-        tuple_op: &TupleOpDef,
-        hugr: &H,
-        encoder: &mut PytketEncoderContext<H>,
-    ) -> Result<EncodeStatus, PytketEncodeError<H::Node>> {
-        if !matches!(tuple_op, TupleOpDef::MakeTuple | TupleOpDef::UnpackTuple) {
-            // Unknown operation
-            return Ok(EncodeStatus::Unsupported);
-        };
-
-        // First, check if we are working with supported types.
-        //
-        // If any of the types cannot be translated to a pytket type, we return
-        // false so the operation is marked as unsupported as a whole.
-        let args = op.args().first();
-        match args {
-            Some(TypeArg::Tuple(elems)) | Some(TypeArg::List(elems)) => {
-                if elems.is_empty() {
-                    return Ok(EncodeStatus::Unsupported);
-                }
-
-                for arg in elems {
-                    let Ok(ty) = arg.clone().try_into() else {
-                        return Ok(EncodeStatus::Unsupported);
-                    };
-                    let count = encoder.config().type_to_pytket(&ty);
-                    if count.is_none_or(|c| c.params > 0) {
-                        return Ok(EncodeStatus::Unsupported);
-                    }
-                }
-            }
-            _ => return Ok(EncodeStatus::Unsupported),
-        };
-
-        // Now we can gather all inputs and assign them to the node outputs transparently.
-        encoder.emit_transparent_node(node, hugr, |ps| ps.input_params.to_owned())?;
-
-        Ok(EncodeStatus::Success)
     }
 }
 

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -9,7 +9,9 @@ use hugr::builder::{
     Container, Dataflow, DataflowHugr, DataflowSubContainer, FunctionBuilder, HugrBuilder,
     ModuleBuilder, SubContainer,
 };
-use hugr::extension::prelude::{ConstExternalSymbol, UnwrapBuilder, bool_t, option_type, qb_t};
+use hugr::extension::prelude::{
+    ConstExternalSymbol, UnpackTuple, UnwrapBuilder, bool_t, option_type, qb_t,
+};
 use hugr::extension::simple_op::MakeExtensionOp;
 use hugr::std_extensions::arithmetic::float_types::{ConstF64, float64_type};
 use hugr::std_extensions::logic::LogicOp;
@@ -33,7 +35,7 @@ use crate::serialize::pytket::{
 };
 use hugr::hugr::hugrmut::HugrMut;
 use hugr::ops::handle::FuncID;
-use hugr::ops::{OpParent, OpType, Value};
+use hugr::ops::{OpParent, OpType, Tag, Value};
 use hugr::std_extensions::arithmetic::float_ops::FloatOps;
 use hugr::types::{Signature, SumType, Type};
 use hugr::{Hugr, HugrView};
@@ -870,6 +872,70 @@ fn circ_complex_param_type() -> Hugr {
     h.finish_hugr_with_outputs([q, float_tuple]).unwrap()
 }
 
+/// A supported qubit tuple produced by an opaque subgraph and consumed by a
+/// pytket operation as separate qubit wires.
+#[fixture]
+fn circ_opaque_qubit_tuple_output() -> Hugr {
+    let pair_type = Type::from(SumType::new_tuple(vec![qb_t(), qb_t()]));
+    let optional_qubit_type = Type::from(option_type([qb_t()]));
+    let signature = Signature::new(
+        vec![qb_t(), qb_t(), optional_qubit_type.clone()],
+        vec![qb_t(), qb_t(), optional_qubit_type.clone()],
+    );
+    let mut h = FunctionBuilder::new("opaque_qubit_tuple_output", signature).unwrap();
+    let [q0, q1, optional_qubit] = h.input_wires_arr();
+
+    let pair = h.make_tuple([q0, q1]).unwrap();
+    let outer_tuple = h.make_tuple([pair, optional_qubit]).unwrap();
+    let [pair, optional_qubit] = h
+        .add_dataflow_op(
+            UnpackTuple::new(vec![pair_type, optional_qubit_type].into()),
+            [outer_tuple],
+        )
+        .unwrap()
+        .outputs_arr();
+    let [q0, q1] = h
+        .add_dataflow_op(UnpackTuple::new(vec![qb_t(), qb_t()].into()), [pair])
+        .unwrap()
+        .outputs_arr();
+    let [q0, q1] = h
+        .add_dataflow_op(TketOp::CX, [q0, q1])
+        .unwrap()
+        .outputs_arr();
+
+    h.finish_hugr_with_outputs([q0, q1, optional_qubit])
+        .unwrap()
+}
+
+/// A qubit tuple consumed by an unsupported output after its elements have
+/// passed through a pytket operation.
+///
+/// The decoder must not try to unpack the tuple again while accounting for
+/// qubits that do not appear directly in the function output signature.
+#[fixture]
+fn circ_consumed_qubit_tuple() -> Hugr {
+    let pair_type = Type::from(SumType::new_tuple(vec![qb_t(), qb_t()]));
+    let optional_pair_type = Type::from(option_type([pair_type.clone()]));
+    let signature = Signature::new(vec![qb_t(), qb_t()], vec![optional_pair_type.clone()]);
+    let mut h = FunctionBuilder::new("consumed_qubit_tuple", signature).unwrap();
+    let [q0, q1] = h.input_wires_arr();
+
+    let [q0, q1] = h
+        .add_dataflow_op(TketOp::CX, [q0, q1])
+        .unwrap()
+        .outputs_arr();
+    let pair = h.make_tuple([q0, q1]).unwrap();
+    let optional_pair = h
+        .add_dataflow_op(
+            Tag::new(1, vec![vec![].into(), vec![pair_type].into()]),
+            [pair],
+        )
+        .unwrap()
+        .out_wire(0);
+
+    h.finish_hugr_with_outputs([optional_pair]).unwrap()
+}
+
 /// A prelude barrier carrying one unsupported value next to a qubit.
 ///
 /// The barrier must be encoded as an opaque subgraph; trying to emit it as a
@@ -1088,29 +1154,6 @@ fn json_file_roundtrip(#[case] circ: impl AsRef<std::path::Path>) {
     let reser: SerialCircuit = SerialCircuit::encode(&hugr, EncodeOptions::new()).unwrap();
     validate_serial_circ(&reser);
     compare_serial_circs(&ser, &reser);
-}
-
-#[test]
-fn decode_tuple_output_from_permuted_barrier_args() {
-    let ser: circuit_json::SerialCircuit = serde_json::from_str(
-        r#"{
-        "phase": "0",
-        "bits": [],
-        "qubits": [["q", [0]], ["q", [1]]],
-        "commands": [
-            {"args": [["q", [1]], ["q", [0]]], "op": {"type": "Barrier"}}
-        ],
-        "implicit_permutation": [[["q", [0]], ["q", [0]]], [["q", [1]], ["q", [1]]]]
-    }"#,
-    )
-    .unwrap();
-
-    let tuple_qubits = Type::from(SumType::new_tuple(vec![qb_t(), qb_t()]));
-    let hugr = ser
-        .decode(DecodeOptions::new().with_signature(Signature::new(vec![], vec![tuple_qubits])))
-        .unwrap();
-
-    hugr.validate().unwrap();
 }
 
 #[test]
@@ -1361,6 +1404,12 @@ fn fail_on_modified_hugr(circ_tk1_ops: Hugr) {
 #[case::unsupported_io_wire(circ_unsupported_io_wire(), 1, CircuitRoundtripTestConfig::Default)]
 #[case::order_edge(circ_order_edge(), 1, CircuitRoundtripTestConfig::Default)]
 #[case::complex_param_type(circ_complex_param_type(), 1, CircuitRoundtripTestConfig::Default)]
+#[case::opaque_qubit_tuple_output(
+    circ_opaque_qubit_tuple_output(),
+    1,
+    CircuitRoundtripTestConfig::Default
+)]
+#[case::consumed_qubit_tuple(circ_consumed_qubit_tuple(), 1, CircuitRoundtripTestConfig::Default)]
 #[case::unsupported_subgraph_skipped_output_before_param(
     circ_unsupported_subgraph_skipped_output_before_param(),
     1,


### PR DESCRIPTION
Alternative to #1834.

Rather than try to fix the automatic conversion between tuple wires and their component wires, disable handling of tuples by the pytket encoder.
This greatly simplifies the logic all around. We weren't really using it for the current set of extensions.

I did a quick cleanup of the main parts of the code dealing with tuples, but will open a code health issue to do a deeper clean.

I validated these changes on the guppy codebase.

Required for https://github.com/Quantinuum/guppylang/issues/2041