### PR TITLE
docs: Show documentation for `tket.extensions` module

### DIFF
--- a/tket-py/tket/extensions/__init__.py
+++ b/tket-py/tket/extensions/__init__.py
@@ -1,3 +1,5 @@
+"""HUGR extension definitions for tket circuits."""
+
 from tket_exts import (
     argument,
     debug,

--- a/tket-py/tket/extensions/__init__.py
+++ b/tket-py/tket/extensions/__init__.py
@@ -21,6 +21,13 @@ Extensions may be imported directly as follows:
 >>> result_extension = ext.result()
 >>> rotation_extension = ext.rotation()
 >>> wasm_extension = ext.wasm()
+>>>
+>>> read_arg_op = argument_extension.get_op("read_arg")
+OpDef(name='read_arg', signature=OpDefSig(poly_func=PolyFuncType(params=[StringParam(), TypeTypeParam(bound=TypeBound.Linear)], body=FunctionType([], [$1])), binary=False), description='Read a runtime argument of the given type identified by a string tag', misc={})
+>>> read_arg_op.description
+'Read a runtime argument of the given type identified by a string tag'
+>>> read_arg_op.signature
+OpDefSig(poly_func=PolyFuncType(params=[StringParam(), TypeTypeParam(bound=TypeBound.Linear)], body=FunctionType([], [$1])), binary=False)
 """
 
 from tket_exts import (

--- a/tket-py/tket/extensions/__init__.py
+++ b/tket-py/tket/extensions/__init__.py
@@ -1,4 +1,27 @@
-"""HUGR extension definitions for tket circuits."""
+"""HUGR extension definitions for tket circuits.
+
+Extensions may be imported directly as follows:
+
+>>> import tket.extensions as ext
+>>>
+>>> argument_extension = ext.argument()
+>>> debug_extension = ext.debug()
+>>> futures_extension = ext.futures()
+>>> global_phase_extension = ext.global_phase()
+>>> gpu_extension = ext.gpu()
+>>> guppy_extension = ext.guppy()
+>>> measurement_extension = ext.measurement()
+>>> modifier_extension = ext.modifier()
+>>> qsystem_extension = ext.qsystem()
+>>> qsystem_helios_extension = ext.qsystem_helios()
+>>> qsystem_sol_extension = ext.qsystem_sol()
+>>> qsystem_random_extension = ext.qsystem_random()
+>>> qsystem_utils_extension = ext.qsystem_utils()
+>>> quantum_extension = ext.quantum()
+>>> result_extension = ext.result()
+>>> rotation_extension = ext.rotation()
+>>> wasm_extension = ext.wasm()
+"""
 
 from tket_exts import (
     argument,
@@ -19,7 +42,25 @@ from tket_exts import (
     rotation,
     wasm,
 )
-
+from tket_exts.tket.argument import ArgumentExtension
+from tket_exts.tket.debug import DebugExtension
+from tket_exts.tket.futures import FuturesExtension
+from tket_exts.tket.global_phase import GlobalPhaseExtension
+from tket_exts.tket.gpu import GpuExtension
+from tket_exts.tket.guppy import GuppyExtension
+from tket_exts.tket.measurement import MeasurementExtension
+from tket_exts.tket.modifier import ModifierExtension
+from tket_exts.tket.qsystem import (
+    QSystemExtension,
+    QSystemHeliosExtension,
+    QSystemRandomExtension,
+    QSystemSolExtension,
+    QSystemUtilsExtension,
+)
+from tket_exts.tket.quantum import QuantumExtension
+from tket_exts.tket.result import ResultExtension
+from tket_exts.tket.rotation import RotationExtension
+from tket_exts.tket.wasm import WasmExtension
 
 __all__ = [
     "argument",
@@ -39,4 +80,21 @@ __all__ = [
     "result",
     "rotation",
     "wasm",
+    "ArgumentExtension",
+    "DebugExtension",
+    "FuturesExtension",
+    "GlobalPhaseExtension",
+    "GpuExtension",
+    "GuppyExtension",
+    "MeasurementExtension",
+    "ModifierExtension",
+    "QSystemExtension",
+    "QSystemHeliosExtension",
+    "QSystemRandomExtension",
+    "QSystemSolExtension",
+    "QSystemUtilsExtension",
+    "QuantumExtension",
+    "ResultExtension",
+    "RotationExtension",
+    "WasmExtension",
 ]


### PR DESCRIPTION
Fixes #1844 .

I could not find any way to make sphinx's `autosummary` include the module-level constants (`argument` etc) imported from `tket_exts`, so this is a compromise soltution:
- Export the class definitions from `tket_exts` (`ArgumentExtension` etc) so that these and their methods are documented.
- Extend the module documentation so that it explains how the extensions can be imported directly.

The main `extensions` page now looks like this:

<img width="1131" height="2006" alt="image" src="https://github.com/user-attachments/assets/ad10ebf3-2ef9-4c52-b9f4-f9843217d51f" />

And if you click on `ArgumentExtension` (for example) you see this:

<img width="1324" height="1676" alt="image" src="https://github.com/user-attachments/assets/d409889c-02da-4ba5-9a46-46a3ef711fd9" />
