### PR TITLE
docs: Add missing docstrings

### DIFF
--- a/qis-compiler/rust/lib.rs
+++ b/qis-compiler/rust/lib.rs
@@ -342,6 +342,7 @@ fn wrap_main<'c>(
     Ok(())
 }
 
+/// Compilation arguments.
 #[derive(Debug)]
 pub struct CompileArgs<'a> {
     /// Entry point symbol
@@ -361,6 +362,7 @@ pub struct CompileArgs<'a> {
 }
 
 impl<'a> CompileArgs<'a> {
+    /// Create compiler arguments.
     pub fn new(
         name: &impl ToString,
         target_machine: &'a TargetMachine,


### PR DESCRIPTION
Clippy checks were failing because of these missing docstrings.