### PR TITLE
feat: Mute internal deprecation warning in tket-exts

### DIFF
--- a/tket-exts/src/tket_exts/__init__.py
+++ b/tket-exts/src/tket_exts/__init__.py
@@ -1,6 +1,8 @@
 """HUGR extension definitions for tket circuits."""
 
-from hugr.ext import ExtensionRegistry
+from collections.abc import Callable
+
+from hugr.ext import Extension, ExtensionRegistry
 
 from tket_exts import tket
 from tket_exts.tket.argument import ArgumentExtension
@@ -56,7 +58,6 @@ rotation: RotationExtension = tket.rotation.RotationExtension()
 futures: FuturesExtension = tket.futures.FuturesExtension()
 qsystem_helios: QSystemHeliosExtension = tket.qsystem.QSystemHeliosExtension()
 qsystem_sol: QSystemSolExtension = tket.qsystem.QSystemSolExtension()
-qsystem: QSystemExtension = tket.qsystem.QSystemExtension()
 qsystem_random: QSystemRandomExtension = tket.qsystem.QSystemRandomExtension()
 qsystem_utils: QSystemUtilsExtension = tket.qsystem.QSystemUtilsExtension()
 quantum: QuantumExtension = tket.quantum.QuantumExtension()
@@ -68,6 +69,9 @@ globals: GlobalsExtension = tket.globals.GlobalsExtension()
 measurement: MeasurementExtension = tket.measurement.MeasurementExtension()
 argument: ArgumentExtension = tket.argument.ArgumentExtension()
 
+# TODO (deprecated): Remove the deprecated tket.qsystem extension in the next breaking release.
+qsystem: QSystemExtension = tket.qsystem.QSystemExtension()
+
 
 def tket_registry() -> ExtensionRegistry:
     """Returns an ExtensionRegistry containing all the tket extensions.
@@ -77,7 +81,7 @@ def tket_registry() -> ExtensionRegistry:
     Returns:
         An ExtensionRegistry containing all the tket extensions.
     """
-    tket_exts = [
+    tket_exts: list[Callable[[], Extension]] = [
         tket.debug.DebugExtension(),
         tket.gpu.GpuExtension(),
         tket.guppy.GuppyExtension(),
@@ -86,7 +90,7 @@ def tket_registry() -> ExtensionRegistry:
         tket.globals.GlobalsExtension(),
         tket.qsystem.QSystemHeliosExtension(),
         tket.qsystem.QSystemSolExtension(),
-        tket.qsystem.QSystemExtension(),
+        qsystem._extension,
         tket.qsystem.QSystemRandomExtension(),
         tket.qsystem.QSystemUtilsExtension(),
         tket.quantum.QuantumExtension(),

--- a/tket-exts/src/tket_exts/tket/qsystem/__init__.py
+++ b/tket-exts/src/tket_exts/tket/qsystem/__init__.py
@@ -29,6 +29,11 @@ class QSystemExtension(TketExtension):
     """
 
     @functools.cache
+    def _extension(self) -> Extension:
+        """Load the extension without emitting its public deprecation warning."""
+        return load_extension("tket.qsystem")
+
+    @functools.cache
     def __call__(self) -> Extension:
         """Returns the qsystem extension"""
         warnings.warn(
@@ -38,7 +43,7 @@ class QSystemExtension(TketExtension):
             DeprecationWarning,
             stacklevel=2,
         )
-        return load_extension("tket.qsystem")
+        return self._extension()
 
     def TYPES(self) -> list[TypeDef]:
         """Return the types defined by this extension"""

--- a/tket-exts/tests/test_validate_exts.py
+++ b/tket-exts/tests/test_validate_exts.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable
 
 import pytest
@@ -271,3 +272,15 @@ def test_exported_extension(
     )
     for op in instantiated_ops:
         assert op.op_def().name in e.operations
+
+
+def check_warnings() -> None:
+    # QSystemExtension is deprecated, so we expect a warning when calling it.
+    with pytest.warns(DeprecationWarning, match="QSystemExtension"):
+        tket_exts.qsystem()
+
+    # Loading the full extension registry should not emit any warnings,
+    # even though it includes the deprecated QSystemExtension.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        tket_exts.tket_registry()


### PR DESCRIPTION
Fixes a warning produced when importing `tket-exts`, due to an internal usage of the deprecated `QSystemExtension`.