### PR TITLE
fix: Parameters used before declaration in pytket decoder

### DIFF
--- a/tket-py/tket/_rewrite.py
+++ b/tket-py/tket/_rewrite.py
@@ -3,7 +3,7 @@ from ._tket.rewrite import ECCRewriter, CircuitRewrite, Subcircuit
 
 __all__ = [
     "default_ecc_rewriter",
-    # Bindings.
+    # Bindings
     # TODO: Wrap these in Python classes.
     "ECCRewriter",
     "CircuitRewrite",

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -262,7 +262,7 @@ impl<'h> PytketDecoderContext<'h> {
                     LoadedParameter::float_half_turns(wire)
                 };
                 match input_params.next() {
-                    Some(param) => wire_tracker.register_input_parameter(loaded, param)?,
+                    Some(param) => wire_tracker.bind_parameter(loaded, param, dfg)?,
                     None => wire_tracker.register_unused_parameter_input(loaded),
                 };
             }
@@ -275,7 +275,7 @@ impl<'h> PytketDecoderContext<'h> {
             let wire = dfg
                 .add_input(rotation_type())
                 .expect("Must be building a FuncDefn or a DFG");
-            wire_tracker.register_input_parameter(LoadedParameter::rotation(wire), param)?;
+            wire_tracker.bind_parameter(LoadedParameter::rotation(wire), param, dfg)?;
         }
 
         // Any additional qubits or bits required by the circuit are registered
