### PR TITLE
feat: Extract multiple pytket circuits from a hugr region

### DIFF
--- a/tket-py/test/test_errors.py
+++ b/tket-py/test/test_errors.py
@@ -6,7 +6,7 @@ from tket._state import CompilationState
 
 
 def test_unresolved_op() -> None:
-    """Define a function with an unresolved op, and try to convert it to a CompilationState."""
+    """Define a function with an unresolved op, and try to convert it to a CompilationState"""
     fn = Function("unresolved_op", [tys.Qubit])
     [q] = fn.inputs()
     [q] = fn.add_op(

--- a/tket-qsystem/src/pytket/tests.rs
+++ b/tket-qsystem/src/pytket/tests.rs
@@ -297,7 +297,7 @@ fn circuit_standalone_roundtrip(#[case] hugr: Hugr) {
     let encoded = EncodedCircuit::new_standalone(&hugr, encode_options.clone())
         .unwrap_or_else(|e| panic!("{e}"));
 
-    assert!(encoded.contains_circuit(hugr.entrypoint()));
+    assert!(encoded.contains_region(hugr.entrypoint()));
     assert_eq!(encoded.len(), 1);
 
     // Re-encode the EncodedCircuit
@@ -313,7 +313,11 @@ fn circuit_standalone_roundtrip(#[case] hugr: Hugr) {
         .unwrap_or_else(|e| panic!("{e}"));
 
     // Extract the head pytket circuit, and re-encode it on its own.
-    let ser: &SerialCircuit = &encoded[hugr.entrypoint()];
+    let mut circuits = encoded.get_circuits(hugr.entrypoint());
+    let (_, ser) = circuits
+        .next()
+        .expect("standalone encoding has one circuit");
+    assert!(circuits.next().is_none());
     let deser: Hugr = ser.decode(decode_options).unwrap_or_else(|e| panic!("{e}"));
 
     let deser_sig = deser
@@ -355,7 +359,7 @@ fn encoded_circuit_roundtrip(#[case] hugr: Hugr, #[case] num_circuits: usize) {
 
     let encoded = EncodedCircuit::new(&hugr, encode_options).unwrap_or_else(|e| panic!("{e}"));
 
-    assert!(encoded.contains_circuit(hugr.entrypoint()));
+    assert!(encoded.contains_region(hugr.entrypoint()));
     assert_eq!(encoded.len(), num_circuits);
 
     let mut deser = hugr.clone();
@@ -397,7 +401,7 @@ fn regression_dropped_order_edge(circ_dropped_order_edge: Hugr) {
         .with_subcircuits(true)
         .with_config(qsystem_encoder_config(QSystemPlatform::Helios));
     let encoded = EncodedCircuit::new(&hugr, encode_options).unwrap_or_else(|e| panic!("{e}"));
-    assert!(encoded.contains_circuit(hugr.entrypoint()));
+    assert!(encoded.contains_region(hugr.entrypoint()));
 
     let mut deser = hugr.clone();
     encoded

--- a/tket/src/serialize/pytket.rs
+++ b/tket/src/serialize/pytket.rs
@@ -9,7 +9,7 @@ pub mod extension;
 pub mod opaque;
 mod options;
 
-pub use circuit::EncodedCircuit;
+pub use circuit::{EncodedCircuit, EncodedCircuitId};
 pub use config::{
     PytketDecoderConfig, PytketEncoderConfig, TypeTranslatorSet, add_default_decoders,
     default_decoder_config, default_encoder_config,
@@ -140,7 +140,7 @@ impl TKETDecode for SerialCircuit {
         options: DecodeOptions,
     ) -> Result<Node, Self::DecodeError> {
         let mut decoder = PytketDecoderContext::new(self, hugr, target, options, None)?;
-        decoder.run_decoder(&self.commands, None)?;
+        decoder.run_decoder(&self.commands)?;
         Ok(decoder.finish(None)?.node())
     }
 
@@ -160,9 +160,14 @@ impl TKETDecode for SerialCircuit {
 
         let mut encoded = EncodedCircuit::new_standalone(hugr, options)?;
 
-        let serial_circ = encoded
-            .get_circuit_mut(hugr.entrypoint())
+        let mut circuits = encoded.get_circuits_mut(hugr.entrypoint());
+        let (_, serial_circ) = circuits
+            .next()
             .expect("Hugr entrypoint must be a dataflow region");
+        debug_assert!(
+            circuits.next().is_none(),
+            "standalone encoding must produce one circuit"
+        );
         Ok(std::mem::take(serial_circ))
     }
 }

--- a/tket/src/serialize/pytket/circuit.rs
+++ b/tket/src/serialize/pytket/circuit.rs
@@ -38,12 +38,13 @@ use super::opaque::OpaqueSubgraphs;
 /// [`EncodedCircuit::ensure_standalone`].
 #[derive(Debug, Clone)]
 pub struct EncodedCircuit<Node: HugrNode> {
-    /// Circuits encoded from independent dataflow regions in the HUGR.
+    /// Circuit segments grouped by their originating dataflow region.
     ///
     /// These correspond to sections of the HUGR that can be optimized
     /// independently.
     ///
-    /// Ordered as a depth-first pre-order.
+    /// Regions are ordered as a depth-first pre-order; segments retain their
+    /// execution order within each region.
     circuits: IndexMap<Node, EncodedCircuitInfo>,
     /// Sets of subgraphs in the HUGR that have been encoded as opaque barriers
     /// in the pytket circuit.
@@ -53,13 +54,30 @@ pub struct EncodedCircuit<Node: HugrNode> {
     opaque_subgraphs: OpaqueSubgraphs<Node>,
 }
 
+/// Identifies one pytket circuit segment within an encoded HUGR region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EncodedCircuitId<Node> {
+    /// The HUGR dataflow region from which the segment was encoded.
+    pub region: Node,
+    /// The segment's zero-based position within the region.
+    pub segment: usize,
+}
+
 /// Information stored about a pytket circuit encoded from a HUGR region.
 #[derive(Debug, Default, Clone)]
 pub(super) struct EncodedCircuitInfo {
-    /// The serial circuit encoded from the region.
-    pub serial_circuit: SerialCircuit,
-    /// Information about any unsupported nodes in the region that could not be encoded as a pytket command.
-    pub additional_nodes_and_wires: AdditionalNodesAndWires,
+    /// Runs of pytket commands encoded from the region.
+    pub serial_circuits: Vec<SerialCircuit>,
+    /// Opaque subgraphs that must be restored before, between, or after the
+    /// serial circuits.
+    ///
+    /// This always contains one more entry than [`Self::serial_circuits`].
+    pub boundaries: Vec<EncodedCircuitBoundary>,
+    /// List of wires that directly connected the input node to the output node in the encoded region,
+    /// and were not encoded in [`serial_circuits`].
+    ///
+    /// We just store the input nodes's output port and output node's input port here.
+    pub straight_through_wires: Vec<StraightThroughWire>,
     /// List of parameters in the pytket circuit in the order they appear in the
     /// hugr input.
     ///
@@ -74,19 +92,51 @@ pub(super) struct EncodedCircuitInfo {
     pub output_bits: Vec<tket_json_rs::register::ElementId>,
 }
 
-/// Nodes and edges from the original region that could not be encoded into the
-/// pytket circuit, as they cannot be attached to a pytket command.
-#[derive(Debug, Default, Clone)]
-pub(super) struct AdditionalNodesAndWires {
-    /// Subgraphs of the region that could not be encoded as a pytket commands,
-    /// and have no qubit/bits in their boundary that could be used to emit an
-    /// opaque barrier command in the [`serial_circuit`].
-    pub additional_subgraphs: Vec<AdditionalSubgraph>,
-    /// List of wires that directly connected the input node to the output node in the encoded region,
-    /// and were not encoded in [`serial_circuit`].
+impl EncodedCircuitInfo {
+    /// Initialize a pytket circuit for a decoder
+    /// for every segment in this region.
     ///
-    /// We just store the input nodes's output port and output node's input port here.
-    pub straight_through_wires: Vec<StraightThroughWire>,
+    /// Callers may add registers to an individual segment, so the initialization
+    /// circuit contains the deterministic union of registers in first-use order.
+    fn decoder_initialization_circuit(&self) -> SerialCircuit {
+        let mut initialization_circuit = self
+            .serial_circuits
+            .first()
+            .cloned()
+            .expect("encoded regions always contain a circuit segment");
+        for circuit in self.serial_circuits.iter().skip(1) {
+            for qubit in &circuit.qubits {
+                if !initialization_circuit.qubits.contains(qubit) {
+                    initialization_circuit.qubits.push(qubit.clone());
+                }
+            }
+            for bit in &circuit.bits {
+                if !initialization_circuit.bits.contains(bit) {
+                    initialization_circuit.bits.push(bit.clone());
+                }
+            }
+        }
+        initialization_circuit.commands.clear();
+        initialization_circuit.phase = "0".to_owned();
+        initialization_circuit.implicit_permutation.clear();
+        initialization_circuit
+    }
+
+    /// Whether the region requires its original HUGR context for decoding.
+    fn has_external_boundaries(&self) -> bool {
+        self.boundaries
+            .iter()
+            .any(|boundary| !boundary.external_subgraphs.is_empty())
+    }
+}
+
+/// Unsupported subgraphs positioned at one boundary between serial circuits.
+#[derive(Debug, Default, Clone)]
+pub(super) struct EncodedCircuitBoundary {
+    /// Subgraphs of the region that could not be encoded as pytket commands,
+    /// and have no qubit/bits in their boundary that could be used to emit an
+    /// opaque barrier command in an adjacent serial circuit.
+    pub external_subgraphs: Vec<AdditionalSubgraph>,
 }
 
 /// A subgraph of the encoded circuit that could not be associated to any qubit or bit register in the pytket circuit.
@@ -94,7 +144,7 @@ pub(super) struct AdditionalNodesAndWires {
 pub(super) struct AdditionalSubgraph {
     /// The subgraph of the region that could not be encoded as a pytket command,
     /// and has no qubit/bits in its boundary that could be used to emit an opaque
-    /// barrier command in the [`serial_circuit`].
+    /// barrier command in an adjacent circuit segment.
     pub id: SubgraphId,
     /// Parameter expression inputs to the `subgraph`.
     pub params: Vec<String>,
@@ -218,16 +268,27 @@ impl EncodedCircuit<Node> {
             // Run the decoder, generating a new function with the extracted definition.
             //
             // Unsupported subgraphs of the original region will be transplanted here.
+            let initialization_circuit = encoded.decoder_initialization_circuit();
             let mut decoder = PytketDecoderContext::new(
-                &encoded.serial_circuit,
+                &initialization_circuit,
                 hugr,
                 DecodeInsertionTarget::Function { fn_name: None },
                 options,
                 Some(&self.opaque_subgraphs),
             )?;
-            decoder.run_decoder(
-                &encoded.serial_circuit.commands,
-                Some(&encoded.additional_nodes_and_wires),
+            decoder.reserve_boundary_parameters(&encoded.boundaries);
+            decoder.connect_straight_through_wires(&encoded.straight_through_wires);
+            for (segment, boundary) in encoded.serial_circuits.iter().zip(&encoded.boundaries) {
+                decoder.insert_boundary(boundary)?;
+                decoder.add_serial_circuit_phase(segment)?;
+                decoder.run_commands(&segment.commands)?;
+                decoder.apply_implicit_permutation(segment)?;
+            }
+            decoder.insert_boundary(
+                encoded
+                    .boundaries
+                    .last()
+                    .expect("encoded region has a trailing boundary"),
             )?;
             let decoded_node = decoder.finish(Some(encoded))?.node();
 
@@ -382,7 +443,8 @@ impl<Node: HugrNode> EncodedCircuit<Node> {
                     .iter()
                     .all(|cmd| cmd.op.op_type == tket_json_rs::OpType::Barrier)
             };
-            if !options.keep_empty_circuits && is_empty_circuit(&encoded.serial_circuit) {
+            if !options.keep_empty_circuits && encoded.serial_circuits.iter().all(is_empty_circuit)
+            {
                 continue;
             }
 
@@ -412,27 +474,35 @@ impl<Node: HugrNode> EncodedCircuit<Node> {
         fn_name: Option<String>,
         options: DecodeOptions,
     ) -> Result<Hugr, PytketDecodeError> {
-        if !self.contains_circuit(region) {
+        if !self.contains_region(region) {
             return Err(PytketDecodeErrorInner::NotAnEncodedRegion {
                 region: region.to_string(),
             }
             .wrap());
         }
         let encoded_info = &self.circuits[&region];
-        let serial_circuit = &encoded_info.serial_circuit;
+        let serial_circuit = encoded_info
+            .serial_circuits
+            .first()
+            .expect("encoded regions always contain a circuit segment");
 
-        if self.len() > 1 {
-            unimplemented!(
-                "Reassembling an `EncodedCircuit` with nested subcircuits is not yet implemented."
-            );
-        };
+        if self.circuits.len() > 1 {
+            return Err(PytketDecodeError::custom(
+                "Reassembling an `EncodedCircuit` with nested subcircuits is not yet implemented.",
+            ));
+        }
+        if encoded_info.serial_circuits.len() != 1 || encoded_info.has_external_boundaries() {
+            return Err(PytketDecodeError::custom(
+                "A segmented encoded region requires its original HUGR context; use `reassemble_inplace`.",
+            ));
+        }
 
         let mut hugr = Hugr::new();
         let target = DecodeInsertionTarget::Function { fn_name };
 
         let mut decoder =
             PytketDecoderContext::new(serial_circuit, &mut hugr, target, options, None)?;
-        decoder.run_decoder(&serial_circuit.commands, None)?;
+        decoder.run_decoder(&serial_circuit.commands)?;
         decoder.finish(Some(encoded_info))?;
         Ok(hugr)
     }
@@ -469,36 +539,117 @@ impl<Node: HugrNode> EncodedCircuit<Node> {
             Ok(())
         }
 
+        if self
+            .circuits
+            .values()
+            .any(EncodedCircuitInfo::has_external_boundaries)
+        {
+            return Err(PytketEncodeError::custom(
+                "A region split by register-free opaque subgraphs cannot be represented as a standalone `SerialCircuit`.",
+            ));
+        }
+
         for encoded in self.circuits.values_mut() {
-            make_commands_standalone(
-                &mut encoded.serial_circuit.commands,
-                &self.opaque_subgraphs,
-                hugr,
-            )?;
+            for circuit in &mut encoded.serial_circuits {
+                make_commands_standalone(&mut circuit.commands, &self.opaque_subgraphs, hugr)?;
+            }
         }
         Ok(())
     }
 
-    /// Returns `true` if there is an encoded pytket circuit for the given region.
-    pub fn contains_circuit(&self, region: Node) -> bool {
+    /// Returns `true` if the given region has any encoded circuit segments.
+    pub fn contains_region(&self, region: Node) -> bool {
         self.circuits.contains_key(&region)
     }
 
-    /// Returns the circuit encoded for the given region, or `None` if there is no circuit for that region.
+    /// Returns `true` if there is an encoded pytket circuit for the given region.
+    #[deprecated(
+        since = "0.21.2",
+        note = "use `contains_region`, since a region may contain multiple circuits"
+    )]
+    pub fn contains_circuit(&self, region: Node) -> bool {
+        self.contains_region(region)
+    }
+
+    /// Returns the first circuit segment encoded for the given region.
+    ///
+    /// This method predates segmented regions and silently ignores every
+    /// segment after the first.
+    #[deprecated(since = "0.21.2", note = "use `get_circuits` or `get_segment`")]
     pub fn get_circuit(&self, region: Node) -> Option<&SerialCircuit> {
-        let circ_info = self.circuits.get(&region)?;
-        Some(&circ_info.serial_circuit)
+        self.get_circuits(region).next().map(|(_, circuit)| circuit)
     }
 
-    /// Returns the circuit encoded for the given region, or `None` if there is no circuit for that region.
+    /// Returns the first mutable circuit segment encoded for the given region.
+    ///
+    /// This method predates segmented regions and silently ignores every
+    /// segment after the first.
+    #[deprecated(since = "0.21.2", note = "use `get_circuits_mut` or `get_segment_mut`")]
     pub fn get_circuit_mut(&mut self, region: Node) -> Option<&mut SerialCircuit> {
-        let circ_info = self.circuits.get_mut(&region)?;
-        Some(&mut circ_info.serial_circuit)
+        self.get_circuits_mut(region)
+            .next()
+            .map(|(_, circuit)| circuit)
     }
 
-    /// Returns the number of encoded pytket circuits.
+    /// Returns the circuit segments encoded for a region, in execution order.
+    ///
+    /// Returns an empty iterator when the region was not encoded.
+    pub fn get_circuits(
+        &self,
+        region: Node,
+    ) -> impl Iterator<Item = (EncodedCircuitId<Node>, &SerialCircuit)> {
+        self.circuits
+            .get(&region)
+            .into_iter()
+            .flat_map(move |info| {
+                info.serial_circuits
+                    .iter()
+                    .enumerate()
+                    .map(move |(segment, circuit)| (EncodedCircuitId { region, segment }, circuit))
+            })
+    }
+
+    /// Returns mutable circuit segments encoded for a region, in execution
+    /// order.
+    ///
+    /// Returns an empty iterator when the region was not encoded.
+    pub fn get_circuits_mut(
+        &mut self,
+        region: Node,
+    ) -> impl Iterator<Item = (EncodedCircuitId<Node>, &mut SerialCircuit)> {
+        self.circuits
+            .get_mut(&region)
+            .into_iter()
+            .flat_map(move |info| {
+                info.serial_circuits
+                    .iter_mut()
+                    .enumerate()
+                    .map(move |(segment, circuit)| (EncodedCircuitId { region, segment }, circuit))
+            })
+    }
+
+    /// Returns a circuit segment by its region and position.
+    pub fn get_segment(&self, id: EncodedCircuitId<Node>) -> Option<&SerialCircuit> {
+        self.circuits
+            .get(&id.region)?
+            .serial_circuits
+            .get(id.segment)
+    }
+
+    /// Returns a mutable circuit segment by its region and position.
+    pub fn get_segment_mut(&mut self, id: EncodedCircuitId<Node>) -> Option<&mut SerialCircuit> {
+        self.circuits
+            .get_mut(&id.region)?
+            .serial_circuits
+            .get_mut(id.segment)
+    }
+
+    /// Returns the total number of encoded pytket circuit segments.
     pub fn len(&self) -> usize {
-        self.circuits.len()
+        self.circuits
+            .values()
+            .map(|region| region.serial_circuits.len())
+            .sum()
     }
 
     /// Returns whether the encoded circuit is empty.
@@ -506,49 +657,113 @@ impl<Node: HugrNode> EncodedCircuit<Node> {
         self.circuits.is_empty()
     }
 
-    /// Returns an iterator over the encoded pytket circuits.
-    pub fn iter(&self) -> impl Iterator<Item = (Node, &SerialCircuit)> {
-        self.circuits
-            .iter()
-            .map(|(&n, circ)| (n, &circ.serial_circuit))
+    /// Returns an iterator over every encoded pytket circuit segment and its ID.
+    pub fn iter(&self) -> impl Iterator<Item = (EncodedCircuitId<Node>, &SerialCircuit)> {
+        self.circuits.iter().flat_map(|(&node, region)| {
+            region
+                .serial_circuits
+                .iter()
+                .enumerate()
+                .map(move |(segment, circuit)| {
+                    (
+                        EncodedCircuitId {
+                            region: node,
+                            segment,
+                        },
+                        circuit,
+                    )
+                })
+        })
     }
 
-    /// Returns a mutable iterator over the encoded pytket circuits.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (Node, &mut SerialCircuit)> {
-        self.circuits
-            .iter_mut()
-            .map(|(&n, circ)| (n, &mut circ.serial_circuit))
+    /// Returns a mutable iterator over every circuit segment and its ID.
+    pub fn iter_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (EncodedCircuitId<Node>, &mut SerialCircuit)> {
+        self.circuits.iter_mut().flat_map(|(&node, region)| {
+            region
+                .serial_circuits
+                .iter_mut()
+                .enumerate()
+                .map(move |(segment, circuit)| {
+                    (
+                        EncodedCircuitId {
+                            region: node,
+                            segment,
+                        },
+                        circuit,
+                    )
+                })
+        })
     }
 }
 
 impl<Node: HugrNode + Send + Sync> EncodedCircuit<Node> {
-    /// Returns a parallel iterator over the encoded pytket circuits.
-    pub fn par_iter(&self) -> impl ParallelIterator<Item = (Node, &SerialCircuit)> {
-        self.circuits
-            .par_iter()
-            .map(|(&n, circ)| (n, &circ.serial_circuit))
+    /// Returns a parallel iterator over every circuit segment and its ID.
+    pub fn par_iter(
+        &self,
+    ) -> impl ParallelIterator<Item = (EncodedCircuitId<Node>, &SerialCircuit)> {
+        self.circuits.par_iter().flat_map_iter(|(&node, region)| {
+            region
+                .serial_circuits
+                .iter()
+                .enumerate()
+                .map(move |(segment, circuit)| {
+                    (
+                        EncodedCircuitId {
+                            region: node,
+                            segment,
+                        },
+                        circuit,
+                    )
+                })
+        })
     }
 
-    /// Returns a parallel mutable iterator over the encoded pytket circuits.
-    pub fn par_iter_mut(&mut self) -> impl ParallelIterator<Item = (Node, &mut SerialCircuit)> {
+    /// Returns a parallel mutable iterator over every circuit segment and its ID.
+    pub fn par_iter_mut(
+        &mut self,
+    ) -> impl ParallelIterator<Item = (EncodedCircuitId<Node>, &mut SerialCircuit)> {
         self.circuits
             .par_iter_mut()
-            .map(|(&n, circ)| (n, &mut circ.serial_circuit))
+            .flat_map_iter(|(&node, region)| {
+                region
+                    .serial_circuits
+                    .iter_mut()
+                    .enumerate()
+                    .map(move |(segment, circuit)| {
+                        (
+                            EncodedCircuitId {
+                                region: node,
+                                segment,
+                            },
+                            circuit,
+                        )
+                    })
+            })
     }
 }
 
-impl<Node: HugrNode> Index<Node> for EncodedCircuit<Node> {
+impl<Node: HugrNode> Index<EncodedCircuitId<Node>> for EncodedCircuit<Node> {
     type Output = SerialCircuit;
 
-    fn index(&self, index: Node) -> &Self::Output {
-        self.get_circuit(index)
-            .unwrap_or_else(|| panic!("Indexing into a circuit that was not encoded: {index}"))
+    fn index(&self, index: EncodedCircuitId<Node>) -> &Self::Output {
+        self.get_segment(index).unwrap_or_else(|| {
+            panic!(
+                "Indexing an encoded circuit segment that does not exist: {}:{}",
+                index.region, index.segment
+            )
+        })
     }
 }
 
-impl<Node: HugrNode> IndexMut<Node> for EncodedCircuit<Node> {
-    fn index_mut(&mut self, index: Node) -> &mut Self::Output {
-        self.get_circuit_mut(index)
-            .unwrap_or_else(|| panic!("Indexing into a circuit that was not encoded: {index}"))
+impl<Node: HugrNode> IndexMut<EncodedCircuitId<Node>> for EncodedCircuit<Node> {
+    fn index_mut(&mut self, index: EncodedCircuitId<Node>) -> &mut Self::Output {
+        self.get_segment_mut(index).unwrap_or_else(|| {
+            panic!(
+                "Indexing an encoded circuit segment that does not exist: {}:{}",
+                index.region, index.segment
+            )
+        })
     }
 }

--- a/tket/src/serialize/pytket/circuit.rs
+++ b/tket/src/serialize/pytket/circuit.rs
@@ -661,6 +661,7 @@ impl<Node: HugrNode> EncodedCircuit<Node> {
     ///
     /// A region containing multiple segments appears once for each segment.
     // TODO: Update signature to return `(EncodedCircuitId<Node>, &SerialCircuit)` in a breaking release.
+    // See https://github.com/Quantinuum/tket2/issues/1901
     pub fn iter(&self) -> impl Iterator<Item = (Node, &SerialCircuit)> {
         self.circuits.iter().flat_map(|(&node, region)| {
             region
@@ -674,6 +675,7 @@ impl<Node: HugrNode> EncodedCircuit<Node> {
     ///
     /// A region containing multiple segments appears once for each segment.
     // TODO: Update signature to return `(EncodedCircuitId<Node>, &mut SerialCircuit)` in a breaking release.
+    // See https://github.com/Quantinuum/tket2/issues/1901
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (Node, &mut SerialCircuit)> {
         self.circuits.iter_mut().flat_map(|(&node, region)| {
             region
@@ -689,6 +691,7 @@ impl<Node: HugrNode + Send + Sync> EncodedCircuit<Node> {
     ///
     /// A region containing multiple segments appears once for each segment.
     // TODO: Update signature to return `(EncodedCircuitId<Node>, &SerialCircuit)` in a breaking release.
+    // See https://github.com/Quantinuum/tket2/issues/1901
     pub fn par_iter(&self) -> impl ParallelIterator<Item = (Node, &SerialCircuit)> {
         self.circuits.par_iter().flat_map_iter(|(&node, region)| {
             region
@@ -702,6 +705,7 @@ impl<Node: HugrNode + Send + Sync> EncodedCircuit<Node> {
     ///
     /// A region containing multiple segments appears once for each segment.
     // TODO: Update signature to return `(EncodedCircuitId<Node>, &mut SerialCircuit)` in a breaking release.
+    // See https://github.com/Quantinuum/tket2/issues/1901
     pub fn par_iter_mut(&mut self) -> impl ParallelIterator<Item = (Node, &mut SerialCircuit)> {
         self.circuits
             .par_iter_mut()

--- a/tket/src/serialize/pytket/circuit.rs
+++ b/tket/src/serialize/pytket/circuit.rs
@@ -657,90 +657,84 @@ impl<Node: HugrNode> EncodedCircuit<Node> {
         self.circuits.is_empty()
     }
 
-    /// Returns an iterator over every encoded pytket circuit segment and its ID.
-    pub fn iter(&self) -> impl Iterator<Item = (EncodedCircuitId<Node>, &SerialCircuit)> {
+    /// Returns an iterator over every encoded pytket circuit segment and its region.
+    ///
+    /// A region containing multiple segments appears once for each segment.
+    // TODO: Update signature to return `(EncodedCircuitId<Node>, &SerialCircuit)` in a breaking release.
+    pub fn iter(&self) -> impl Iterator<Item = (Node, &SerialCircuit)> {
         self.circuits.iter().flat_map(|(&node, region)| {
             region
                 .serial_circuits
                 .iter()
-                .enumerate()
-                .map(move |(segment, circuit)| {
-                    (
-                        EncodedCircuitId {
-                            region: node,
-                            segment,
-                        },
-                        circuit,
-                    )
-                })
+                .map(move |circuit| (node, circuit))
         })
     }
 
-    /// Returns a mutable iterator over every circuit segment and its ID.
-    pub fn iter_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (EncodedCircuitId<Node>, &mut SerialCircuit)> {
+    /// Returns a mutable iterator over every circuit segment and its region.
+    ///
+    /// A region containing multiple segments appears once for each segment.
+    // TODO: Update signature to return `(EncodedCircuitId<Node>, &mut SerialCircuit)` in a breaking release.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (Node, &mut SerialCircuit)> {
         self.circuits.iter_mut().flat_map(|(&node, region)| {
             region
                 .serial_circuits
                 .iter_mut()
-                .enumerate()
-                .map(move |(segment, circuit)| {
-                    (
-                        EncodedCircuitId {
-                            region: node,
-                            segment,
-                        },
-                        circuit,
-                    )
-                })
+                .map(move |circuit| (node, circuit))
         })
     }
 }
 
 impl<Node: HugrNode + Send + Sync> EncodedCircuit<Node> {
-    /// Returns a parallel iterator over every circuit segment and its ID.
-    pub fn par_iter(
-        &self,
-    ) -> impl ParallelIterator<Item = (EncodedCircuitId<Node>, &SerialCircuit)> {
+    /// Returns a parallel iterator over every circuit segment and its region.
+    ///
+    /// A region containing multiple segments appears once for each segment.
+    // TODO: Update signature to return `(EncodedCircuitId<Node>, &SerialCircuit)` in a breaking release.
+    pub fn par_iter(&self) -> impl ParallelIterator<Item = (Node, &SerialCircuit)> {
         self.circuits.par_iter().flat_map_iter(|(&node, region)| {
             region
                 .serial_circuits
                 .iter()
-                .enumerate()
-                .map(move |(segment, circuit)| {
-                    (
-                        EncodedCircuitId {
-                            region: node,
-                            segment,
-                        },
-                        circuit,
-                    )
-                })
+                .map(move |circuit| (node, circuit))
         })
     }
 
-    /// Returns a parallel mutable iterator over every circuit segment and its ID.
-    pub fn par_iter_mut(
-        &mut self,
-    ) -> impl ParallelIterator<Item = (EncodedCircuitId<Node>, &mut SerialCircuit)> {
+    /// Returns a parallel mutable iterator over every circuit segment and its region.
+    ///
+    /// A region containing multiple segments appears once for each segment.
+    // TODO: Update signature to return `(EncodedCircuitId<Node>, &mut SerialCircuit)` in a breaking release.
+    pub fn par_iter_mut(&mut self) -> impl ParallelIterator<Item = (Node, &mut SerialCircuit)> {
         self.circuits
             .par_iter_mut()
             .flat_map_iter(|(&node, region)| {
                 region
                     .serial_circuits
                     .iter_mut()
-                    .enumerate()
-                    .map(move |(segment, circuit)| {
-                        (
-                            EncodedCircuitId {
-                                region: node,
-                                segment,
-                            },
-                            circuit,
-                        )
-                    })
+                    .map(move |circuit| (node, circuit))
             })
+    }
+}
+
+/// Backwards-compatible region indexing that ignores all but the first segment.
+/// This implementation will be removed in a breaking release.
+impl<Node: HugrNode> Index<Node> for EncodedCircuit<Node> {
+    type Output = SerialCircuit;
+
+    fn index(&self, index: Node) -> &Self::Output {
+        self.circuits
+            .get(&index)
+            .and_then(|region| region.serial_circuits.first())
+            .unwrap_or_else(|| panic!("Indexing into a circuit that was not encoded: {index}"))
+    }
+}
+
+/// Backwards-compatible mutable region indexing that ignores all but the first segment.
+/// This implementation will be removed in a breaking release.
+impl<Node: HugrNode> IndexMut<Node> for EncodedCircuit<Node> {
+    fn index_mut(&mut self, index: Node) -> &mut Self::Output {
+        self.circuits
+            .get_mut(&index)
+            .and_then(|region| region.serial_circuits.first_mut())
+            .unwrap_or_else(|| panic!("Indexing into a circuit that was not encoded: {index}"))
     }
 }
 

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -36,7 +36,7 @@ use crate::extension::global_phase::GlobalPhase;
 use crate::extension::rotation::rotation_type;
 use crate::metadata;
 use crate::serialize::pytket::circuit::{
-    AdditionalNodesAndWires, EncodedCircuitInfo, StraightThroughWire,
+    EncodedCircuitBoundary, EncodedCircuitInfo, StraightThroughWire,
 };
 use crate::serialize::pytket::config::PytketDecoderConfig;
 use crate::serialize::pytket::decoder::wires::WireTracker;
@@ -583,74 +583,26 @@ impl<'h> PytketDecoderContext<'h> {
     /// # Arguments
     ///
     /// - `commands`: The list of pytket commands to decode.
-    /// - `extra_subgraph`: An additional subgraph of the original Hugr that was
-    ///   not encoded as a pytket command, and must be decoded independently.
-    /// - `straight_through_wires`: A list of wires that directly connected the
-    ///   input node to the output node in the original region, and were not
-    ///   encoded in the pytket circuit or unsupported graphs.
-    ///   (They cannot be encoded in `extra_subgraph`).
     pub(super) fn run_decoder(
         &mut self,
         commands: &[circuit_json::Command],
-        extra_nodes_and_wires: Option<&AdditionalNodesAndWires>,
     ) -> Result<(), PytketDecodeError> {
-        // Add additional subgraphs and wires not encoded in commands.
-        let [input_node, output_node] = self.builder.io();
-        if let Some(extras) = extra_nodes_and_wires {
-            self.reserve_additional_subgraph_parameters(extras);
-
-            for extra_subgraph in &extras.additional_subgraphs {
-                let params = extra_subgraph
-                    .params
-                    .iter()
-                    .map(|p| self.load_half_turns(p))
-                    .collect_vec();
-
-                self.insert_external_subgraph(extra_subgraph.id, &[], &[], &params)
-                    .map_err(|e| e.hugr_op("External subgraph"))?;
-            }
-
-            // Add wires from the input node to the output node that didn't get encoded in commands.
-            for StraightThroughWire {
-                input_source,
-                output_target,
-            } in &extras.straight_through_wires
-            {
-                self.builder.hugr_mut().connect(
-                    input_node,
-                    *input_source,
-                    output_node,
-                    *output_target,
-                );
-            }
-        }
-
-        // Decode the pytket commands.
-        let config = self.config().clone();
-        for com in commands {
-            let op_type = com.op.op_type;
-            self.process_command(com, config.as_ref())
-                .map_err(|e| e.pytket_op(&op_type))?;
-        }
-
-        Ok(())
+        self.run_commands(commands)
     }
 
-    /// Reserve parameter variables used before pytket commands are decoded.
+    /// Reserve every parameter referenced by an external region boundary.
     ///
-    /// Additional subgraphs are restored first, so their expressions may refer
-    /// to parameters produced by a later opaque barrier. Genuine region inputs
-    /// are already registered and are left unchanged by the wire tracker.
-    fn reserve_additional_subgraph_parameters(&mut self, extras: &AdditionalNodesAndWires) {
+    /// Boundaries may use parameters produced later in the region, so all
+    /// names are reserved before any subgraph is transplanted.
+    pub(super) fn reserve_boundary_parameters(&mut self, boundaries: &[EncodedCircuitBoundary]) {
         let mut params = IndexSet::new();
-        extras
-            .additional_subgraphs
+        boundaries
             .iter()
+            .flat_map(|boundary| &boundary.external_subgraphs)
             .flat_map(|subgraph| &subgraph.params)
             .map(|param| PytketParam::parse(param))
             .for_each(|param| {
                 param.visit_input_variables(&mut |name| {
-                    // `pi` is loaded as a constant rather than routed as a parameter.
                     if name != "pi" {
                         params.insert(name.to_owned());
                     }
@@ -661,6 +613,79 @@ impl<'h> PytketDecoderContext<'h> {
             self.wire_tracker
                 .reserve_forward_parameter(param, &mut self.builder);
         }
+    }
+
+    /// Restore the unsupported subgraphs assigned to one circuit boundary.
+    pub(super) fn insert_boundary(
+        &mut self,
+        boundary: &EncodedCircuitBoundary,
+    ) -> Result<(), PytketDecodeError> {
+        for extra_subgraph in &boundary.external_subgraphs {
+            let params = extra_subgraph
+                .params
+                .iter()
+                .map(|p| self.load_half_turns(p))
+                .collect_vec();
+
+            self.insert_external_subgraph(extra_subgraph.id, &[], &[], &params)
+                .map_err(|e| e.hugr_op("External subgraph"))?;
+        }
+        Ok(())
+    }
+
+    /// Restore wires that directly bypassed the encoded contents of a region.
+    pub(super) fn connect_straight_through_wires(
+        &mut self,
+        straight_through_wires: &[StraightThroughWire],
+    ) {
+        let [input_node, output_node] = self.builder.io();
+        for &StraightThroughWire {
+            input_source,
+            output_target,
+        } in straight_through_wires
+        {
+            self.builder
+                .hugr_mut()
+                .connect(input_node, input_source, output_node, output_target);
+        }
+    }
+
+    /// Decode a contiguous list of pytket commands.
+    pub(super) fn run_commands(
+        &mut self,
+        commands: &[circuit_json::Command],
+    ) -> Result<(), PytketDecodeError> {
+        let config = self.config().clone();
+        for com in commands {
+            let op_type = com.op.op_type;
+            self.process_command(com, config.as_ref())
+                .map_err(|e| e.pytket_op(&op_type))?;
+        }
+
+        Ok(())
+    }
+
+    /// Decode a segment's circuit-level global phase.
+    pub(super) fn add_serial_circuit_phase(
+        &mut self,
+        serial_circuit: &SerialCircuit,
+    ) -> Result<(), PytketDecodeError> {
+        if !serial_circuit.phase.is_empty() && !PytketParam::parse(&serial_circuit.phase).is_zero()
+        {
+            let phase = self.load_half_turns(&serial_circuit.phase);
+            self.add_global_phase(phase)?;
+        }
+        Ok(())
+    }
+
+    /// Apply a segment's implicit qubit permutation before decoding the next
+    /// segment.
+    pub(super) fn apply_implicit_permutation(
+        &mut self,
+        serial_circuit: &SerialCircuit,
+    ) -> Result<(), PytketDecodeError> {
+        self.wire_tracker
+            .apply_implicit_permutation(&serial_circuit.implicit_permutation)
     }
 
     /// Add a tket1 [`circuit_json::Command`] from the serial circuit to the

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -590,6 +590,21 @@ impl<'h> PytketDecoderContext<'h> {
         self.run_commands(commands)
     }
 
+    /// Decode a contiguous list of pytket commands.
+    pub(super) fn run_commands(
+        &mut self,
+        commands: &[circuit_json::Command],
+    ) -> Result<(), PytketDecodeError> {
+        let config = self.config().clone();
+        for com in commands {
+            let op_type = com.op.op_type;
+            self.process_command(com, config.as_ref())
+                .map_err(|e| e.pytket_op(&op_type))?;
+        }
+
+        Ok(())
+    }
+
     /// Reserve every parameter referenced by an external region boundary.
     ///
     /// Boundaries may use parameters produced later in the region, so all
@@ -650,21 +665,6 @@ impl<'h> PytketDecoderContext<'h> {
                 .hugr_mut()
                 .connect(input_node, input_source, output_node, output_target);
         }
-    }
-
-    /// Decode a contiguous list of pytket commands.
-    pub(super) fn run_commands(
-        &mut self,
-        commands: &[circuit_json::Command],
-    ) -> Result<(), PytketDecodeError> {
-        let config = self.config().clone();
-        for com in commands {
-            let op_type = com.op.op_type;
-            self.process_command(com, config.as_ref())
-                .map_err(|e| e.pytket_op(&op_type))?;
-        }
-
-        Ok(())
     }
 
     /// Decode a segment's circuit-level global phase.

--- a/tket/src/serialize/pytket/decoder.rs
+++ b/tket/src/serialize/pytket/decoder.rs
@@ -603,6 +603,8 @@ impl<'h> PytketDecoderContext<'h> {
             .map(|param| PytketParam::parse(param))
             .for_each(|param| {
                 param.visit_input_variables(&mut |name| {
+                    // TODO: Avoid hardcoding this here by treating `pi` as a constant name in the parser.
+                    // See https://github.com/Quantinuum/tket2/issues/1900
                     if name != "pi" {
                         params.insert(name.to_owned());
                     }

--- a/tket/src/serialize/pytket/decoder/subgraph.rs
+++ b/tket/src/serialize/pytket/decoder/subgraph.rs
@@ -205,8 +205,20 @@ impl<'h> PytketDecoderContext<'h> {
             if let Some(counts) = self.config().type_to_pytket(ty).filter(|c| c.params == 0) {
                 // This port declares new bit/qubit outputs to be tracked by the decoder.
 
-                // Make sure to disconnect the old wire.
-                self.builder.hugr_mut().disconnect(*src, *src_port);
+                // Disconnect consumers outside the transplanted subgraph. The
+                // output port may also fan out to nodes inside the subgraph,
+                // and those original connections must remain intact.
+                for (target, target_port) in self
+                    .builder
+                    .hugr()
+                    .linked_inputs(*src, *src_port)
+                    .filter(|(target, _)| !subgraph.nodes().contains(target))
+                    .collect_vec()
+                {
+                    self.builder
+                        .hugr_mut()
+                        .disconnect_edge(*src, *src_port, target, target_port);
+                }
 
                 let wire_qubits = output_qubits.split_off(..counts.qubits);
                 let wire_bits = output_bits.split_off(..counts.bits);

--- a/tket/src/serialize/pytket/decoder/wires.rs
+++ b/tket/src/serialize/pytket/decoder/wires.rs
@@ -342,7 +342,7 @@ pub(crate) struct WireTracker {
     /// Not yet-produced parameters that have been referenced in the decoded hugr.
     ///
     /// These are introduced when decoding opaque hugr subgraphs outside the pytket commands.
-    /// See [`super::AdditionalNodesAndWires`].
+    /// See [`super::EncodedCircuitBoundary`].
     forward_parameter_placeholders: IndexSet<String>,
     /// A permutation of qubit registers in `latest_qubit_tracker` that we
     /// expect to see at the output.
@@ -435,6 +435,84 @@ impl WireTracker {
             reordered.insert(output_pos, input_pos);
         }
         self.output_qubit_permutation = reordered.values().copied().collect();
+    }
+
+    /// Relabel the current qubit values according to an intermediate circuit
+    /// permutation.
+    ///
+    /// Unlike the final output permutation, an intermediate permutation must
+    /// update register lookup before the next segment is decoded. The HUGR
+    /// wires themselves do not change; fresh tracked elements associate those
+    /// wires with their new pytket register names.
+    pub(super) fn apply_implicit_permutation(
+        &mut self,
+        permutation: &[ImplicitPermutation],
+    ) -> Result<(), PytketDecodeError> {
+        if permutation.is_empty() {
+            return Ok(());
+        }
+
+        let register_count = self.latest_qubit_tracker.len();
+        let mut source_for_output = (0..register_count).collect_vec();
+        for ImplicitPermutation(input, output) in permutation {
+            let input_hash = RegisterHash::from(input);
+            let output_hash = RegisterHash::from(output);
+            let Some(input_pos) = self.latest_qubit_tracker.get_index_of(&input_hash) else {
+                return Err(PytketDecodeError::custom(format!(
+                    "Unknown qubit register in implicit permutation: {input:?}"
+                )));
+            };
+            let Some(output_pos) = self.latest_qubit_tracker.get_index_of(&output_hash) else {
+                return Err(PytketDecodeError::custom(format!(
+                    "Unknown qubit register in implicit permutation: {output:?}"
+                )));
+            };
+            source_for_output[output_pos] = input_pos;
+        }
+
+        let current_ids = self.latest_qubit_tracker.values().copied().collect_vec();
+        let destination_registers = current_ids
+            .iter()
+            .map(|&id| self.get_qubit(id).pytket_register_arc())
+            .collect_vec();
+        let source_wires = source_for_output
+            .iter()
+            .map(|&source_pos| self.qubit_wires[&current_ids[source_pos]].clone())
+            .collect_vec();
+
+        for &id in &current_ids {
+            self.qubits[id.0].mark_outdated();
+        }
+
+        let mut replacements = BTreeMap::new();
+        for (output_pos, (register, wires)) in destination_registers
+            .into_iter()
+            .zip(source_wires)
+            .enumerate()
+        {
+            let hash = RegisterHash::from(register.as_ref());
+            let new_id = TrackedQubitId(self.qubits.len());
+            self.qubits
+                .push(TrackedQubit::new_with_hash(new_id, register, hash));
+            *self
+                .latest_qubit_tracker
+                .get_index_mut(output_pos)
+                .expect("tracked qubit position remains valid")
+                .1 = new_id;
+            self.qubit_wires.insert(new_id, wires);
+            replacements.insert(current_ids[source_for_output[output_pos]], new_id);
+        }
+
+        for wire_data in self.wires.values_mut() {
+            for qubit in &mut wire_data.qubits {
+                if let Some(replacement) = replacements.get(qubit) {
+                    *qubit = *replacement;
+                }
+            }
+        }
+
+        self.output_qubit_permutation.clear();
+        Ok(())
     }
 
     /// Returns a reference to the tracked qubit at the given index.

--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -7,7 +7,6 @@ mod value_tracker;
 use hugr::core::HugrNode;
 use tket_json_rs::clexpr::InputClRegister;
 use tket_json_rs::clexpr::operator::{ClArgument, ClOperator, ClTerminal, ClVariable};
-use tket_json_rs::opbox::BoxID;
 pub use value_tracker::{
     TrackedBit, TrackedParam, TrackedQubit, TrackedValue, TrackedValues, ValueTracker,
 };
@@ -801,149 +800,6 @@ impl<H: HugrView> PytketEncoderContext<H> {
         self.segments.push_command(command);
     }
 
-    /// Helper to emit a `CircBox` tket1 command corresponding to a region of the Hugr.
-    ///
-    /// Returns a bool indicating whether the subcircuit was successfully emitted,
-    /// or should be encoded opaquely instead. This is the case when the subcircuit
-    /// contains output parameters.
-    ///
-    // TODO: Support output parameters in subcircuits. This may require
-    // substituting variables in the parameter expressions.
-    #[expect(unused)]
-    fn emit_subcircuit(
-        &mut self,
-        node: H::Node,
-        hugr: &H,
-    ) -> Result<EncodeStatus, PytketEncodeError<H::Node>> {
-        let config = Arc::clone(&self.config);
-
-        // Recursively encode the sub-graph.
-        let opaque_subgraphs = std::mem::take(&mut self.opaque_subgraphs);
-        let mut subencoder = PytketEncoderContext::new(hugr, node, opaque_subgraphs, config)?;
-        subencoder.function_cache = self.function_cache.clone();
-        subencoder.run_encoder(hugr, node)?;
-
-        let (info, opaque_subgraphs) = subencoder.finish(hugr, node)?;
-        self.opaque_subgraphs = opaque_subgraphs;
-        if !info.output_params.is_empty()
-            || info.serial_circuits.len() != 1
-            || info
-                .boundaries
-                .iter()
-                .any(|boundary| !boundary.external_subgraphs.is_empty())
-        {
-            return Ok(EncodeStatus::Unsupported);
-        }
-
-        self.emit_circ_box(
-            node,
-            info.serial_circuits
-                .into_iter()
-                .next()
-                .expect("encoded region has one circuit"),
-            hugr,
-        )?;
-        Ok(EncodeStatus::Success)
-    }
-
-    /// Helper to emit a `CircBox` tket1 command corresponding to a function definition in the Hugr.
-    ///
-    /// The function encoding is cached and reused if possible.
-    ///
-    /// Returns a bool indicating whether the subcircuit was successfully emitted,
-    /// or should be encoded opaquely instead. This is the case when the subcircuit
-    /// contains output parameters.
-    ///
-    // TODO: Support output parameters in subcircuits. This may require
-    // substituting variables in the parameter expressions.
-    #[expect(unused)]
-    fn emit_function_call(
-        &mut self,
-        node: H::Node,
-        function: H::Node,
-        hugr: &H,
-    ) -> Result<EncodeStatus, PytketEncodeError<H::Node>> {
-        let cache = self.function_cache.read().ok();
-        if let Some(encoded) = cache.as_ref().and_then(|c| c.get(&function)) {
-            let encoded = encoded.clone();
-            drop(cache);
-            match encoded {
-                CachedEncodedFunction::Encoded { serial_circuit } => {
-                    self.emit_circ_box(node, serial_circuit, hugr)?;
-                    return Ok(EncodeStatus::Success);
-                }
-                CachedEncodedFunction::Unsupported | CachedEncodedFunction::InEncodingStack => {
-                    return Ok(EncodeStatus::Unsupported);
-                }
-            };
-        }
-        drop(cache);
-
-        // If the function is not cached, we need to encode it.
-        let config = Arc::clone(&self.config);
-        let opaque_subgraphs = std::mem::take(&mut self.opaque_subgraphs);
-        // Recursively encode the sub-graph.
-        let mut subencoder = PytketEncoderContext::new(hugr, function, opaque_subgraphs, config)?;
-        subencoder.function_cache = self.function_cache.clone();
-        subencoder.run_encoder(hugr, function)?;
-        let (info, opaque_subgraphs) = subencoder.finish(hugr, function)?;
-        self.opaque_subgraphs = opaque_subgraphs;
-
-        let serial_circuit = (info.serial_circuits.len() == 1
-            && info
-                .boundaries
-                .iter()
-                .all(|boundary| boundary.external_subgraphs.is_empty()))
-        .then(|| info.serial_circuits[0].clone());
-        let (result, cached_fn) = match (info.output_params.is_empty(), serial_circuit) {
-            (true, Some(serial_circuit)) => (
-                EncodeStatus::Success,
-                CachedEncodedFunction::Encoded { serial_circuit },
-            ),
-            _ => (
-                EncodeStatus::Unsupported,
-                CachedEncodedFunction::Unsupported,
-            ),
-        };
-
-        // Cache the encoded subcircuit for future use.
-        // If the cache is poisoned, ignore it.
-        if let Ok(mut cache) = self.function_cache.write() {
-            cache.insert(function, cached_fn.clone());
-        }
-
-        if result == EncodeStatus::Success {
-            let CachedEncodedFunction::Encoded { serial_circuit } = cached_fn else {
-                unreachable!("successful function encoding is cached as a circuit");
-            };
-            self.emit_circ_box(node, serial_circuit, hugr)?;
-        }
-        Ok(result)
-    }
-
-    /// Helper to emit a `CircBox` tket1 command from a Serialised circuit.
-    fn emit_circ_box(
-        &mut self,
-        node: H::Node,
-        boxed_circuit: SerialCircuit,
-        hugr: &H,
-    ) -> Result<(), PytketEncodeError<H::Node>> {
-        self.emit_node_command(
-            node,
-            hugr,
-            EmitCommandOptions::new().reuse_all_bits(),
-            |args| {
-                let mut pytket_op = make_tk1_operation(tket_json_rs::OpType::CircBox, args);
-                pytket_op.op_box = Some(tket_json_rs::opbox::OpBox::CircBox {
-                    id: BoxID::new(),
-                    circuit: boxed_circuit,
-                });
-                pytket_op
-            },
-        )?;
-        Ok(())
-    }
-
     /// Encode a single circuit node into pytket commands and update the
     /// encoder.
     ///
@@ -1016,27 +872,6 @@ impl<H: HugrView> PytketEncoderContext<H> {
                     return Ok(EncodeStatus::Success);
                 }
             }
-            // TODO: DFG and function call emissions are temporarily disabled,
-            // since we cannot track additional metadata associated with the
-            // nested circuit in a `CircuitBox` as we'd do for the root one in
-            // [`EncodedCircuitInfo`].
-            //
-            // See the `unsupported_extras_in_circ_box` case in
-            // `tests::encoded_circuit_roundtrip` for a failing case when this
-            // is enabled.
-            /*
-            OpType::DFG(_) => return self.emit_subcircuit(node, circ),
-            OpType::Call(call) => {
-                let (fn_node, _) = hugr
-                    .single_linked_output(node, call.called_function_port())
-                    .expect("Function call must be linked to a function");
-                if hugr.get_optype(fn_node).is_func_defn()
-                    && self.emit_function_call(node, fn_node, hugr)? == EncodeStatus::Success
-                {
-                    return Ok(EncodeStatus::Success);
-                }
-            }
-            */
             OpType::Input(_) | OpType::Output(_) => {
                 // I/O nodes are handled by the container's encoder.
                 return Ok(EncodeStatus::Success);
@@ -1476,14 +1311,18 @@ impl<N: HugrNode> NodeInputValues<N> {
 ///
 /// If the function contains output parameters, it is unsupported
 /// and should be emitted as an unsupported op instead.
+//
+// TODO: Remove the leftover circbox encoding logic.
 #[derive(Clone, Debug)]
 enum CachedEncodedFunction {
     /// Successfully encoded function.
+    #[expect(unused)]
     Encoded {
         /// The serialised circuit for the function.
         serial_circuit: SerialCircuit,
     },
     /// Unsupported function
+    #[expect(unused)]
     Unsupported,
     /// A marker for functions currently being encoded.
     ///

--- a/tket/src/serialize/pytket/encoder.rs
+++ b/tket/src/serialize/pytket/encoder.rs
@@ -28,7 +28,7 @@ use super::opaque::OpaqueSubgraphs;
 use super::{PytketEncodeError, PytketEncodeOpError};
 use crate::metadata;
 use crate::serialize::pytket::circuit::{
-    AdditionalNodesAndWires, AdditionalSubgraph, EncodedCircuitInfo,
+    AdditionalSubgraph, EncodedCircuitBoundary, EncodedCircuitInfo,
 };
 use crate::serialize::pytket::config::PytketEncoderConfig;
 use crate::serialize::pytket::extension::RegisterCount;
@@ -45,8 +45,8 @@ pub struct PytketEncoderContext<H: HugrView> {
     /// Defaults to "0" unless the circuit has a [METADATA_PHASE] metadata
     /// entry.
     phase: String,
-    /// The already-encoded serialised pytket commands.
-    commands: Vec<circuit_json::Command>,
+    /// Pytket command runs and the opaque boundaries separating them.
+    segments: CircuitSegments,
     /// A tracker for qubit/bit/parameter values associated with the circuit's wires.
     ///
     /// Contains methods to update the registers in the circuit being built.
@@ -55,17 +55,69 @@ pub struct PytketEncoderContext<H: HugrView> {
     unsupported: UnsupportedTracker<H::Node>,
     /// A registry of already-encoded opaque subgraphs.
     opaque_subgraphs: OpaqueSubgraphs<H::Node>,
-    /// Subgraphs in `opaque_subgraphs` that could not be emitted as opaque
-    /// barriers, and must be stored in the [`EncodedCircuitInfo`] instead when
-    /// finishing the encoding. Identified by their
-    /// [`super::opaque::SubgraphId`] in `opaque_subgraphs`.
-    non_emitted_subgraphs: Vec<AdditionalSubgraph>,
     /// Configuration for the encoding.
     ///
     /// Contains custom operation/type/const emitters.
     config: Arc<PytketEncoderConfig<H>>,
     /// A cache of translated hugr functions, to be encoded as op boxes.
     function_cache: Arc<RwLock<HashMap<H::Node, CachedEncodedFunction>>>,
+}
+
+/// Accumulates pytket command runs separated by external opaque subgraphs.
+///
+/// There is always one boundary before the current run. Flushing a non-empty
+/// run creates the following boundary, so the finished representation has one
+/// more boundary than command runs.
+#[derive(Debug, Default)]
+struct CircuitSegments {
+    /// Finished command runs, each separated by a boundary.
+    command_runs: Vec<Vec<circuit_json::Command>>,
+    /// Boundaries separating the command runs.
+    ///
+    /// There is always the same number of boundaries as `command_runs + 1`.
+    boundaries: Vec<EncodedCircuitBoundary>,
+    current_run: Vec<circuit_json::Command>,
+}
+
+impl CircuitSegments {
+    /// Create an accumulator with the leading region boundary.
+    fn new() -> Self {
+        Self {
+            boundaries: vec![EncodedCircuitBoundary::default()],
+            ..Self::default()
+        }
+    }
+
+    /// Append a pytket command to the current maximal run.
+    fn push_command(&mut self, command: circuit_json::Command) {
+        self.current_run.push(command);
+    }
+
+    /// Record an opaque subgraph at its current position in the traversal.
+    fn push_external_subgraph(&mut self, subgraph: AdditionalSubgraph) {
+        self.flush_run();
+        self.boundaries
+            .last_mut()
+            .expect("segment accumulator always has a boundary")
+            .external_subgraphs
+            .push(subgraph);
+    }
+
+    /// Finish the current command run and create its following boundary.
+    fn flush_run(&mut self) {
+        if self.current_run.is_empty() {
+            return;
+        }
+        self.command_runs
+            .push(std::mem::take(&mut self.current_run));
+        self.boundaries.push(EncodedCircuitBoundary::default());
+    }
+
+    /// Return all command runs and their interleaved boundaries.
+    fn finish(mut self) -> (Vec<Vec<circuit_json::Command>>, Vec<EncodedCircuitBoundary>) {
+        self.flush_run();
+        (self.command_runs, self.boundaries)
+    }
 }
 
 /// Options used when emitting a pytket command from HUGR operations.
@@ -181,11 +233,10 @@ impl<H: HugrView> PytketEncoderContext<H> {
         Ok(Self {
             name: fn_name,
             phase,
-            commands: vec![],
+            segments: CircuitSegments::new(),
             values: ValueTracker::new(hugr, region, &config)?,
             unsupported: UnsupportedTracker::new(hugr),
             opaque_subgraphs,
-            non_emitted_subgraphs: vec![],
             config,
             function_cache: Arc::new(RwLock::new(HashMap::new())),
         })
@@ -225,7 +276,8 @@ impl<H: HugrView> PytketEncoderContext<H> {
     ///
     /// # Returns
     ///
-    /// * An [`EncodedCircuitInfo`] containing the final [`SerialCircuit`] and some additional metadata.
+    /// * An [`EncodedCircuitInfo`] containing the final circuit segments and
+    ///   region metadata.
     /// * The set of opaque subgraphs that were referenced (from/inside) pytket barriers.
     #[expect(clippy::type_complexity)]
     pub(super) fn finish(
@@ -241,23 +293,50 @@ impl<H: HugrView> PytketEncoderContext<H> {
         }
 
         let tracker_result = self.values.finish(hugr, region)?;
+        let (mut command_runs, mut boundaries) = self.segments.finish();
+        if command_runs.is_empty() {
+            command_runs.push(Vec::new());
+            boundaries.push(EncodedCircuitBoundary::default());
+        }
 
-        let mut ser = SerialCircuit::new(self.name, self.phase);
-
-        ser.commands = self.commands;
-        ser.qubits = tracker_result.qubits.into_iter().map_into().collect();
-        ser.bits = tracker_result.bits.into_iter().map_into().collect();
-        ser.implicit_permutation = tracker_result.qubit_permutation;
-        ser.number_of_ws = None;
+        let qubits = tracker_result
+            .qubits
+            .into_iter()
+            .map_into()
+            .collect::<Vec<_>>();
+        let bits = tracker_result
+            .bits
+            .into_iter()
+            .map_into()
+            .collect::<Vec<_>>();
+        let final_segment = command_runs.len() - 1;
+        let serial_circuits = command_runs
+            .into_iter()
+            .enumerate()
+            .map(|(segment, commands)| {
+                let phase = if segment == 0 {
+                    self.phase.clone()
+                } else {
+                    "0".to_owned()
+                };
+                let mut circuit = SerialCircuit::new(self.name.clone(), phase);
+                circuit.commands = commands;
+                circuit.qubits = qubits.clone();
+                circuit.bits = bits.clone();
+                if segment == final_segment {
+                    circuit.implicit_permutation = tracker_result.qubit_permutation.clone();
+                }
+                circuit.number_of_ws = None;
+                circuit
+            })
+            .collect();
 
         let info = EncodedCircuitInfo {
-            serial_circuit: ser,
+            serial_circuits,
+            boundaries,
             input_params: tracker_result.input_params,
             output_params: tracker_result.params,
-            additional_nodes_and_wires: AdditionalNodesAndWires {
-                additional_subgraphs: self.non_emitted_subgraphs,
-                straight_through_wires: tracker_result.straight_through_wires,
-            },
+            straight_through_wires: tracker_result.straight_through_wires,
             output_qubits: tracker_result.qubit_outputs,
             output_bits: tracker_result.bit_outputs,
         };
@@ -653,7 +732,7 @@ impl<H: HugrView> PytketEncoderContext<H> {
             // That list contains a list of subgraphs so we don't need to do any
             // additional handling, but if we preferred in the future we could
             // instead merge a single list of nodes if we wanted.
-            self.non_emitted_subgraphs.push(AdditionalSubgraph {
+            self.segments.push_external_subgraph(AdditionalSubgraph {
                 id: subgraph_id,
                 params: input_param_exprs.clone(),
             });
@@ -719,7 +798,7 @@ impl<H: HugrView> PytketEncoderContext<H> {
             opgroup,
         };
 
-        self.commands.push(command);
+        self.segments.push_command(command);
     }
 
     /// Helper to emit a `CircBox` tket1 command corresponding to a region of the Hugr.
@@ -745,12 +824,25 @@ impl<H: HugrView> PytketEncoderContext<H> {
         subencoder.run_encoder(hugr, node)?;
 
         let (info, opaque_subgraphs) = subencoder.finish(hugr, node)?;
-        if !info.output_params.is_empty() {
+        self.opaque_subgraphs = opaque_subgraphs;
+        if !info.output_params.is_empty()
+            || info.serial_circuits.len() != 1
+            || info
+                .boundaries
+                .iter()
+                .any(|boundary| !boundary.external_subgraphs.is_empty())
+        {
             return Ok(EncodeStatus::Unsupported);
         }
-        self.opaque_subgraphs = opaque_subgraphs;
 
-        self.emit_circ_box(node, info.serial_circuit, hugr)?;
+        self.emit_circ_box(
+            node,
+            info.serial_circuits
+                .into_iter()
+                .next()
+                .expect("encoded region has one circuit"),
+            hugr,
+        )?;
         Ok(EncodeStatus::Success)
     }
 
@@ -797,14 +889,18 @@ impl<H: HugrView> PytketEncoderContext<H> {
         let (info, opaque_subgraphs) = subencoder.finish(hugr, function)?;
         self.opaque_subgraphs = opaque_subgraphs;
 
-        let (result, cached_fn) = match info.output_params.is_empty() {
-            true => (
+        let serial_circuit = (info.serial_circuits.len() == 1
+            && info
+                .boundaries
+                .iter()
+                .all(|boundary| boundary.external_subgraphs.is_empty()))
+        .then(|| info.serial_circuits[0].clone());
+        let (result, cached_fn) = match (info.output_params.is_empty(), serial_circuit) {
+            (true, Some(serial_circuit)) => (
                 EncodeStatus::Success,
-                CachedEncodedFunction::Encoded {
-                    serial_circuit: info.serial_circuit.clone(),
-                },
+                CachedEncodedFunction::Encoded { serial_circuit },
             ),
-            false => (
+            _ => (
                 EncodeStatus::Unsupported,
                 CachedEncodedFunction::Unsupported,
             ),
@@ -813,11 +909,14 @@ impl<H: HugrView> PytketEncoderContext<H> {
         // Cache the encoded subcircuit for future use.
         // If the cache is poisoned, ignore it.
         if let Ok(mut cache) = self.function_cache.write() {
-            cache.insert(function, cached_fn);
+            cache.insert(function, cached_fn.clone());
         }
 
         if result == EncodeStatus::Success {
-            self.emit_circ_box(node, info.serial_circuit, hugr)?;
+            let CachedEncodedFunction::Encoded { serial_circuit } = cached_fn else {
+                unreachable!("successful function encoding is cached as a circuit");
+            };
+            self.emit_circ_box(node, serial_circuit, hugr)?;
         }
         Ok(result)
     }

--- a/tket/src/serialize/pytket/encoder/unsupported_tracker.rs
+++ b/tket/src/serialize/pytket/encoder/unsupported_tracker.rs
@@ -1,6 +1,6 @@
 //! Tracking of subgraphs of unsupported nodes in the hugr.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use hugr::HugrView;
 use hugr::core::HugrNode;
@@ -22,7 +22,7 @@ pub struct UnsupportedTracker<N> {
     /// Stores the index of each node in [`Self::components`].
     ///
     /// Once a node has been extracted, it is removed from this map.
-    nodes: HashMap<N, UnsupportedNode>,
+    nodes: BTreeMap<N, UnsupportedNode>,
     /// A UnionFind structure for tracking connected components of `Self::nodes`.
     components: UnionFind<usize>,
 }
@@ -43,7 +43,7 @@ impl<N: HugrNode> UnsupportedTracker<N> {
     /// Create a new [`UnsupportedTracker`].
     pub fn new(_hugr: &impl HugrView<Node = N>) -> Self {
         Self {
-            nodes: HashMap::new(),
+            nodes: BTreeMap::new(),
             components: UnionFind::new_empty(),
         }
     }
@@ -94,7 +94,9 @@ impl<N: HugrNode> UnsupportedTracker<N> {
 
         nodes.extend(
             self.nodes
-                .extract_if(|_, data| self.components.find_mut(data.component) == representative)
+                .extract_if(.., |_, data| {
+                    self.components.find_mut(data.component) == representative
+                })
                 .map(|(n, _)| n),
         );
 
@@ -115,7 +117,7 @@ impl<N: HugrNode> UnsupportedTracker<N> {
 impl<N> Default for UnsupportedTracker<N> {
     fn default() -> Self {
         Self {
-            nodes: HashMap::new(),
+            nodes: BTreeMap::new(),
             components: UnionFind::new_empty(),
         }
     }

--- a/tket/src/serialize/pytket/extension/core.rs
+++ b/tket/src/serialize/pytket/extension/core.rs
@@ -102,7 +102,7 @@ impl PytketDecoder for CoreDecoder {
                     options,
                     decoder.opaque_subgraphs,
                 )?;
-                nested_decoder.run_decoder(&serial_circuit.commands, None)?;
+                nested_decoder.run_decoder(&serial_circuit.commands)?;
                 let internal = nested_decoder.finish(None)?.node();
 
                 decoder

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -29,9 +29,9 @@ use crate::serialize::pytket::PytketEncodeError;
 use crate::serialize::pytket::decoder::PytketParam;
 use crate::serialize::pytket::extension::{CoreDecoder, OpaqueTk1Op, PreludeEmitter};
 use crate::serialize::pytket::{
-    DecodeInsertionTarget, DecodeOptions, EncodeOptions, EncodedCircuit, PytketDecodeError,
-    PytketDecodeErrorInner, PytketDecoderConfig, PytketEncodeOpError, PytketEncoderConfig,
-    default_decoder_config, default_encoder_config,
+    DecodeInsertionTarget, DecodeOptions, EncodeOptions, EncodedCircuit, EncodedCircuitId,
+    PytketDecodeError, PytketDecodeErrorInner, PytketDecoderConfig, PytketEncodeOpError,
+    PytketEncoderConfig, default_decoder_config, default_encoder_config,
 };
 use hugr::hugr::hugrmut::HugrMut;
 use hugr::ops::handle::FuncID;
@@ -1570,7 +1570,7 @@ fn encoded_circuit_roundtrip(
 
 /// Segment-local implicit permutations must be visible to subsequent
 /// segments, while the final permutation still determines region outputs.
-#[test]
+#[rstest]
 fn segmented_circuit_tracks_implicit_permutations() {
     let hugr = circ_mid_circuit_external_subgraph();
     let mut encoded =
@@ -1618,6 +1618,55 @@ fn segmented_circuit_tracks_implicit_permutations() {
     assert_eq!(decoded.get_optype(rz), &OpType::from(TketOp::Rz));
     let (h, _) = decoded.single_linked_output(rz, 0).expect("Rz qubit input");
     assert_eq!(decoded.get_optype(h), &OpType::from(TketOp::H));
+}
+
+/// Segment accessors identify and mutate each circuit within a region.
+#[rstest]
+fn encoded_circuit_segment_accessors() {
+    let hugr = circ_mid_circuit_external_subgraph();
+    let region = hugr.entrypoint();
+    let mut encoded =
+        EncodedCircuit::new(&hugr, EncodeOptions::new()).expect("fixture should encode");
+
+    let segment_ids = encoded.get_circuits(region).map(|(id, _)| id).collect_vec();
+    assert_eq!(
+        segment_ids,
+        [
+            EncodedCircuitId { region, segment: 0 },
+            EncodedCircuitId { region, segment: 1 },
+        ]
+    );
+
+    for (id, circuit) in encoded.get_circuits_mut(region) {
+        circuit.phase = id.segment.to_string();
+    }
+
+    let [first, second] = segment_ids.as_slice() else {
+        panic!("fixture should encode as two segments");
+    };
+    assert_eq!(
+        encoded.get_segment(*first).expect("first segment").phase,
+        "0"
+    );
+    assert_eq!(encoded[*second].phase, "1");
+
+    encoded
+        .get_segment_mut(*first)
+        .expect("first segment")
+        .phase = "2".to_owned();
+    encoded[*second].phase = "3".to_owned();
+    assert_eq!(encoded[*first].phase, "2");
+    assert!(
+        encoded
+            .get_segment(EncodedCircuitId { region, segment: 2 })
+            .is_none()
+    );
+    let missing_region = EncodedCircuitId {
+        region: hugr.module_root(),
+        segment: 0,
+    };
+    assert!(encoded.get_segment(missing_region).is_none());
+    assert!(encoded.get_segment_mut(missing_region).is_none());
 }
 
 /// A split region depends on boundary metadata that cannot be represented in

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -34,7 +34,7 @@ use crate::serialize::pytket::{
     PytketEncoderConfig, default_decoder_config, default_encoder_config,
 };
 use hugr::hugr::hugrmut::HugrMut;
-use hugr::ops::handle::FuncID;
+use hugr::ops::handle::{FuncID, NodeHandle};
 use hugr::ops::{OpParent, OpType, Tag, Value};
 use hugr::std_extensions::arithmetic::float_ops::FloatOps;
 use hugr::types::{Signature, SumType, Type};
@@ -1169,6 +1169,79 @@ fn circ_measure_and_read() -> Hugr {
     h.finish_hugr_with_outputs([bit]).unwrap()
 }
 
+/// A measured bit used as both a CFG predicate and an input to an unsupported
+/// operation.
+///
+/// This is the minimal HUGR structure produced by the Guppy Getting Started
+/// example that fails a pytket encoding roundtrip.
+#[fixture]
+fn circ_cfg_read_fanout() -> Hugr {
+    let mut function =
+        FunctionBuilder::new("cfg_read_fanout", Signature::new(vec![], vec![qb_t()])).unwrap();
+    let consume_bool = function
+        .module_root_builder()
+        .declare(
+            "consume_bool",
+            Signature::new(vec![bool_t()], vec![]).into(),
+        )
+        .unwrap();
+
+    let cfg = {
+        let mut cfg = function.cfg_builder([], vec![qb_t()].into()).unwrap();
+        let entry = {
+            let mut block = cfg
+                .entry_builder(vec![vec![].into(), vec![].into()], vec![qb_t()].into())
+                .unwrap();
+            let [q1] = block
+                .add_dataflow_op(TketOp::QAlloc, [])
+                .unwrap()
+                .outputs_arr();
+            let [q2] = block
+                .add_dataflow_op(TketOp::QAlloc, [])
+                .unwrap()
+                .outputs_arr();
+            let [q1] = block
+                .add_dataflow_op(TketOp::H, [q1])
+                .unwrap()
+                .outputs_arr();
+            let measure = block.add_dataflow_op(TketOp::MeasureFree, [q1]).unwrap();
+            let [measurement] = measure.outputs_arr();
+            let [bit] = block
+                .add_dataflow_op(MeasurementOp::Read, [measurement])
+                .unwrap()
+                .outputs_arr();
+            let result = block.call(&consume_bool, &[], [bit]).unwrap();
+            block.add_other_wire(measure.node(), result.node());
+            block.add_other_wire(result.node(), block.output().node());
+
+            block.finish_with_outputs(bit, [q2]).unwrap()
+        };
+
+        let branches = [false, true].map(|apply_x| {
+            let mut block = cfg
+                .simple_block_builder(Signature::new_endo([qb_t()]), 1)
+                .unwrap();
+            let [q] = block.input_wires_arr();
+            let q = if apply_x {
+                block.add_dataflow_op(TketOp::X, [q]).unwrap().out_wire(0)
+            } else {
+                q
+            };
+            let branch = block.add_load_value(Value::unary_unit_sum());
+            block.finish_with_outputs(branch, [q]).unwrap()
+        });
+
+        let exit = cfg.exit_block();
+        for (port, branch) in branches.iter().enumerate() {
+            cfg.branch(&entry, port, branch).unwrap();
+            cfg.branch(branch, 0, &exit).unwrap();
+        }
+        cfg.finish_sub_container().unwrap()
+    };
+
+    function.finish_hugr_with_outputs(cfg.outputs()).unwrap()
+}
+
 /// Check that all circuit ops have been translated to a native gate.
 ///
 /// Panics if there are tk1 ops in the circuit.
@@ -1525,6 +1598,7 @@ fn fail_on_modified_hugr(circ_tk1_ops: Hugr) {
 #[case::measure_and_read(circ_measure_and_read(), 1, CircuitRoundtripTestConfig::Default)]
 #[case::meas_ancilla(circ_measure_ancilla(), 1, CircuitRoundtripTestConfig::Default)]
 #[case::preset_bits(circ_preset_bits(), 1, CircuitRoundtripTestConfig::Default)]
+#[case::read_fanout(circ_cfg_read_fanout(), 2, CircuitRoundtripTestConfig::Default)]
 
 fn encoded_circuit_roundtrip(
     #[case] hugr: Hugr,

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -1093,6 +1093,44 @@ fn circ_forward_opaque_parameter() -> Hugr {
     h.finish_hugr_with_outputs([q, rotation]).unwrap()
 }
 
+/// A register-free opaque subgraph ordered between two supported command runs.
+///
+/// Regression test for <https://github.com/Quantinuum/tket2/issues/1856>.
+#[fixture]
+fn circ_mid_circuit_external_subgraph() -> Hugr {
+    let opaque_type = Type::from(option_type([bool_t()]));
+    let signature = Signature::new(vec![qb_t(), qb_t()], vec![qb_t(), qb_t()]);
+    let mut h = FunctionBuilder::new("mid_circuit_external_subgraph", signature).unwrap();
+    let [q0, q1] = h.input_wires_arr();
+
+    let producer = h
+        .module_root_builder()
+        .declare(
+            "opaque_producer",
+            Signature::new(vec![qb_t()], vec![opaque_type.clone(), qb_t()]).into(),
+        )
+        .unwrap();
+    let consumer = h
+        .module_root_builder()
+        .declare(
+            "opaque_consumer",
+            Signature::new(vec![opaque_type], vec![rotation_type()]).into(),
+        )
+        .unwrap();
+
+    let producer_call = h.call(&producer, &[], [q1]).unwrap();
+    let [opaque, q1] = producer_call.outputs_arr();
+    let [q1] = h.add_dataflow_op(TketOp::H, [q1]).unwrap().outputs_arr();
+    let consumer_call = h.call(&consumer, &[], [opaque]).unwrap();
+    let [rotation] = consumer_call.outputs_arr();
+    let [q1] = h
+        .add_dataflow_op(TketOp::Rz, [q1, rotation])
+        .unwrap()
+        .outputs_arr();
+
+    h.finish_hugr_with_outputs([q0, q1]).unwrap()
+}
+
 // A circuit that discards the first qubit input and only outputs the second one.
 #[fixture]
 fn circ_discard_first_qubit() -> Hugr {
@@ -1352,7 +1390,7 @@ fn circuit_standalone_roundtrip(#[case] hugr: Hugr, #[case] config: CircuitRound
     let encoded = EncodedCircuit::new_standalone(&hugr, encode_options.clone())
         .unwrap_or_else(|e| panic!("{e}"));
 
-    assert!(encoded.contains_circuit(hugr.entrypoint()));
+    assert!(encoded.contains_region(hugr.entrypoint()));
     assert_eq!(encoded.len(), 1);
 
     // Re-encode the EncodedCircuit
@@ -1368,7 +1406,11 @@ fn circuit_standalone_roundtrip(#[case] hugr: Hugr, #[case] config: CircuitRound
         .unwrap_or_else(|e| panic!("{e}"));
 
     // Extract the head pytket circuit, and re-encode it on its own.
-    let ser: &SerialCircuit = &encoded[hugr.entrypoint()];
+    let mut circuits = encoded.get_circuits(hugr.entrypoint());
+    let (_, ser) = circuits
+        .next()
+        .expect("standalone encoding has one circuit");
+    assert!(circuits.next().is_none());
     let deser: Hugr = ser.decode(decode_options).unwrap_or_else(|e| panic!("{e}"));
 
     deser.validate().unwrap_or_else(|e| panic!("{e}"));
@@ -1474,6 +1516,11 @@ fn fail_on_modified_hugr(circ_tk1_ops: Hugr) {
     1,
     CircuitRoundtripTestConfig::Default
 )]
+#[case::mid_circuit_external_subgraph(
+    circ_mid_circuit_external_subgraph(),
+    2,
+    CircuitRoundtripTestConfig::Default
+)]
 #[case::discard_first_qubit(circ_discard_first_qubit(), 1, CircuitRoundtripTestConfig::Default)]
 #[case::measure_and_read(circ_measure_and_read(), 1, CircuitRoundtripTestConfig::Default)]
 #[case::meas_ancilla(circ_measure_ancilla(), 1, CircuitRoundtripTestConfig::Default)]
@@ -1519,6 +1566,68 @@ fn encoded_circuit_roundtrip(
         "Output signature mismatch\n  Expected: {}\n  Actual:   {}",
         circ_signature, deser_sig
     );
+}
+
+/// Segment-local implicit permutations must be visible to subsequent
+/// segments, while the final permutation still determines region outputs.
+#[test]
+fn segmented_circuit_tracks_implicit_permutations() {
+    let hugr = circ_mid_circuit_external_subgraph();
+    let mut encoded =
+        EncodedCircuit::new(&hugr, EncodeOptions::new()).expect("fixture should encode");
+    let region = hugr.entrypoint();
+    assert!(encoded.contains_region(region));
+    assert!(encoded.get_circuits(hugr.module_root()).next().is_none());
+
+    let mut segments = encoded.get_circuits_mut(region);
+    let (first_id, first) = segments.next().expect("first segment");
+    let (second_id, second) = segments.next().expect("second segment");
+    assert_eq!(first_id.region, second_id.region);
+    assert_eq!((first_id.segment, second_id.segment), (0, 1));
+    assert!(segments.next().is_none());
+
+    let q0 = first.qubits[0].clone();
+    let q1 = first.qubits[1].clone();
+    let swap = vec![
+        circuit_json::ImplicitPermutation(q0.clone(), q1.clone()),
+        circuit_json::ImplicitPermutation(q1.clone(), q0.clone()),
+    ];
+    first.implicit_permutation = swap.clone();
+
+    let rz = second
+        .commands
+        .iter_mut()
+        .find(|command| command.op.op_type == tket_json_rs::OpType::Rz)
+        .expect("second segment contains Rz");
+    assert_eq!(rz.args, vec![q1.id.clone()]);
+    rz.args = vec![q0.id.clone()];
+    second.implicit_permutation = swap;
+    drop(segments);
+
+    let mut decoded = hugr.clone();
+    encoded
+        .reassemble_inplace(&mut decoded, None)
+        .expect("segmented circuit should decode");
+    decoded.validate().expect("decoded HUGR should be valid");
+
+    let region = decoded.entrypoint();
+    let output = decoded.get_io(region).expect("dataflow region IO")[1];
+    let (rz, _) = decoded
+        .single_linked_output(output, 1)
+        .expect("second qubit output");
+    assert_eq!(decoded.get_optype(rz), &OpType::from(TketOp::Rz));
+    let (h, _) = decoded.single_linked_output(rz, 0).expect("Rz qubit input");
+    assert_eq!(decoded.get_optype(h), &OpType::from(TketOp::H));
+}
+
+/// A split region depends on boundary metadata that cannot be represented in
+/// one standalone pytket circuit.
+#[test]
+fn segmented_circuit_rejects_standalone_encoding() {
+    let hugr = circ_mid_circuit_external_subgraph();
+    let error = EncodedCircuit::new_standalone(&hugr, EncodeOptions::new())
+        .expect_err("segmented encoding cannot be standalone");
+    assert!(error.to_string().contains("register-free opaque subgraphs"));
 }
 
 /// Test serialisation of circuits with a symbolic expression.

--- a/tket/src/serialize/pytket/tests.rs
+++ b/tket/src/serialize/pytket/tests.rs
@@ -40,6 +40,7 @@ use hugr::std_extensions::arithmetic::float_ops::FloatOps;
 use hugr::types::{Signature, SumType, Type};
 use hugr::{Hugr, HugrView};
 use itertools::Itertools;
+use rayon::iter::ParallelIterator;
 use rstest::{fixture, rstest};
 use tket_json_rs::circuit_json::{self, SerialCircuit};
 use tket_json_rs::optype;
@@ -1741,6 +1742,53 @@ fn encoded_circuit_segment_accessors() {
     };
     assert!(encoded.get_segment(missing_region).is_none());
     assert!(encoded.get_segment_mut(missing_region).is_none());
+}
+
+/// Test the iterators over the segments of an encoded circuit,
+/// when a node has multiple segments.
+#[rstest]
+fn encoded_circuit_iterators() {
+    let hugr = circ_mid_circuit_external_subgraph();
+    let region = hugr.entrypoint();
+    let mut encoded =
+        EncodedCircuit::new(&hugr, EncodeOptions::new()).expect("fixture should encode");
+
+    assert_eq!(
+        encoded.iter().map(|(region, _)| region).collect_vec(),
+        [region, region]
+    );
+    assert_eq!(
+        encoded
+            .par_iter()
+            .map(|(region, _)| region)
+            .collect::<Vec<_>>(),
+        [region, region]
+    );
+
+    for (segment, (segment_region, circuit)) in encoded.iter_mut().enumerate() {
+        assert_eq!(segment_region, region);
+        circuit.phase = segment.to_string();
+    }
+    encoded
+        .par_iter_mut()
+        .for_each(|(segment_region, _)| assert_eq!(segment_region, region));
+
+    assert_eq!(encoded[region].phase, "0");
+    encoded[region].phase = "first".to_owned();
+    assert_eq!(
+        encoded
+            .get_segment(EncodedCircuitId { region, segment: 0 })
+            .expect("first segment")
+            .phase,
+        "first"
+    );
+    assert_eq!(
+        encoded
+            .get_segment(EncodedCircuitId { region, segment: 1 })
+            .expect("second segment")
+            .phase,
+        "1"
+    );
 }
 
 /// A split region depends on boundary metadata that cannot be represented in


### PR DESCRIPTION
Fixes #1856 by extracting multiple circuits per hugr region, separated by unsupported graphs that must be ordered in-between them.

`EncodedCircuit` has new `contains_region` and `get_circuits` methods.
The old `get_circuit` method that returns a single circuit has been marked as deprecated.

This is a requirement for re-enabling default quantum optimizations in guppy.
I tested the fix on `guppylang` & `guppylang-docs`.

BEGIN_COMMIT_OVERRIDE
fix: Panic when applying a `PytketHugrPass` on complex regions (#1894)
END_COMMIT_OVERRIDE