### PR TITLE
chore: Release tket 0.19.3 and tket-qsystem 0.25.3 backports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tket"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "anyhow",
  "ascent",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "tket-qsystem"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/badger-optimiser/Cargo.toml
+++ b/badger-optimiser/Cargo.toml
@@ -16,7 +16,7 @@ tket = { path = "../tket", features = [
     "rewrite-tracing",
     "binary-eccs",
 ] }
-tket-qsystem = { path = "../tket-qsystem", version = "0.25.2" }
+tket-qsystem = { path = "../tket-qsystem", version = "0.25.3" }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }

--- a/qis-compiler/Cargo.toml
+++ b/qis-compiler/Cargo.toml
@@ -20,8 +20,8 @@ serde_json.workspace = true
 tracing.workspace = true
 itertools.workspace = true
 strum.workspace = true
-tket = { path = "../tket", version = "0.19.2" }
-tket-qsystem = { path = "../tket-qsystem", version = "0.25.2", features = [
+tket = { path = "../tket", version = "0.19.3" }
+tket-qsystem = { path = "../tket-qsystem", version = "0.25.3", features = [
     "llvm",
 ] }
 

--- a/tket-py/Cargo.toml
+++ b/tket-py/Cargo.toml
@@ -20,11 +20,11 @@ test = false
 bench = false
 
 [dependencies]
-tket = { path = "../tket", version = "0.19.2", features = [
+tket = { path = "../tket", version = "0.19.3", features = [
     "portmatching",
     "binary-eccs",
 ] }
-tket-qsystem = { path = "../tket-qsystem", version = "0.25.2" }
+tket-qsystem = { path = "../tket-qsystem", version = "0.25.3" }
 tket1-passes = { path = "../tket1-passes", version = "0.0.0" }
 
 derive_more = { workspace = true, features = ["into", "from"] }

--- a/tket-qec/Cargo.toml
+++ b/tket-qec/Cargo.toml
@@ -20,4 +20,4 @@ workspace = true
 hugr.workspace = true
 semver = "1.0.28"
 strum = { workspace = true, features = ["derive"] }
-tket-qsystem = { version = "0.25.2", path = "../tket-qsystem" }
+tket-qsystem = { version = "0.25.3", path = "../tket-qsystem" }

--- a/tket-qsystem/CHANGELOG.md
+++ b/tket-qsystem/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## [0.25.3](https://github.com/quantinuum/tket2/compare/tket-qsystem-v0.25.2...tket-qsystem-v0.25.3) - 2026-07-22
+
+### New Features
+
+- Frontend support for Helios platform configuration ([#1848](https://github.com/quantinuum/tket2/pull/1848))
+
 ## [0.25.2](https://github.com/quantinuum/tket2/compare/tket-qsystem-v0.25.1...tket-qsystem-v0.25.2) - 2026-07-17
 
 ### Bug Fixes

--- a/tket-qsystem/Cargo.toml
+++ b/tket-qsystem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tket-qsystem"
-version = "0.25.2"
+version = "0.25.3"
 edition.workspace = true
 rust-version.workspace = true
 
@@ -23,7 +23,7 @@ name = "tket-qsystem"
 required-features = ["cli"]
 
 [dependencies]
-tket = { path = "../tket", version = "0.19.2" }
+tket = { path = "../tket", version = "0.19.3" }
 
 hugr.workspace = true
 hugr-core.workspace = true

--- a/tket/CHANGELOG.md
+++ b/tket/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [0.19.3](https://github.com/quantinuum/tket2/compare/tket-v0.19.2...tket-v0.19.3) - 2026-07-22
+
+### Performance
+
+- Improve rule evaluation order in dataflow analysis ([#1806](https://github.com/quantinuum/tket2/pull/1806))
+- Pre-compute edge neighbours in dataflow analysis ([#1805](https://github.com/quantinuum/tket2/pull/1805))
+
 ## [0.19.1](https://github.com/quantinuum/tket2/compare/tket-v0.19.0...tket-v0.19.1) - 2026-07-06
 
 ### Performance

--- a/tket/Cargo.toml
+++ b/tket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tket"
-version = "0.19.2"
+version = "0.19.3"
 edition = { workspace = true }
 rust-version = { workspace = true }
 

--- a/tket1-passes/Cargo.toml
+++ b/tket1-passes/Cargo.toml
@@ -31,7 +31,7 @@ rayon.workspace = true
 
 # Used for integration tests
 hugr = { workspace = true }
-tket = { path = "../tket", version = "0.19.2" }
+tket = { path = "../tket", version = "0.19.3" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Backported release compatible with guppy v0.21.


### `tket-qsystem 0.25.3`

```
### New Features

- Frontend support for Helios platform configuration ([#1848](https://github.com/quantinuum/tket2/pull/1848))
```

### `tket 0.19.3`

```
### Performance

- Improve rule evaluation order in dataflow analysis ([#1806](https://github.com/quantinuum/tket2/pull/1806))
- Pre-compute edge neighbours in dataflow analysis ([#1805](https://github.com/quantinuum/tket2/pull/1805))
```