### PR TITLE
chore: Fix ruff checks on pg-libs in the pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,10 +109,10 @@ repos:
         language: system
         files: ^pg-libs/.*\.py$
         pass_filenames: false
-      - id: ruff-check-pg-libs
+      - id: ruff-fix-pg-libs
         name: ruff (pg-libs)
-        description: Check pg-libs python code with `ruff`.
-        entry: sh -c "cd pg-libs && just check-python"
+        description: Fix pg-libs python code with `ruff`.
+        entry: sh -c "cd pg-libs && just fix-python"
         language: system
         files: ^pg-libs/.*\.py$
         pass_filenames: false


### PR DESCRIPTION
I use the `--fix` variant since that is what the other pre-commit also uses (and I consider ruff fixes to be safe to apply).

Closes #1889