### PR TITLE
chore: Release tket-exts 0.12.4 backport

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
     "tket-py": "0.13.2",
     "tket-eccs": "0.5.1",
-    "tket-exts": "0.12.3",
+    "tket-exts": "0.12.4",
     "qis-compiler": "0.2.11"
 }

--- a/tket-exts/CHANGELOG.md
+++ b/tket-exts/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.12.4](https://github.com/Quantinuum/tket2/compare/tket-exts-v0.12.3...tket-exts-v0.12.4) (2026-07-22)
+
+
+### Features
+
+* Add multiple platform-specific qsystem extensions ([#1567](https://github.com/Quantinuum/tket2/issues/1567)) ([b60553f](https://github.com/Quantinuum/tket2/commit/b60553fec5e81b698c75916658bae7d1c527907e))
+
 ## [0.12.3](https://github.com/Quantinuum/tket2/compare/tket-exts-v0.12.2...tket-exts-v0.12.3) (2026-04-07)
 
 

--- a/tket-exts/pyproject.toml
+++ b/tket-exts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tket-exts"
-version = "0.12.3"
+version = "0.12.4"
 requires-python = ">=3.10"
 description = "Python interface for hugr extensions offered by tket"
 license = { file = "LICENCE" }

--- a/tket-exts/src/tket_exts/__init__.py
+++ b/tket-exts/src/tket_exts/__init__.py
@@ -25,7 +25,7 @@ from tket_exts import tket
 
 # This is updated by our release-please workflow, triggered by this
 # annotation: x-release-please-version
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 
 __all__ = [
     "bool",

--- a/tket-py/pyproject.toml
+++ b/tket-py/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dependencies = [
     'hugr ~= 0.16.0',
     'tket_eccs ~= 0.5.1',
-    'tket_exts >= 0.12.3, <0.13',
+    'tket_exts >= 0.12.4, <0.13',
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3133,7 +3133,7 @@ source = { editable = "tket-eccs" }
 
 [[package]]
 name = "tket-exts"
-version = "0.12.3"
+version = "0.12.4"
 source = { editable = "tket-exts" }
 dependencies = [
     { name = "hugr" },


### PR DESCRIPTION
Backported change. It was required for the `tket-py 0.12.3` release.