@@ -597,6 +597,8 @@ impl<'h> PytketDecoderContext<'h> {
         // Add additional subgraphs and wires not encoded in commands.
         let [input_node, output_node] = self.builder.io();
         if let Some(extras) = extra_nodes_and_wires {
+            self.reserve_additional_subgraph_parameters(extras);
+
             for extra_subgraph in &extras.additional_subgraphs {
                 let params = extra_subgraph
                     .params
@@ -632,6 +634,33 @@ impl<'h> PytketDecoderContext<'h> {
         }
 
         Ok(())
+    }
+
+    /// Reserve parameter variables used before pytket commands are decoded.
+    ///
+    /// Additional subgraphs are restored first, so their expressions may refer
+    /// to parameters produced by a later opaque barrier. Genuine region inputs
+    /// are already registered and are left unchanged by the wire tracker.
+    fn reserve_additional_subgraph_parameters(&mut self, extras: &AdditionalNodesAndWires) {
+        let mut params = IndexSet::new();
+        extras
+            .additional_subgraphs
+            .iter()
+            .flat_map(|subgraph| &subgraph.params)
+            .map(|param| PytketParam::parse(param))
+            .for_each(|param| {
+                param.visit_input_variables(&mut |name| {
+                    // `pi` is loaded as a constant rather than routed as a parameter.
+                    if name != "pi" {
+                        params.insert(name.to_owned());
+                    }
+                });
+            });
+
+        for param in params {
+            self.wire_tracker
+                .reserve_forward_parameter(param, &mut self.builder);
+        }
     }
 
     /// Add a tket1 [`circuit_json::Command`] from the serial circuit to the

--- a/tket/src/serialize/pytket/decoder/param/parser.rs
+++ b/tket/src/serialize/pytket/decoder/param/parser.rs
@@ -65,6 +65,22 @@ impl<'a> PytketParam<'a> {
     pub fn is_zero(&self) -> bool {
         matches!(self, PytketParam::Constant(value) if *value == 0.0)
     }
+
+    /// Visit the input variables referenced by this parsed expression.
+    ///
+    /// Variables inside unrecognized SymPy expressions cannot be routed by the
+    /// decoder, so [`Self::Sympy`] is treated as an opaque leaf.
+    pub fn visit_input_variables(&self, visitor: &mut impl FnMut(&'a str)) {
+        match self {
+            Self::InputVariable { name } => visitor(name),
+            Self::Operation { args, .. } => {
+                for arg in args {
+                    arg.visit_input_variables(visitor);
+                }
+            }
+            Self::Constant(_) | Self::Sympy(_) => {}
+        }
+    }
 }
 
 impl<'a> PartialEq for PytketParam<'a> {
@@ -335,5 +351,17 @@ mod test {
                 "Incorrect parameter parsing\n\texpression: \"{param}\"\n\tparsed: {parsed}\n\texpected: {expected}"
             );
         }
+    }
+
+    #[rstest]
+    #[case::constant("42", &[])]
+    #[case::variable("p0", &["p0"])]
+    #[case::nested("2 * (p0 + p1 + pi)", &["p0", "p1", "pi"])]
+    #[case::opaque_sympy("unknown_op(p0)", &[])]
+    fn visit_input_variables(#[case] param: &str, #[case] expected: &[&str]) {
+        let parsed = PytketParam::parse(param);
+        let mut variables = Vec::new();
+        parsed.visit_input_variables(&mut |name| variables.push(name));
+        assert_eq!(variables, expected);
     }
 }

--- a/tket/src/serialize/pytket/decoder/subgraph.rs
+++ b/tket/src/serialize/pytket/decoder/subgraph.rs
@@ -235,7 +235,7 @@ impl<'h> PytketDecoderContext<'h> {
                     LoadedParameter::float_half_turns(wire)
                 };
                 self.wire_tracker
-                    .register_input_parameter(param, param_name)?;
+                    .bind_parameter(param, param_name, &mut self.builder)?;
             } else {
                 // This is an unsupported wire. If it was connected to the old
                 // region's output, rewire it to the new region's output.

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -3,13 +3,13 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 
-use hugr::builder::{DFGBuilder, Dataflow as _};
+use hugr::builder::{Container as _, DFGBuilder, Dataflow as _};
 use hugr::extension::prelude::{bool_t, qb_t};
 use hugr::hugr::hugrmut::HugrMut;
 use hugr::ops::Value;
 use hugr::std_extensions::arithmetic::float_types::{ConstF64, float64_type};
 use hugr::types::Type;
-use hugr::{Hugr, IncomingPort, Node, Wire};
+use hugr::{Hugr, HugrView as _, IncomingPort, Node, Wire};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use tket_json_rs::circuit_json::ImplicitPermutation;
@@ -339,6 +339,11 @@ pub(crate) struct WireTracker {
     ///
     /// Ordered according to their order in the function input.
     parameter_vars: IndexSet<String>,
+    /// Not yet-produced parameters that have been referenced in the decoded hugr.
+    ///
+    /// These are introduced when decoding opaque hugr subgraphs outside the pytket commands.
+    /// See [`super::AdditionalNodesAndWires`].
+    forward_parameter_placeholders: IndexSet<String>,
     /// A permutation of qubit registers in `latest_qubit_tracker` that we
     /// expect to see at the output.
     ///
@@ -394,6 +399,7 @@ impl WireTracker {
             parameters: IndexMap::new(),
             unused_parameter_inputs: VecDeque::new(),
             parameter_vars: IndexSet::new(),
+            forward_parameter_placeholders: IndexSet::new(),
             output_qubit_permutation: Vec::with_capacity(qubit_count),
             unsupported_wires: IndexMap::new(),
         }
@@ -1036,22 +1042,91 @@ impl WireTracker {
         Ok(())
     }
 
-    /// Associate an input wire to the region with a parameter.
-    pub(super) fn register_input_parameter(
+    /// Bind a pytket variable name to its loaded parameter value.
+    ///
+    /// If [`Self::reserve_forward_parameter`] created a placeholder for the
+    /// parameter name, this replaces the placeholder binding, rewires all of
+    /// its consumers to the produced value, and removes the temporary node.
+    ///
+    /// Otherwise, this creates a new binding and records the name in the
+    /// context. In that case the `builder` is not modified.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PytketDecodeErrorInner::DuplicatedParameter`] if the name is
+    /// already bound and is not an unresolved forward reference.
+    pub(super) fn bind_parameter(
         &mut self,
         loaded: LoadedParameter,
         param: String,
+        builder: &mut DFGBuilder<&mut Hugr>,
     ) -> Result<(), PytketDecodeError> {
-        let entry = self.parameters.entry(param.clone());
-        if let indexmap::map::Entry::Occupied(_) = &entry {
-            return Err(PytketDecodeErrorInner::DuplicatedParameter {
-                param: entry.key().clone(),
+        let was_predeclared = self.forward_parameter_placeholders.contains(&param);
+
+        if !was_predeclared {
+            let entry = self.parameters.entry(param.clone());
+            if let indexmap::map::Entry::Occupied(_) = &entry {
+                return Err(PytketDecodeErrorInner::DuplicatedParameter {
+                    param: entry.key().clone(),
+                }
+                .into());
             }
-            .into());
+            self.parameter_vars.insert(param);
+            entry.insert_entry(loaded);
+        } else {
+            // Replace a pre-declared parameter placeholder with the actual value, and rewire all of its consumers.
+
+            let placeholder = self
+                .parameters
+                .insert(param, loaded)
+                .expect("reserved parameter must have a placeholder");
+            let targets = builder
+                .hugr()
+                .linked_inputs(placeholder.wire().node(), placeholder.wire().source())
+                .collect_vec();
+            if !targets.is_empty() {
+                let replacement = loaded.with_type(placeholder.typ(), builder).wire();
+                builder
+                    .hugr_mut()
+                    .disconnect(placeholder.wire().node(), placeholder.wire().source());
+                for (node, port) in targets {
+                    builder.hugr_mut().connect(
+                        replacement.node(),
+                        replacement.source(),
+                        node,
+                        port,
+                    );
+                }
+            }
+            builder.hugr_mut().remove_node(placeholder.wire().node());
         }
-        self.parameter_vars.insert(param);
-        entry.insert_entry(loaded);
+
         Ok(())
+    }
+
+    /// Reserve a parameter name referenced before its producer is decoded.
+    ///
+    /// Adds a placeholder constant definition to the Hugr, which will be
+    /// replaced by the actual parameter value when it is produced.
+    ///
+    /// If the name is already bound, no reservation is needed so this is a
+    /// no-op.
+    pub(super) fn reserve_forward_parameter(
+        &mut self,
+        param: String,
+        builder: &mut DFGBuilder<&mut Hugr>,
+    ) {
+        if self.parameters.contains_key(&param) {
+            return;
+        }
+
+        let wire = builder
+            .add_dataflow_op(symbolic_constant_op(param.clone()), [])
+            .expect("symbolic parameter placeholder must be valid")
+            .out_wire(0);
+        self.parameters
+            .insert(param.clone(), LoadedParameter::rotation(wire));
+        self.forward_parameter_placeholders.insert(param);
     }
 
     /// Track a parameter input to the region for which we don't have a variable name yet.

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -1052,6 +1052,47 @@ fn circ_unsupported_subgraph_no_registers() -> Hugr {
     h.finish_hugr_with_outputs([q, rot2]).unwrap()
 }
 
+/// A parameter produced by an opaque barrier and consumed by a separate
+/// register-free opaque subgraph.
+#[fixture]
+fn circ_forward_opaque_parameter() -> Hugr {
+    let signature = Signature::new(vec![qb_t()], vec![qb_t(), rotation_type()]);
+    let mut h = FunctionBuilder::new("forward_opaque_parameter", signature).unwrap();
+    let [q] = h.input_wires_arr();
+
+    let consumer = h
+        .module_root_builder()
+        .declare(
+            "consumer",
+            Signature::new(vec![float64_type()], vec![rotation_type()]).into(),
+        )
+        .unwrap();
+
+    let [q, parameter] = {
+        let mut producer = h
+            .dfg_builder(
+                Signature::new(vec![qb_t()], vec![qb_t(), float64_type()]),
+                [q],
+            )
+            .unwrap();
+        let [q] = producer.input_wires_arr();
+        let parameter = producer.add_load_value(ConstF64::new(0.5));
+        producer
+            .finish_with_outputs([q, parameter])
+            .unwrap()
+            .outputs_arr()
+    };
+    let [q] = h.add_dataflow_op(TketOp::H, [q]).unwrap().outputs_arr();
+    let two = h.add_load_value(ConstF64::new(2.0));
+    let [parameter] = h
+        .add_dataflow_op(FloatOps::fmul, [parameter, two])
+        .unwrap()
+        .outputs_arr();
+    let [rotation] = h.call(&consumer, &[], [parameter]).unwrap().outputs_arr();
+
+    h.finish_hugr_with_outputs([q, rotation]).unwrap()
+}
+
 // A circuit that discards the first qubit input and only outputs the second one.
 #[fixture]
 fn circ_discard_first_qubit() -> Hugr {
@@ -1425,6 +1466,11 @@ fn fail_on_modified_hugr(circ_tk1_ops: Hugr) {
 #[case::non_local(circ_non_local(), 2, CircuitRoundtripTestConfig::Default)]
 #[case::unsupported_subgraph_no_registers(
     circ_unsupported_subgraph_no_registers(),
+    1,
+    CircuitRoundtripTestConfig::Default
+)]
+#[case::forward_opaque_parameter(
+    circ_forward_opaque_parameter(),
     1,
     CircuitRoundtripTestConfig::Default
 )]


### PR DESCRIPTION
Fixes an edge-case when decoding a pytket circuit where parameters were used before being produced.

Required for https://github.com/Quantinuum/guppylang/issues/2041.

---

Opaque subgraphs from a hugr may be encoded in two ways when producing pytket circuits:
- As a pytket Barrier command, if they contained register input/outputs (so their order is well preserved).
- As an external hugr subgraph in the rust context.

While pytket sets a strict order between commands, we have no way to impose an order between them and the subgraphs in the hugr.

This is not normally a problem, except that different subgraphs may be connected via parameter wires that can be produced and consumed in both kinds of subgraphs.

Since we process all the external subgraphs at the beginning of the decoding process, if we find a parameter input we should register it somewhere such that if a pytket barrier declares it as an output we are able to connect the ports correctly.

This PR does so by adding an internal `WireTracker::reserve_forward_parameter` call.